### PR TITLE
Add distance indicator to search page business cards

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import Ticker from '../components/neo/Ticker';
 import CategoryMarquee from '../components/neo/CategoryMarquee';
 import { useBenefitsData } from '../hooks/useBenefitsData';
 import { Business } from '../types';
+import { formatDistance } from '../utils/distance';
 import { trackFilterApply, trackSearchIntent, trackViewBenefit } from '../analytics/intentTracking';
 
 function HomePage() {
@@ -257,8 +258,16 @@ function HomePage() {
 
                     {/* Card content */}
                     <div className="p-3 bg-white">
-                      <h3 className="font-semibold text-sm text-blink-ink truncate mb-0.5">
-                        {item.business.name}
+                      <h3 className="font-semibold text-sm text-blink-ink mb-0.5 flex items-center gap-1 min-w-0">
+                        <span className="truncate">{item.business.name}</span>
+                        {(item.business.distanceText || item.business.distance !== undefined) && (
+                          <>
+                            <span className="shrink-0 font-normal text-blink-muted">·</span>
+                            <span className="shrink-0 text-[11px] font-normal text-blink-muted">
+                              {item.business.distanceText || formatDistance(item.business.distance!)}
+                            </span>
+                          </>
+                        )}
                       </h3>
                       <p className="text-xs text-blink-muted truncate mb-2">
                         {item.benefit.bankName} · {item.benefit.cardName}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -114,7 +114,7 @@ function HomePage() {
         <Ticker count={totalBusinesses || 0} />
       </header>
 
-      <main className="flex-1 flex flex-col gap-8 pb-24">
+      <main className="flex-1 flex flex-col gap-8 pb-32">
         {/* Hero Section */}
         <section className="px-4 pt-6">
           <h1 className="text-[2rem] font-bold leading-tight text-blink-ink text-center mb-2">

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -788,9 +788,18 @@ function SearchPage() {
 
                   {/* Info */}
                   <div className="flex-1 min-w-0">
-                    <h2 className="font-bold text-[13.5px] text-blink-ink truncate leading-snug mb-[7px]">
-                      {business.name}
-                    </h2>
+                    {/* Name + distance row */}
+                    <div className="flex items-center justify-between gap-2 mb-[7px]">
+                      <h2 className="font-bold text-[13.5px] text-blink-ink truncate leading-snug min-w-0">
+                        {business.name}
+                      </h2>
+                      {(business.distanceText || business.distance !== undefined) && (
+                        <span className="text-[10px] text-blink-muted flex items-center gap-0.5 shrink-0">
+                          <span className="material-symbols-outlined" style={{ fontSize: 10 }}>near_me</span>
+                          {business.distanceText || formatDistance(business.distance!)}
+                        </span>
+                      )}
+                    </div>
 
                     {/* Banks + count row */}
                     <div className="flex items-center gap-1.5">
@@ -814,15 +823,6 @@ function SearchPage() {
                       <span className="text-[10px] text-blink-muted ml-1.5">
                         {business.benefits.length} {business.benefits.length !== 1 ? 'beneficios' : 'beneficio'}
                       </span>
-                      {(business.distanceText || business.distance !== undefined) && (
-                        <>
-                          <span className="text-[10px] text-blink-muted">·</span>
-                          <span className="text-[10px] text-blink-muted flex items-center gap-0.5">
-                            <span className="material-symbols-outlined" style={{ fontSize: 10 }}>near_me</span>
-                            {business.distanceText || formatDistance(business.distance!)}
-                          </span>
-                        </>
-                      )}
                     </div>
                   </div>
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -789,17 +789,17 @@ function SearchPage() {
                   {/* Info */}
                   <div className="flex-1 min-w-0">
                     {/* Name + distance row */}
-                    <div className="flex items-center justify-between gap-2 mb-[7px]">
-                      <h2 className="font-bold text-[13.5px] text-blink-ink truncate leading-snug min-w-0">
-                        {business.name}
-                      </h2>
+                    <h2 className="font-bold text-[13.5px] text-blink-ink leading-snug mb-[7px] flex items-center gap-1 min-w-0">
+                      <span className="truncate">{business.name}</span>
                       {(business.distanceText || business.distance !== undefined) && (
-                        <span className="text-[10px] text-blink-muted flex items-center gap-0.5 shrink-0">
-                          <span className="material-symbols-outlined" style={{ fontSize: 10 }}>near_me</span>
-                          {business.distanceText || formatDistance(business.distance!)}
-                        </span>
+                        <>
+                          <span className="shrink-0 font-normal text-blink-muted">·</span>
+                          <span className="shrink-0 text-[11px] font-normal text-blink-muted">
+                            {business.distanceText || formatDistance(business.distance!)}
+                          </span>
+                        </>
                       )}
-                    </div>
+                    </h2>
 
                     {/* Banks + count row */}
                     <div className="flex items-center gap-1.5">

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -15,6 +15,7 @@ import {
   trackSearchIntent,
   trackSelectBusiness,
 } from '../analytics/intentTracking';
+import { formatDistance } from '../utils/distance';
 
 interface BankDescriptor {
   token: string;
@@ -813,6 +814,15 @@ function SearchPage() {
                       <span className="text-[10px] text-blink-muted ml-1.5">
                         {business.benefits.length} {business.benefits.length !== 1 ? 'beneficios' : 'beneficio'}
                       </span>
+                      {(business.distanceText || business.distance !== undefined) && (
+                        <>
+                          <span className="text-[10px] text-blink-muted">·</span>
+                          <span className="text-[10px] text-blink-muted flex items-center gap-0.5">
+                            <span className="material-symbols-outlined" style={{ fontSize: 10 }}>near_me</span>
+                            {business.distanceText || formatDistance(business.distance!)}
+                          </span>
+                        </>
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
Shows distance (e.g. "300m", "1.2km") on each business card in the
search results, using the existing distanceText/distance fields
already populated by the backend when user location is available.

https://claude.ai/code/session_01CvqDK77EpkZzwiWNxLKFnB