### PR TITLE
fix: allow disk use for merchant sort in businesses endpoint

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1686,7 +1686,7 @@ async function handleGetBusinesses(req, res, url, db) {
           {
             $project: merchantProjection
           }
-        ])
+        ], { allowDiskUse: true })
         .toArray();
 
       const merchantsWithDistance = withGeo.map((merchant) => ({

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1670,7 +1670,7 @@ async function handleGetBusinesses(req, res, url, db) {
               distanceMeters: 1
             }
           }
-        ])
+        ], { allowDiskUse: true })
         .toArray();
 
       const withoutGeo = await merchantCollection


### PR DESCRIPTION
NaranjaX (and other large banks) caused Sort exceeded memory limit (32MB) when sorting all merchants without geo points by merchantName.