### PR TITLE
feat(search): infinite scroll + scroll position restoration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import RouteSEO from './components/seo/RouteSEO';
 function ScrollToTop() {
   const { pathname } = useLocation();
   useEffect(() => {
+    // SearchPage manages its own scroll (restoration + reset on fresh mount)
+    if (pathname === '/search') return;
     window.scrollTo(0, 0);
   }, [pathname]);
   return null;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import BottomNav from '../components/neo/BottomNav';
@@ -332,6 +332,46 @@ function SearchPage() {
   const searchIntentSignatureRef = useRef('');
   const noResultsSignatureRef = useRef('');
 
+  // Infinite scroll sentinel
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const infiniteScrollStateRef = useRef({ hasMore, isLoadingMore, loadMore });
+
+  // Keep ref values fresh every render (no deps = runs every render)
+  useEffect(() => {
+    infiniteScrollStateRef.current = { hasMore, isLoadingMore, loadMore };
+  });
+
+  // Create IntersectionObserver once on mount
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          const { hasMore: more, isLoadingMore: loading, loadMore: load } = infiniteScrollStateRef.current;
+          if (more && !loading) load();
+        }
+      },
+      { rootMargin: '300px' },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
+  // Scroll position restoration on mount
+  useLayoutEffect(() => {
+    const key = 'blink.search.scrollY';
+    const saved = sessionStorage.getItem(key);
+    if (saved) {
+      sessionStorage.removeItem(key);
+      window.scrollTo({ top: Number(saved), behavior: 'instant' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'instant' });
+    }
+  }, []);
+
   useEffect(() => {
     if (!hasInitializedFiltersRef.current) {
       hasInitializedFiltersRef.current = true;
@@ -547,6 +587,7 @@ function SearchPage() {
   };
 
   const handleBusinessSelect = (business: Business, position: number) => {
+    sessionStorage.setItem('blink.search.scrollY', String(window.scrollY));
     trackSelectBusiness({
       source: 'search_results',
       businessId: business.id,
@@ -851,16 +892,14 @@ function SearchPage() {
           })
         )}
 
-        {/* Load More */}
-        {hasMore && (
-          <button
-            onClick={loadMore}
-            disabled={isLoadingMore}
-            className="w-full py-3.5 rounded-2xl text-sm font-medium text-primary transition-colors disabled:opacity-50"
-            style={{ border: '1.5px dashed #C7D2FE', background: '#EEF2FF' }}
-          >
-            {isLoadingMore ? 'Cargando...' : 'Cargar más tiendas'}
-          </button>
+        {/* Infinite scroll sentinel — triggers loadMore when entering viewport */}
+        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+
+        {/* Loading indicator shown while fetching next page */}
+        {isLoadingMore && (
+          <div className="flex justify-center py-4">
+            <div className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          </div>
         )}
       </main>
 


### PR DESCRIPTION
- Replace 'Load More' button with IntersectionObserver sentinel that auto-triggers loadMore() when the user scrolls within 300px of the list end; uses a stable ref to always read fresh hasMore/isLoadingMore values without re-creating the observer.

- Save window.scrollY to sessionStorage before navigating to a business detail, then restore it on SearchPage mount via useLayoutEffect so going back lands at the exact position the user was at.

- SearchPage now owns its own scroll management (reset to top on fresh visits, restore on back-navigation); ScrollToTop in App.tsx skips the /search route to avoid overriding it.

https://claude.ai/code/session_019xQBEHwSRgyVa5UrmeRBws