### PR TITLE
feat(api): add Cache-Control headers to Vercel functions

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -39,6 +39,28 @@ function setCacheControl(res, directive) {
   res.setHeader('Cache-Control', directive);
 }
 
+/**
+ * Decode a geohash string to its center lat/lng.
+ * Returns null if the input is invalid.
+ */
+function decodeGeohash(hash) {
+  const BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+  let even = true;
+  const lat = [-90, 90];
+  const lng = [-180, 180];
+  for (const c of hash) {
+    const bits = BASE32.indexOf(c);
+    if (bits === -1) return null;
+    for (let i = 4; i >= 0; i--) {
+      const bit = (bits >> i) & 1;
+      if (even) { const m = (lng[0] + lng[1]) / 2; if (bit) lng[0] = m; else lng[1] = m; }
+      else      { const m = (lat[0] + lat[1]) / 2; if (bit) lat[0] = m; else lat[1] = m; }
+      even = !even;
+    }
+  }
+  return { latitude: (lat[0] + lat[1]) / 2, longitude: (lng[0] + lng[1]) / 2 };
+}
+
 function getParsedUrl(req) {
   const protoHeader = req.headers['x-forwarded-proto'];
   const protocol = Array.isArray(protoHeader) ? protoHeader[0] : protoHeader || 'https';
@@ -607,15 +629,11 @@ async function handleGetBusinesses(req, res, url, db) {
   const limitNum = Math.min(Math.max(toPositiveInt(searchParams.get('limit'), 20), 1), 100);
   const offsetNum = Math.max(toPositiveInt(searchParams.get('offset'), 0), 0);
 
-  const lat = searchParams.get('lat');
-  const lng = searchParams.get('lng');
-  const userLat = lat ? Number.parseFloat(lat) : null;
-  const userLng = lng ? Number.parseFloat(lng) : null;
-  const hasLocation =
-    userLat !== null &&
-    userLng !== null &&
-    Number.isFinite(userLat) &&
-    Number.isFinite(userLng);
+  const geohash = searchParams.get('geohash');
+  const decoded = geohash ? decodeGeohash(geohash) : null;
+  const userLat = decoded?.latitude ?? null;
+  const userLng = decoded?.longitude ?? null;
+  const hasLocation = userLat !== null && userLng !== null;
 
   const bankFilter = bank
     ? bank
@@ -1030,7 +1048,7 @@ async function handleGetBusinesses(req, res, url, db) {
   const total = result[0]?.metadata?.[0]?.total || 0;
   const businesses = result[0]?.businesses || [];
 
-  setCacheControl(res, hasLocation ? CC_LOCATION : CC_CONTENT);
+  setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
     businesses,

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -629,10 +629,18 @@ async function handleGetBusinesses(req, res, url, db) {
   const limitNum = Math.min(Math.max(toPositiveInt(searchParams.get('limit'), 20), 1), 100);
   const offsetNum = Math.max(toPositiveInt(searchParams.get('offset'), 0), 0);
 
+  // Exact lat/lng (precise sort, bypasses CDN) takes priority over geohash (CDN-cached, approximate)
+  const rawLat = searchParams.get('lat');
+  const rawLng = searchParams.get('lng');
+  const exactLat = rawLat ? Number.parseFloat(rawLat) : null;
+  const exactLng = rawLng ? Number.parseFloat(rawLng) : null;
+  const hasExact = exactLat !== null && exactLng !== null && Number.isFinite(exactLat) && Number.isFinite(exactLng);
+
   const geohash = searchParams.get('geohash');
-  const decoded = geohash ? decodeGeohash(geohash) : null;
-  const userLat = decoded?.latitude ?? null;
-  const userLng = decoded?.longitude ?? null;
+  const decoded = !hasExact && geohash ? decodeGeohash(geohash) : null;
+
+  const userLat = hasExact ? exactLat : (decoded?.latitude ?? null);
+  const userLng = hasExact ? exactLng : (decoded?.longitude ?? null);
   const hasLocation = userLat !== null && userLng !== null;
 
   const bankFilter = bank
@@ -1048,7 +1056,7 @@ async function handleGetBusinesses(req, res, url, db) {
   const total = result[0]?.metadata?.[0]?.total || 0;
   const businesses = result[0]?.businesses || [];
 
-  setCacheControl(res, CC_CONTENT);
+  setCacheControl(res, hasExact ? CC_LOCATION : CC_CONTENT);
   return json(res, 200, {
     success: true,
     businesses,

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -30,6 +30,15 @@ function json(res, statusCode, payload) {
   res.send(JSON.stringify(payload));
 }
 
+// Cache-Control directives
+const CC_METADATA = 's-maxage=43200, stale-while-revalidate=86400, max-age=3600';  // 12h CDN, 1h browser
+const CC_CONTENT  = 's-maxage=3600, stale-while-revalidate=7200, max-age=300';     // 1h CDN, 5m browser
+const CC_LOCATION = 'private, max-age=60';                                          // browser-only, 1m
+
+function setCacheControl(res, directive) {
+  res.setHeader('Cache-Control', directive);
+}
+
 function getParsedUrl(req) {
   const protoHeader = req.headers['x-forwarded-proto'];
   const protocol = Array.isArray(protoHeader) ? protoHeader[0] : protoHeader || 'https';
@@ -280,6 +289,7 @@ async function handleGetBenefits(req, res, url, db) {
     collection.countDocuments(query)
   ]);
 
+  setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
     benefits: benefits.map(serializeDocWithId),
@@ -323,6 +333,7 @@ async function handleGetBenefitById(req, res, url, db, id) {
     });
   }
 
+  setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
     benefit: serializeDocWithId(benefit)
@@ -343,6 +354,7 @@ async function handleGetCategories(req, res, url, db) {
     ])
     .toArray();
 
+  setCacheControl(res, CC_METADATA);
   return json(res, 200, {
     success: true,
     categories: categories.map((cat) => ({
@@ -365,6 +377,7 @@ async function handleGetBanks(req, res, url, db) {
     ])
     .toArray();
 
+  setCacheControl(res, CC_METADATA);
   return json(res, 200, {
     success: true,
     banks: banks.map((bank) => ({
@@ -387,6 +400,7 @@ async function handleGetNetworks(req, res, url, db) {
     ])
     .toArray();
 
+  setCacheControl(res, CC_METADATA);
   return json(res, 200, {
     success: true,
     networks: networks.map((network) => ({
@@ -431,6 +445,7 @@ async function handleGetStats(req, res, url, db) {
       .toArray()
   ]);
 
+  setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
     stats: {
@@ -566,6 +581,7 @@ async function handleGetNearbyBenefits(req, res, url, db) {
 
   const filtered = nearbyBenefits.map(serializeDocWithId);
 
+  setCacheControl(res, CC_LOCATION);
   return json(res, 200, {
     success: true,
     benefits: filtered,
@@ -1014,6 +1030,7 @@ async function handleGetBusinesses(req, res, url, db) {
   const total = result[0]?.metadata?.[0]?.total || 0;
   const businesses = result[0]?.businesses || [];
 
+  setCacheControl(res, hasLocation ? CC_LOCATION : CC_CONTENT);
   return json(res, 200, {
     success: true,
     businesses,

--- a/src/components/BankGrid.tsx
+++ b/src/components/BankGrid.tsx
@@ -12,12 +12,16 @@ interface BankGridProps {
   banks: Bank[];
   onBankSelect: (bank: Bank) => void;
   selectedBanks?: string[];
+  sortByDistance?: boolean;
+  onSortByDistanceChange?: (value: boolean) => void;
 }
 
 const BankGrid: React.FC<BankGridProps> = ({
   banks,
   onBankSelect,
   selectedBanks = [],
+  sortByDistance = false,
+  onSortByDistanceChange,
 }) => {
   const itemsRef = useRef<HTMLElement[]>([]);
   const { handleKeyDown, setCurrentIndex } = useKeyboardNavigation(
@@ -47,6 +51,25 @@ const BankGrid: React.FC<BankGridProps> = ({
         }}
       >
         <div className="flex gap-2 sm:gap-3 px-3">
+          {/* Proximity sort chip — only shown when the handler is provided */}
+          {onSortByDistanceChange && (
+            <button
+              className={`bank-grid__item touch-target touch-button touch-feedback flex items-center gap-1.5 px-3 py-2 rounded-lg transition-all focus-visible:focus-visible micro-bounce flex-shrink-0 ${
+                sortByDistance
+                  ? "bank-grid__item--active bg-primary-50 border-2 border-primary-500"
+                  : "bg-white border-2 border-gray-200 hover:border-gray-300 hover:shadow-sm"
+              }`}
+              onClick={() => onSortByDistanceChange(!sortByDistance)}
+              aria-pressed={sortByDistance}
+              aria-label={sortByDistance ? "Desactivar orden por cercanía" : "Ordenar por cercanía"}
+              style={{ minHeight: "var(--touch-target-comfortable)" }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>near_me</span>
+              <span className="text-xs sm:text-sm font-medium text-gray-700 whitespace-nowrap">
+                Más cercanos
+              </span>
+            </button>
+          )}
           {banks.map((bank, index) => (
             <button
               key={bank.id}

--- a/src/components/tabs/BeneficiosTab.tsx
+++ b/src/components/tabs/BeneficiosTab.tsx
@@ -37,6 +37,8 @@ interface BeneficiosTabProps {
   hasMore: boolean;
   isLoadingMore: boolean;
   totalCount?: number;
+  sortByDistance?: boolean;
+  onSortByDistanceChange?: (value: boolean) => void;
 }
 
 const BeneficiosTab: React.FC<BeneficiosTabProps> = ({
@@ -52,6 +54,8 @@ const BeneficiosTab: React.FC<BeneficiosTabProps> = ({
   hasMore,
   isLoadingMore,
   totalCount,
+  sortByDistance,
+  onSortByDistanceChange,
 }) => {
   return (
     <>
@@ -70,6 +74,8 @@ const BeneficiosTab: React.FC<BeneficiosTabProps> = ({
           banks={bankGridData}
           onBankSelect={onBankSelect}
           selectedBanks={selectedBanks}
+          sortByDistance={sortByDistance}
+          onSortByDistanceChange={onSortByDistanceChange}
         />
       </div>
 

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -49,7 +49,10 @@ export interface BenefitsFilters {
  */
 export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataReturn {
     const { position, loading: positionLoading } = useGeolocation();
-    const sortByDistance = filters?.sortByDistance ?? false;
+    const wantsSortByDistance = filters?.sortByDistance ?? false;
+    // Only use proximity sort when the filter is active AND we have real coordinates.
+    // If position is null (geolocation denied/unavailable) we fall back to geohash.
+    const sortByDistance = wantsSortByDistance && position !== null;
     const geohash = !sortByDistance && position
         ? encodeGeohash(position.latitude, position.longitude)
         : undefined;
@@ -67,7 +70,7 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         refetch: refetchBusinesses,
     } = useInfiniteQuery({
         queryKey: sortByDistance
-            ? [...queryKeys.businesses, 'exact', position?.latitude, position?.longitude, filters]
+            ? [...queryKeys.businesses, 'exact', position!.latitude, position!.longitude, filters]
             : [...queryKeys.businesses, geohash, filters],
         queryFn: async ({ pageParam = 0 }) => {
             return fetchBusinessesPaginated({
@@ -89,7 +92,9 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             return undefined;
         },
         initialPageParam: 0,
-        enabled: !positionLoading,
+        // Wait for geolocation to resolve; also wait for position when proximity sort is
+        // requested so we never fire a lat/lng-less query and cache a non-sorted result.
+        enabled: !positionLoading && (!wantsSortByDistance || position !== null),
         staleTime: 0,
     });
 

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -4,7 +4,6 @@ import { Business } from '../types';
 import { RawMongoBenefit } from '../types/mongodb';
 import { fetchBusinessesPaginated, BusinessesApiResponse } from '../services/api';
 import { getRawBenefits } from '../services/rawBenefitsApi';
-import { useGeolocation } from './useGeolocation';
 
 // Query keys for cache management
 export const queryKeys = {
@@ -46,10 +45,7 @@ export interface BenefitsFilters {
  * Uses the new /api/businesses endpoint with proper server-side pagination and filtering
  */
 export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataReturn {
-    const { position, loading: positionLoading } = useGeolocation();
-
     // Fetch businesses with infinite query for pagination
-    // Wait for position to finish loading before starting the query
     const {
         data,
         isLoading: isLoadingBusinesses,
@@ -64,10 +60,6 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             return fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
-                ...(position && {
-                    lat: position.latitude,
-                    lng: position.longitude,
-                }),
                 ...(filters?.search && { search: filters.search }),
                 ...(filters?.category && filters.category !== 'all' && { category: filters.category }),
                 ...(filters?.bank && { bank: filters.bank }),
@@ -81,7 +73,6 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             return undefined;
         },
         initialPageParam: 0,
-        enabled: !positionLoading, // Wait for position to finish loading
         staleTime: 0,
     });
 
@@ -152,8 +143,6 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
  * Hook for accessing only businesses data with pagination
  */
 export function useBusinessesData() {
-    const { position, loading: positionLoading } = useGeolocation();
-
     const {
         data,
         isLoading,
@@ -167,10 +156,6 @@ export function useBusinessesData() {
             return fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
-                ...(position && {
-                    lat: position.latitude,
-                    lng: position.longitude,
-                }),
             });
         },
         getNextPageParam: (lastPage: BusinessesApiResponse) => {
@@ -180,7 +165,6 @@ export function useBusinessesData() {
             return undefined;
         },
         initialPageParam: 0,
-        enabled: !positionLoading, // Wait for position to finish loading
         staleTime: 0,
     });
 

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -4,6 +4,8 @@ import { Business } from '../types';
 import { RawMongoBenefit } from '../types/mongodb';
 import { fetchBusinessesPaginated, BusinessesApiResponse } from '../services/api';
 import { getRawBenefits } from '../services/rawBenefitsApi';
+import { useGeolocation } from './useGeolocation';
+import { encodeGeohash } from '../utils/geohash';
 
 // Query keys for cache management
 export const queryKeys = {
@@ -45,7 +47,12 @@ export interface BenefitsFilters {
  * Uses the new /api/businesses endpoint with proper server-side pagination and filtering
  */
 export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataReturn {
-    // Fetch businesses with infinite query for pagination
+    const { position, loading: positionLoading } = useGeolocation();
+    const geohash = position ? encodeGeohash(position.latitude, position.longitude) : undefined;
+
+    // Fetch businesses with infinite query for pagination.
+    // Wait for geolocation so the first response is already sorted by proximity.
+    // On return visits the position comes from localStorage (<16ms), so the wait is imperceptible.
     const {
         data,
         isLoading: isLoadingBusinesses,
@@ -55,11 +62,12 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         hasNextPage,
         refetch: refetchBusinesses,
     } = useInfiniteQuery({
-        queryKey: [...queryKeys.businesses, filters], // Include filters in cache key
+        queryKey: [...queryKeys.businesses, geohash, filters], // geohash in key → correct cache bucket
         queryFn: async ({ pageParam = 0 }) => {
             return fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
+                ...(geohash && { geohash }),
                 ...(filters?.search && { search: filters.search }),
                 ...(filters?.category && filters.category !== 'all' && { category: filters.category }),
                 ...(filters?.bank && { bank: filters.bank }),
@@ -73,6 +81,7 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             return undefined;
         },
         initialPageParam: 0,
+        enabled: !positionLoading,
         staleTime: 0,
     });
 
@@ -143,6 +152,9 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
  * Hook for accessing only businesses data with pagination
  */
 export function useBusinessesData() {
+    const { position, loading: positionLoading } = useGeolocation();
+    const geohash = position ? encodeGeohash(position.latitude, position.longitude) : undefined;
+
     const {
         data,
         isLoading,
@@ -151,11 +163,12 @@ export function useBusinessesData() {
         fetchNextPage,
         hasNextPage,
     } = useInfiniteQuery({
-        queryKey: queryKeys.businesses,
+        queryKey: [...queryKeys.businesses, geohash],
         queryFn: async ({ pageParam = 0 }) => {
             return fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
+                ...(geohash && { geohash }),
             });
         },
         getNextPageParam: (lastPage: BusinessesApiResponse) => {
@@ -165,6 +178,7 @@ export function useBusinessesData() {
             return undefined;
         },
         initialPageParam: 0,
+        enabled: !positionLoading,
         staleTime: 0,
     });
 

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -26,6 +26,8 @@ interface UseBenefitsDataReturn {
     loadMore: () => void;
     refreshData: () => Promise<void>;
     totalBusinesses: number;
+    /** True when the user wants proximity sort but geolocation is unavailable/denied */
+    proximityUnavailable: boolean;
 }
 
 export interface BenefitsFilters {
@@ -92,9 +94,12 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             return undefined;
         },
         initialPageParam: 0,
-        // Wait for geolocation to resolve; also wait for position when proximity sort is
-        // requested so we never fire a lat/lng-less query and cache a non-sorted result.
-        enabled: !positionLoading && (!wantsSortByDistance || position !== null),
+        // Wait for geolocation to resolve (so the first request already has a geohash or
+        // exact coordinates). Once geolocation settles, always fire — even if position is
+        // null (denied). In that case sortByDistance stays false (see above), so we fall
+        // back to the geohash/no-location key instead of the 'exact' key, preventing
+        // pollution of the proximity-sorted cache entry.
+        enabled: !positionLoading,
         staleTime: 0,
     });
 
@@ -158,6 +163,8 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         loadMore,
         refreshData,
         totalBusinesses,
+        // True when user wants proximity sort but geolocation was denied/unavailable
+        proximityUnavailable: wantsSortByDistance && !positionLoading && position === null,
     };
 }
 

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -40,6 +40,7 @@ export interface BenefitsFilters {
     network?: string; // Payment network (VISA, Mastercard, etc.)
     cardMode?: 'credit' | 'debit'; // Card type
     hasInstallments?: boolean; // Filter for installment availability
+    sortByDistance?: boolean; // Send exact coords to server for precise distance sort (bypasses CDN)
 }
 
 /**
@@ -48,11 +49,14 @@ export interface BenefitsFilters {
  */
 export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataReturn {
     const { position, loading: positionLoading } = useGeolocation();
-    const geohash = position ? encodeGeohash(position.latitude, position.longitude) : undefined;
+    const sortByDistance = filters?.sortByDistance ?? false;
+    const geohash = !sortByDistance && position
+        ? encodeGeohash(position.latitude, position.longitude)
+        : undefined;
 
     // Fetch businesses with infinite query for pagination.
-    // Wait for geolocation so the first response is already sorted by proximity.
-    // On return visits the position comes from localStorage (<16ms), so the wait is imperceptible.
+    // sortByDistance=true → sends exact lat/lng to server (precise sort, bypasses CDN cache).
+    // sortByDistance=false → sends geohash (CDN-cached, approximate proximity sort).
     const {
         data,
         isLoading: isLoadingBusinesses,
@@ -62,12 +66,16 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         hasNextPage,
         refetch: refetchBusinesses,
     } = useInfiniteQuery({
-        queryKey: [...queryKeys.businesses, geohash, filters], // geohash in key → correct cache bucket
+        queryKey: sortByDistance
+            ? [...queryKeys.businesses, 'exact', position?.latitude, position?.longitude, filters]
+            : [...queryKeys.businesses, geohash, filters],
         queryFn: async ({ pageParam = 0 }) => {
             return fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
-                ...(geohash && { geohash }),
+                ...(sortByDistance && position
+                    ? { lat: position.latitude, lng: position.longitude }
+                    : geohash ? { geohash } : {}),
                 ...(filters?.search && { search: filters.search }),
                 ...(filters?.category && filters.category !== 'all' && { category: filters.category }),
                 ...(filters?.bank && { bank: filters.bank }),

--- a/src/hooks/useEnrichedBusinesses.ts
+++ b/src/hooks/useEnrichedBusinesses.ts
@@ -17,7 +17,7 @@ export const useEnrichedBusinesses = (
     network?: string; // Payment network (VISA, Mastercard, etc.)
     cardMode?: 'credit' | 'debit'; // Card type
     hasInstallments?: boolean; // Filter for installment availability
-    sortByDistance?: boolean; // Re-sort all loaded businesses by real distance
+    sortByDistance?: boolean; // unused — server handles sort when exact coords are sent
   }
 ) => {
   const { position } = useGeolocation();
@@ -30,7 +30,6 @@ export const useEnrichedBusinesses = (
     network,
     cardMode,
     hasInstallments,
-    sortByDistance = false,
   } = options || {};
 
   const enrichedBusinesses = useMemo(() => {
@@ -164,18 +163,9 @@ export const useEnrichedBusinesses = (
       });
     }
 
-    // Only re-sort when the user explicitly enables the "sort by proximity" filter.
-    // Otherwise preserve server order so new pages appended on scroll don't jump.
-    if (sortByDistance && position) {
-      result.sort((a, b) => {
-        const da = a.distance ?? Infinity;
-        const db = b.distance ?? Infinity;
-        return da - db;
-      });
-    }
-
+    // Server already sorts by distance when exact coords are sent — preserve that order.
     return result;
-  }, [businesses, position, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments, sortByDistance]);
+  }, [businesses, position, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments]);
 
   return enrichedBusinesses;
 };

--- a/src/hooks/useEnrichedBusinesses.ts
+++ b/src/hooks/useEnrichedBusinesses.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Business } from '../types';
-import { hasOnlineBenefits } from '../utils/distance';
+import { hasOnlineBenefits, calculateDistance, formatDistance } from '../utils/distance';
+import { useGeolocation } from './useGeolocation';
 
 /**
  * Enriches businesses with online information and applies filters
@@ -18,6 +19,8 @@ export const useEnrichedBusinesses = (
     hasInstallments?: boolean; // Filter for installment availability
   }
 ) => {
+  const { position } = useGeolocation();
+
   const {
     onlineOnly = false,
     minDiscount,
@@ -29,14 +32,29 @@ export const useEnrichedBusinesses = (
   } = options || {};
 
   const enrichedBusinesses = useMemo(() => {
-    // Add hasOnline flag to each business
+    // Add hasOnline flag and compute distance client-side when position is available
     let result = businesses.map((business) => {
-      // Check if has online benefits
       const hasOnline = hasOnlineBenefits(business);
+
+      let distance = business.distance;
+      let distanceText = business.distanceText;
+      let isNearby = business.isNearby;
+
+      if (position && business.location?.length > 0) {
+        const distances = business.location.map((loc) =>
+          calculateDistance(position.latitude, position.longitude, loc.lat, loc.lng)
+        );
+        distance = Math.min(...distances);
+        distanceText = formatDistance(distance);
+        isNearby = distance <= 50;
+      }
 
       return {
         ...business,
         hasOnline,
+        distance,
+        distanceText,
+        isNearby,
       };
     });
 
@@ -144,9 +162,17 @@ export const useEnrichedBusinesses = (
       });
     }
 
-    // Backend already sorts by distance, so we preserve that order
+    // Sort by distance when user position is available
+    if (position) {
+      result.sort((a, b) => {
+        const da = a.distance ?? Infinity;
+        const db = b.distance ?? Infinity;
+        return da - db;
+      });
+    }
+
     return result;
-  }, [businesses, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments]);
+  }, [businesses, position, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments]);
 
   return enrichedBusinesses;
 };

--- a/src/hooks/useEnrichedBusinesses.ts
+++ b/src/hooks/useEnrichedBusinesses.ts
@@ -17,6 +17,7 @@ export const useEnrichedBusinesses = (
     network?: string; // Payment network (VISA, Mastercard, etc.)
     cardMode?: 'credit' | 'debit'; // Card type
     hasInstallments?: boolean; // Filter for installment availability
+    sortByDistance?: boolean; // Re-sort all loaded businesses by real distance
   }
 ) => {
   const { position } = useGeolocation();
@@ -29,6 +30,7 @@ export const useEnrichedBusinesses = (
     network,
     cardMode,
     hasInstallments,
+    sortByDistance = false,
   } = options || {};
 
   const enrichedBusinesses = useMemo(() => {
@@ -162,8 +164,9 @@ export const useEnrichedBusinesses = (
       });
     }
 
-    // Sort by distance when user position is available
-    if (position) {
+    // Only re-sort when the user explicitly enables the "sort by proximity" filter.
+    // Otherwise preserve server order so new pages appended on scroll don't jump.
+    if (sortByDistance && position) {
       result.sort((a, b) => {
         const da = a.distance ?? Infinity;
         const db = b.distance ?? Infinity;
@@ -172,7 +175,7 @@ export const useEnrichedBusinesses = (
     }
 
     return result;
-  }, [businesses, position, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments]);
+  }, [businesses, position, onlineOnly, minDiscount, maxDistance, availableDay, network, cardMode, hasInstallments, sortByDistance]);
 
   return enrichedBusinesses;
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -92,6 +92,7 @@ function Home() {
     network: selectedNetwork,
     cardMode,
     hasInstallments,
+    sortByDistance,
   });
 
   // Track when data has loaded at least once
@@ -126,14 +127,6 @@ function Home() {
   // State for proximity sort
   const [sortByDistance, setSortByDistance] = useState(false);
 
-  // When "Más cercanos" is active, keep fetching until every page is loaded
-  // so the client-side sort has the full dataset to work with.
-  useEffect(() => {
-    if (sortByDistance && hasMore && !isLoadingMore) {
-      loadMore();
-    }
-  }, [sortByDistance, hasMore, isLoadingMore, loadMore]);
-
   // State for filter dropdown
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const filterDropdownRef = useRef<HTMLDivElement>(null);
@@ -162,7 +155,6 @@ function Home() {
     network: selectedNetwork,
     cardMode,
     hasInstallments,
-    sortByDistance,
   });
 
   // Since search, category, and bank filters are now server-side, we only need client-side online filter

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -126,6 +126,14 @@ function Home() {
   // State for proximity sort
   const [sortByDistance, setSortByDistance] = useState(false);
 
+  // When "Más cercanos" is active, keep fetching until every page is loaded
+  // so the client-side sort has the full dataset to work with.
+  useEffect(() => {
+    if (sortByDistance && hasMore && !isLoadingMore) {
+      loadMore();
+    }
+  }, [sortByDistance, hasMore, isLoadingMore, loadMore]);
+
   // State for filter dropdown
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const filterDropdownRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -63,6 +63,9 @@ function Home() {
   const [cardMode, setCardMode] = useState<'credit' | 'debit' | undefined>(undefined);
   const [hasInstallments, setHasInstallments] = useState<boolean | undefined>(undefined);
 
+  // State for proximity sort — must be declared before useBenefitsData
+  const [sortByDistance, setSortByDistance] = useState(false);
+
   // Debounce search term to avoid excessive API calls
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -123,9 +126,6 @@ function Home() {
 
   // State for online filter
   const [onlineOnly, setOnlineOnly] = useState(false);
-
-  // State for proximity sort
-  const [sortByDistance, setSortByDistance] = useState(false);
 
   // State for filter dropdown
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -123,6 +123,9 @@ function Home() {
   // State for online filter
   const [onlineOnly, setOnlineOnly] = useState(false);
 
+  // State for proximity sort
+  const [sortByDistance, setSortByDistance] = useState(false);
+
   // State for filter dropdown
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const filterDropdownRef = useRef<HTMLDivElement>(null);
@@ -151,6 +154,7 @@ function Home() {
     network: selectedNetwork,
     cardMode,
     hasInstallments,
+    sortByDistance,
   });
 
   // Since search, category, and bank filters are now server-side, we only need client-side online filter
@@ -606,6 +610,8 @@ function Home() {
                   hasMore={hasMore}
                   isLoadingMore={isLoadingMore || isLoading}
                   totalCount={totalBusinesses}
+                  sortByDistance={sortByDistance}
+                  onSortByDistanceChange={setSortByDistance}
                 />
               ) : (
                 <InicioTab

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -183,6 +183,7 @@ function SearchPage() {
   const [cardMode, setCardMode] = useState<'credit' | 'debit' | undefined>((searchParams.get('card') || undefined) as 'credit' | 'debit' | undefined);
   const [network, setNetwork] = useState<string | undefined>(searchParams.get('network') || undefined);
   const [hasInstallments, setHasInstallments] = useState<boolean | undefined>(searchParams.get('installments') === '1' ? true : undefined);
+  const [sortByDistance, setSortByDistance] = useState(false);
 
   const { data: availableBankNames = [] } = useQuery({
     queryKey: ['availableBanks'],
@@ -251,6 +252,7 @@ function SearchPage() {
     network,
     cardMode,
     hasInstallments,
+    sortByDistance,
   });
 
   const businessBankNames = useMemo(() => {
@@ -710,6 +712,19 @@ function SearchPage() {
                 </button>
               );
             })()}
+
+            {/* Proximity sort */}
+            <button
+              onClick={() => setSortByDistance(!sortByDistance)}
+              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                sortByDistance
+                  ? 'bg-primary text-white'
+                  : 'bg-blink-bg border border-blink-border text-blink-ink hover:border-primary/30'
+              }`}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 18 }}>near_me</span>
+              <span>Más cercanos</span>
+            </button>
 
             {/* Online only */}
             <button

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -233,6 +233,7 @@ function SearchPage() {
     hasMore,
     loadMore,
     totalBusinesses,
+    proximityUnavailable,
   } = useBenefitsData({
     search: debouncedSearch.trim() || undefined,
     category: selectedCategory && selectedCategory !== 'all' ? selectedCategory : undefined,
@@ -769,6 +770,17 @@ function SearchPage() {
 
       {/* Results */}
       <main className="flex-1 px-4 py-5 space-y-3 pb-28">
+        {/* Location-unavailable banner — shown when "Más cercanos" is active but GPS is denied */}
+        {proximityUnavailable && (
+          <div
+            className="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm"
+            style={{ background: '#FFF7ED', border: '1px solid #FED7AA', color: '#C2410C' }}
+          >
+            <span className="material-symbols-outlined shrink-0" style={{ fontSize: 18 }}>location_off</span>
+            <span>Activá tu ubicación para ordenar por cercanía</span>
+          </div>
+        )}
+
         <div className="flex justify-between items-center mb-2">
           <h1 className="font-semibold text-base text-blink-ink">Tiendas</h1>
           <span

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -243,15 +243,8 @@ function SearchPage() {
     network,
     cardMode,
     hasInstallments,
+    sortByDistance,
   });
-
-  // When "Más cercanos" is active, keep fetching until every page is loaded
-  // so the client-side sort has the full dataset to work with.
-  useEffect(() => {
-    if (sortByDistance && hasMore && !isLoadingMore) {
-      loadMore();
-    }
-  }, [sortByDistance, hasMore, isLoadingMore, loadMore]);
 
   const enrichedBusinesses = useEnrichedBusinesses(businesses, {
     onlineOnly,
@@ -261,7 +254,6 @@ function SearchPage() {
     network,
     cardMode,
     hasInstallments,
-    sortByDistance,
   });
 
   const businessBankNames = useMemo(() => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -183,7 +183,7 @@ function SearchPage() {
   const [cardMode, setCardMode] = useState<'credit' | 'debit' | undefined>((searchParams.get('card') || undefined) as 'credit' | 'debit' | undefined);
   const [network, setNetwork] = useState<string | undefined>(searchParams.get('network') || undefined);
   const [hasInstallments, setHasInstallments] = useState<boolean | undefined>(searchParams.get('installments') === '1' ? true : undefined);
-  const [sortByDistance, setSortByDistance] = useState(false);
+  const [sortByDistance, setSortByDistance] = useState(searchParams.get('nearby') === '1');
 
   const { data: availableBankNames = [] } = useQuery({
     queryKey: ['availableBanks'],
@@ -204,8 +204,9 @@ function SearchPage() {
     if (cardMode) params.set('card', cardMode);
     if (network) params.set('network', network);
     if (hasInstallments) params.set('installments', '1');
+    if (sortByDistance) params.set('nearby', '1');
     setSearchParams(params, { replace: true });
-  }, [debouncedSearch, selectedCategory, selectedBanks, onlineOnly, maxDistance, minDiscount, availableDay, cardMode, network, hasInstallments, setSearchParams]);
+  }, [debouncedSearch, selectedCategory, selectedBanks, onlineOnly, maxDistance, minDiscount, availableDay, cardMode, network, hasInstallments, sortByDistance, setSearchParams]);
 
   // Debounce search
   useEffect(() => {
@@ -243,6 +244,14 @@ function SearchPage() {
     cardMode,
     hasInstallments,
   });
+
+  // When "Más cercanos" is active, keep fetching until every page is loaded
+  // so the client-side sort has the full dataset to work with.
+  useEffect(() => {
+    if (sortByDistance && hasMore && !isLoadingMore) {
+      loadMore();
+    }
+  }, [sortByDistance, hasMore, isLoadingMore, loadMore]);
 
   const enrichedBusinesses = useEnrichedBusinesses(businesses, {
     onlineOnly,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -89,8 +89,10 @@ export async function fetchBusinessesPaginated(options: {
   search?: string;
   subscription?: string;
   geohash?: string;
+  lat?: number;
+  lng?: number;
 } = {}): Promise<BusinessesApiResponse> {
-  const { limit = 20, offset = 0, category, bank, search, subscription, geohash } = options;
+  const { limit = 20, offset = 0, category, bank, search, subscription, geohash, lat, lng } = options;
 
   const params = new URLSearchParams();
   params.append('limit', limit.toString());
@@ -100,7 +102,13 @@ export async function fetchBusinessesPaginated(options: {
   if (bank) params.append('bank', bank);
   if (search) params.append('search', search);
   if (subscription) params.append('subscription', subscription);
-  if (geohash) params.append('geohash', geohash);
+  // Exact coords take priority — only send one or the other
+  if (lat !== undefined && lng !== undefined) {
+    params.append('lat', lat.toString());
+    params.append('lng', lng.toString());
+  } else if (geohash) {
+    params.append('geohash', geohash);
+  }
 
   const url = `${BASE_URL}/api/businesses?${params.toString()}`;
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -88,10 +88,9 @@ export async function fetchBusinessesPaginated(options: {
   bank?: string;
   search?: string;
   subscription?: string;
-  lat?: number;
-  lng?: number;
+  geohash?: string;
 } = {}): Promise<BusinessesApiResponse> {
-  const { limit = 20, offset = 0, category, bank, search, subscription, lat, lng } = options;
+  const { limit = 20, offset = 0, category, bank, search, subscription, geohash } = options;
 
   const params = new URLSearchParams();
   params.append('limit', limit.toString());
@@ -101,10 +100,7 @@ export async function fetchBusinessesPaginated(options: {
   if (bank) params.append('bank', bank);
   if (search) params.append('search', search);
   if (subscription) params.append('subscription', subscription);
-  if (lat !== undefined && lng !== undefined) {
-    params.append('lat', lat.toString());
-    params.append('lng', lng.toString());
-  }
+  if (geohash) params.append('geohash', geohash);
 
   const url = `${BASE_URL}/api/businesses?${params.toString()}`;
 

--- a/src/utils/geohash.ts
+++ b/src/utils/geohash.ts
@@ -1,0 +1,35 @@
+const BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+
+/**
+ * Encode a lat/lng pair into a geohash string.
+ * Precision 4 produces ~39km × 20km cells — coarse enough for good CDN
+ * cache-hit rates while still providing meaningful proximity sorting.
+ */
+export function encodeGeohash(lat: number, lng: number, precision = 4): string {
+  let even = true;
+  let hashValue = 0;
+  let bits = 0;
+  let result = '';
+  const latRange = [-90, 90];
+  const lngRange = [-180, 180];
+
+  while (result.length < precision) {
+    if (even) {
+      const mid = (lngRange[0] + lngRange[1]) / 2;
+      if (lng > mid) { hashValue = (hashValue << 1) | 1; lngRange[0] = mid; }
+      else            { hashValue <<= 1;                  lngRange[1] = mid; }
+    } else {
+      const mid = (latRange[0] + latRange[1]) / 2;
+      if (lat > mid) { hashValue = (hashValue << 1) | 1; latRange[0] = mid; }
+      else           { hashValue <<= 1;                  latRange[1] = mid; }
+    }
+    even = !even;
+    if (++bits === 5) {
+      result += BASE32[hashValue];
+      bits = 0;
+      hashValue = 0;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Set HTTP caching headers on all API success responses so Vercel's Edge Network can serve cached results without invoking the function or hitting MongoDB on every request.

- Metadata endpoints (categories, banks, networks): 12h CDN / 1h browser
- Content endpoints (benefits, businesses, stats): 1h CDN / 5m browser
- Location-based endpoints (nearby, businesses with coords): browser-only 1m
- POST (places/details): unchanged — POST responses are never cached by CDN