### PR TITLE
feat: Refine day availability parsing to correctly interpret "permane…

### DIFF
--- a/src/utils/__tests__/dayAvailabilityParser.test.ts
+++ b/src/utils/__tests__/dayAvailabilityParser.test.ts
@@ -362,14 +362,18 @@ describe('dayAvailabilityParser', () => {
                 expect(result?.allDays).toBe(true);
             });
 
-            it('should parse "permanente"', () => {
+            it('should NOT parse "permanente" as all days (describes duration, not day availability)', () => {
                 const result = parseDayAvailability('permanente');
-                expect(result?.allDays).toBe(true);
+                // "permanente" describes benefit duration, not day-of-week availability
+                expect(result?.allDays).toBe(false);
+                expect(result?.customText).toBe('permanente');
             });
 
-            it('should parse "siempre"', () => {
+            it('should NOT parse "siempre" as all days (describes duration, not day availability)', () => {
                 const result = parseDayAvailability('siempre');
-                expect(result?.allDays).toBe(true);
+                // "siempre" describes benefit duration, not day-of-week availability
+                expect(result?.allDays).toBe(false);
+                expect(result?.customText).toBe('siempre');
             });
 
             it('should be case insensitive for all days patterns', () => {


### PR DESCRIPTION
…nte" and "siempre" as custom text, and add support for "todos los días [day]" patterns.