### PR TITLE
Improve day availability parsing with abbreviation support

### DIFF
--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -10,11 +10,13 @@ const DAY_ABBR: Record<string, string> = {
 };
 
 const formatCuando = (cuando?: string): string => {
-  if (!cuando) return 'Todos los días';
+  if (!cuando) return 'Consultar';
   const lower = cuando.toLowerCase();
   // Check if all days of the week are mentioned
   const uniqueDays = new Set(ALL_DAYS.filter((d) => lower.includes(d)).map((d) => DAY_ABBR[d]));
   if (uniqueDays.size >= 7) return 'Todos los días';
+  // Handle explicit "todos los días" text
+  if (/todos?\s+los?\s+d[ií]as?/i.test(lower)) return 'Todos los días';
   // Replace full day names with abbreviations
   let result = cuando;
   Object.entries(DAY_ABBR).forEach(([full, abbr]) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -483,7 +483,8 @@ export async function fetchBusinesses(options: {
           requisitos: [benefit.cardTypes[0]?.name || 'Tarjeta de crédito'],
           usos: benefit.online ? ['online', 'presencial'] : ['presencial'],
           textoAplicacion: benefit.link || undefined,
-          subscription: benefit.subscription || null
+          subscription: benefit.subscription || null,
+          availableDays: benefit.availableDays || [],
         };
 
         business.benefits.push(bankBenefit);
@@ -514,7 +515,8 @@ export async function fetchBusinesses(options: {
           requisitos: [benefit.cardTypes[0]?.name || 'Tarjeta de crédito'],
           usos: benefit.online ? ['online', 'presencial'] : ['presencial'],
           textoAplicacion: benefit.link || undefined,
-          subscription: benefit.subscription || null
+          subscription: benefit.subscription || null,
+          availableDays: benefit.availableDays || [],
         };
         business.benefits.push(bankBenefit);
       }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -439,15 +439,13 @@ export async function fetchBusinesses(options: {
       return [];
     }
 
-    // Abbreviate day names and collapse full week to "Todos los días"
-    const DAY_ABBR: Record<string, string> = {
-      lunes: 'Lun', martes: 'Mar', miércoles: 'Mié', miercoles: 'Mié',
-      jueves: 'Jue', viernes: 'Vie', sábado: 'Sáb', sabado: 'Sáb', domingo: 'Dom',
-    };
+    // Keep full day names so the dayAvailabilityParser can parse them correctly.
+    // Display-level abbreviation is handled by formatCuando in BusinessDetailPage.
     const formatDays = (days: string[]): string => {
+      if (days.length === 0) return '';
       if (days.length >= 7) return 'Todos los días';
       return days
-        .map((d) => DAY_ABBR[d.toLowerCase().trim()] || d)
+        .map((d) => d.toLowerCase().trim())
         .join(', ');
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,8 @@ export interface BankBenefit {
   requisitos?: string[];
   usos?: string[];
   textoAplicacion?: string;
+  // Raw day availability from MongoDB (authoritative source for available days)
+  availableDays?: string[];
   // AI Analysis specific fields
   originalAnalyzedText?: string;
   description?: string;


### PR DESCRIPTION
## Summary
This PR enhances the day availability parser to properly handle abbreviated Spanish day names (e.g., "Lun", "Mar", "Vie") and improves the parsing pipeline by prioritizing the `availableDays` array as the most authoritative source of day information.

## Key Changes

- **Added abbreviation normalization**: Introduced `normalizeAbbreviatedDays()` function that converts abbreviated day names to their full Spanish equivalents before parsing. Uses regex with lookbehind/lookahead assertions to handle accented characters correctly and avoid false matches within full day names.

- **New `DAY_ABBREVIATIONS` map**: Created a mapping of Spanish day abbreviations (lun, mar, mié, jue, vie, sáb, dom) to full day names to support the normalization process.

- **Prioritized `availableDays` array parsing**: Added `availableDaysArrayToAvailability()` function that converts the `availableDays` array directly to `DayAvailability` objects, treating it as the most authoritative source. This bypasses text parsing when a specific subset of days is available.

- **Updated keyword detection**: Extended `containsDayKeywords()` to recognize abbreviated day names in addition to full names.

- **Improved API formatting**: Modified `fetchBusinesses()` to keep full day names instead of abbreviating them at the API level, allowing the parser to handle them correctly. Display-level abbreviation is now delegated to the UI layer.

- **Enhanced UI formatting**: Updated `formatCuando()` in BusinessDetailPage to:
  - Return 'Consultar' instead of 'Todos los días' for empty/null values
  - Explicitly detect "todos los días" text patterns
  - Abbreviate day names for display purposes

## Implementation Details

- The abbreviation normalization uses Unicode-aware regex patterns (`[a-záéíóúüñ]`) to properly handle Spanish accented characters, addressing JavaScript's limitation with `\b` word boundaries.
- The `availableDays` array is checked first in the parsing pipeline before falling back to text-based parsing, ensuring data consistency.
- The parser gracefully handles both accented and non-accented variants of Spanish day names (e.g., "miércoles" and "miercoles").

https://claude.ai/code/session_01VNrHPrnwDWeB7kERqkR1Ch