### PR TITLE
Filter banks by minimum transaction count in aggregation

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -395,6 +395,7 @@ async function handleGetBanks(req, res, url, db) {
     .aggregate([
       ...(activeMatch ? [{ $match: activeMatch }] : []),
       { $group: { _id: '$bank', count: { $sum: 1 } } },
+      { $match: { count: { $gte: 5 } } },
       { $sort: { count: -1 } }
     ])
     .toArray();


### PR DESCRIPTION
## Summary
Added a filtering stage to the bank aggregation pipeline to exclude banks with fewer than 5 transactions from the results.

## Key Changes
- Added `$match` stage in the `handleGetBanks` aggregation pipeline to filter out banks with a transaction count below 5
- The filter is applied after grouping and counting transactions, ensuring only banks meeting the minimum threshold are returned

## Implementation Details
The new `{ $match: { count: { $gte: 5 } } }` stage is positioned after the `$group` stage, allowing it to filter based on the aggregated count. This ensures the API only returns banks that have at least 5 associated transactions, improving data quality and reducing noise in the results.

https://claude.ai/code/session_01F916T53XpCA2iRWSiVzF88