### PR TITLE
fix: Repair broken CSS comment in featured-benefit.css

### DIFF
--- a/src/styles/featured-benefit.css
+++ b/src/styles/featured-benefit.css
@@ -265,8 +265,8 @@
     display: none;
   }
 }
-/
-* Featured Benefits Section Styles */
+
+/* Featured Benefits Section Styles */
 .featured-benefits {
   padding: 20px 16px;
   background: #fff;


### PR DESCRIPTION
Fixed syntax error where '/' should have been '/*' for CSS comment. This was causing build warnings and potential styling issues in production.