### PR TITLE
Redesign BusinessDetailPage to match competitor UX

### DIFF
--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -89,10 +89,35 @@ function BusinessDetailPage() {
   const [activeTab, setActiveTab] = useState<ActiveTab>('mis-beneficios');
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
-  const [isCompact, setIsCompact] = useState(false);
+
+  // Refs for scroll-driven header collapse — no setState, zero re-renders
+  const topRowRef = useRef<HTMLDivElement>(null);
+  const logoRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLHeadingElement>(null);
+  const secondaryRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const onScroll = () => setIsCompact(window.scrollY > 56);
+    let compact = false;
+    const apply = (next: boolean) => {
+      if (next === compact) return;
+      compact = next;
+      if (topRowRef.current) {
+        topRowRef.current.style.paddingTop = next ? '8px' : '16px';
+        topRowRef.current.style.paddingBottom = next ? '8px' : '16px';
+      }
+      if (logoRef.current) {
+        logoRef.current.style.width = next ? '36px' : '64px';
+        logoRef.current.style.height = next ? '36px' : '64px';
+        logoRef.current.style.borderRadius = next ? '10px' : '16px';
+        logoRef.current.style.boxShadow = next ? 'none' : '0 2px 12px rgba(0,0,0,0.10)';
+      }
+      if (nameRef.current) nameRef.current.style.fontSize = next ? '15px' : '17px';
+      if (secondaryRef.current) {
+        secondaryRef.current.style.maxHeight = next ? '0px' : '52px';
+        secondaryRef.current.style.opacity = next ? '0' : '1';
+      }
+    };
+    const onScroll = () => apply(window.scrollY > 56);
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
@@ -253,10 +278,11 @@ function BusinessDetailPage() {
 
         {/* Top row */}
         <div
+          ref={topRowRef}
           className="flex items-center gap-3 px-4"
           style={{
-            paddingTop: isCompact ? 8 : 16,
-            paddingBottom: isCompact ? 8 : 16,
+            paddingTop: 16,
+            paddingBottom: 16,
             transition: 'padding 250ms cubic-bezier(0.4,0,0.2,1)',
           }}
         >
@@ -269,35 +295,38 @@ function BusinessDetailPage() {
 
           {/* Logo — shrinks on scroll */}
           <div
+            ref={logoRef}
             className="flex-shrink-0 bg-white flex items-center justify-center overflow-hidden"
             style={{
-              width: isCompact ? 36 : 64,
-              height: isCompact ? 36 : 64,
-              borderRadius: isCompact ? 10 : 16,
+              width: 64,
+              height: 64,
+              borderRadius: 16,
               border: '1px solid #E8E6E1',
-              boxShadow: isCompact ? 'none' : '0 2px 12px rgba(0,0,0,0.10)',
+              boxShadow: '0 2px 12px rgba(0,0,0,0.10)',
               transition: 'width 250ms cubic-bezier(0.4,0,0.2,1), height 250ms cubic-bezier(0.4,0,0.2,1), border-radius 250ms ease, box-shadow 250ms ease',
             }}
           >
             {business.image ? (
               <img alt={business.name} className="w-full h-full object-contain p-1.5" src={business.image} />
             ) : (
-              <span className="font-black text-blink-muted" style={{ fontSize: isCompact ? 14 : 24 }}>{business.name?.charAt(0)}</span>
+              <span className="font-black text-2xl text-blink-muted">{business.name?.charAt(0)}</span>
             )}
           </div>
 
           {/* Name + collapsible secondary info */}
           <div className="flex-1 min-w-0">
             <h1
+              ref={nameRef}
               className="font-bold text-blink-ink leading-tight truncate"
-              style={{ fontSize: isCompact ? 15 : 17, transition: 'font-size 250ms ease' }}
+              style={{ fontSize: 17, transition: 'font-size 250ms ease' }}
             >
               {business.name}
             </h1>
             <div
+              ref={secondaryRef}
               style={{
-                maxHeight: isCompact ? 0 : 52,
-                opacity: isCompact ? 0 : 1,
+                maxHeight: 52,
+                opacity: 1,
                 overflow: 'hidden',
                 transition: 'max-height 250ms cubic-bezier(0.4,0,0.2,1), opacity 200ms ease',
               }}

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -102,6 +102,8 @@ function BusinessDetailPage() {
     // events at page bottom that make the animation shake.
     const isStandalone =
       window.matchMedia('(display-mode: standalone)').matches ||
+      window.matchMedia('(display-mode: fullscreen)').matches ||
+      window.matchMedia('(display-mode: minimal-ui)').matches ||
       (navigator as unknown as { standalone?: boolean }).standalone === true;
     if (!isStandalone) return;
 
@@ -124,16 +126,25 @@ function BusinessDetailPage() {
         secondaryRef.current.style.opacity = next ? '0' : '1';
       }
     };
-    // Hysteresis: collapse at 56px, but only expand again when back near top (< 10px).
-    // Without this, pages barely taller than the viewport oscillate: collapsing the
-    // header shrinks max-scrollY below 56px, triggering an expand, which pushes
-    // max-scrollY back above 56px, triggering a collapse again — infinite shake.
+
+    let expandTimer = 0;
     const onScroll = () => {
       const y = window.scrollY;
-      apply(isCompactRef.current ? y > 10 : y > 56);
+      // Collapse immediately when scrolled down enough.
+      if (y > 56) { clearTimeout(expandTimer); apply(true); return; }
+      // Expand only after a 200ms quiet period — filters the spurious near-zero
+      // scroll event WebKit fires when the page shrinks after a collapse, which
+      // would otherwise cause an instant expand → grow → collapse → oscillation.
+      if (isCompactRef.current) {
+        clearTimeout(expandTimer);
+        expandTimer = window.setTimeout(() => {
+          if (window.scrollY <= 56) apply(false);
+        }, 200);
+      }
     };
+
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => { window.removeEventListener('scroll', onScroll); clearTimeout(expandTimer); };
   }, []);
 
   useSEO({

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -124,7 +124,14 @@ function BusinessDetailPage() {
         secondaryRef.current.style.opacity = next ? '0' : '1';
       }
     };
-    const onScroll = () => apply(window.scrollY > 56);
+    // Hysteresis: collapse at 56px, but only expand again when back near top (< 10px).
+    // Without this, pages barely taller than the viewport oscillate: collapsing the
+    // header shrinks max-scrollY below 56px, triggering an expand, which pushes
+    // max-scrollY back above 56px, triggering a collapse again — infinite shake.
+    const onScroll = () => {
+      const y = window.scrollY;
+      apply(isCompactRef.current ? y > 10 : y > 56);
+    };
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -117,9 +117,13 @@ function BusinessDetailPage() {
         secondaryRef.current.style.opacity = next ? '0' : '1';
       }
     };
-    const onScroll = () => apply(window.scrollY > 56);
+    let rafId = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => apply(window.scrollY > 56));
+    };
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => { window.removeEventListener('scroll', onScroll); cancelAnimationFrame(rafId); };
   }, []);
 
   useSEO({

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -91,6 +91,7 @@ function BusinessDetailPage() {
   const [filterToday, setFilterToday] = useState(false);
 
   // Refs for scroll-driven header collapse — no setState, zero re-renders
+  const isCompactRef = useRef(false);
   const topRowRef = useRef<HTMLDivElement>(null);
   const logoRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLHeadingElement>(null);
@@ -104,10 +105,9 @@ function BusinessDetailPage() {
       (navigator as unknown as { standalone?: boolean }).standalone === true;
     if (!isStandalone) return;
 
-    let compact = false;
     const apply = (next: boolean) => {
-      if (next === compact) return;
-      compact = next;
+      if (next === isCompactRef.current) return;
+      isCompactRef.current = next;
       if (topRowRef.current) {
         topRowRef.current.style.paddingTop = next ? '8px' : '16px';
         topRowRef.current.style.paddingBottom = next ? '8px' : '16px';
@@ -288,8 +288,8 @@ function BusinessDetailPage() {
           ref={topRowRef}
           className="flex items-center gap-3 px-4"
           style={{
-            paddingTop: 16,
-            paddingBottom: 16,
+            paddingTop: isCompactRef.current ? 8 : 16,
+            paddingBottom: isCompactRef.current ? 8 : 16,
             transition: 'padding 250ms cubic-bezier(0.4,0,0.2,1)',
           }}
         >
@@ -305,11 +305,11 @@ function BusinessDetailPage() {
             ref={logoRef}
             className="flex-shrink-0 bg-white flex items-center justify-center overflow-hidden"
             style={{
-              width: 64,
-              height: 64,
-              borderRadius: 16,
+              width: isCompactRef.current ? 36 : 64,
+              height: isCompactRef.current ? 36 : 64,
+              borderRadius: isCompactRef.current ? 10 : 16,
               border: '1px solid #E8E6E1',
-              boxShadow: '0 2px 12px rgba(0,0,0,0.10)',
+              boxShadow: isCompactRef.current ? 'none' : '0 2px 12px rgba(0,0,0,0.10)',
               transition: 'width 250ms cubic-bezier(0.4,0,0.2,1), height 250ms cubic-bezier(0.4,0,0.2,1), border-radius 250ms ease, box-shadow 250ms ease',
             }}
           >
@@ -325,15 +325,15 @@ function BusinessDetailPage() {
             <h1
               ref={nameRef}
               className="font-bold text-blink-ink leading-tight truncate"
-              style={{ fontSize: 17, transition: 'font-size 250ms ease' }}
+              style={{ fontSize: isCompactRef.current ? 15 : 17, transition: 'font-size 250ms ease' }}
             >
               {business.name}
             </h1>
             <div
               ref={secondaryRef}
               style={{
-                maxHeight: 52,
-                opacity: 1,
+                maxHeight: isCompactRef.current ? 0 : 52,
+                opacity: isCompactRef.current ? 0 : 1,
                 overflow: 'hidden',
                 transition: 'max-height 250ms cubic-bezier(0.4,0,0.2,1), opacity 200ms ease',
               }}

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -90,7 +90,6 @@ function BusinessDetailPage() {
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
 
-
   useSEO({
     title: business
       ? `${business.name}: descuentos y beneficios bancarios | Blink`
@@ -240,7 +239,7 @@ function BusinessDetailPage() {
   const branchLabel = branchCount > 1 ? `${branchCount} sucursales` : branchCount === 1 ? '1 sucursal' : '';
 
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col" style={{ overscrollBehavior: 'none' }}>
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col">
 
       {/* ── Sticky header ── */}
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
@@ -256,7 +255,7 @@ function BusinessDetailPage() {
 
           <div
             className="flex-shrink-0 w-[64px] h-[64px] rounded-2xl bg-white flex items-center justify-center overflow-hidden"
-            style={{ border: '1px solid #E8E6E1', boxShadow: '0 2px 12px rgba(0,0,0,0.10)' }}
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.10)', border: '1px solid #E8E6E1' }}
           >
             {business.image ? (
               <img alt={business.name} className="w-full h-full object-contain p-1.5" src={business.image} />
@@ -456,7 +455,6 @@ function BusinessDetailPage() {
                   {/* Expand button */}
                   {!expanded && hiddenCount > 0 && (
                     <button
-                      type="button"
                       onClick={() => toggleGroup(bankName)}
                       className="w-full py-3 text-sm font-semibold flex items-center justify-center gap-1"
                       style={{ color: '#DC2626', borderTop: '1px solid #E8E6E1' }}

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -65,13 +65,9 @@ const isBenefitAvailableToday = (b: BankBenefit): boolean =>
 
 const INITIAL_SHOW = 2;
 
-type ActiveTab = 'mis-beneficios' | 'por-beneficio' | 'sucursal';
+type ViewMode = 'por-beneficio' | 'sucursal' | null;
 
-const TABS: { key: ActiveTab; label: string; icon: string }[] = [
-  { key: 'mis-beneficios', label: 'Mis beneficios', icon: 'person' },
-  { key: 'por-beneficio', label: 'Por beneficio', icon: 'visibility' },
-  { key: 'sucursal', label: 'Sucursal', icon: 'storefront' },
-];
+const BANK_STORAGE_KEY = 'blink.search.selectedBanks';
 
 function BusinessDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -89,9 +85,17 @@ function BusinessDetailPage() {
   const businessBenefitCount = business?.benefits.length || 0;
   const businessPath = id ? `/business/${id}` : '/business';
 
-  const [activeTab, setActiveTab] = useState<ActiveTab>('mis-beneficios');
+  const [viewMode, setViewMode] = useState<ViewMode>(null);
+  const [filterMyBanks, setFilterMyBanks] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
+
+  const myBanks = useMemo<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(BANK_STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch { return []; }
+  }, []);
 
   useSEO({
     title: business
@@ -221,6 +225,24 @@ function BusinessDetailPage() {
     [sortedBenefits, filterToday],
   );
 
+  const displayedGroupedBenefits = useMemo(() => {
+    if (!filterMyBanks || myBanks.length === 0) return filteredGroupedBenefits;
+    const result: Record<string, BankBenefit[]> = {};
+    for (const [bank, benefits] of Object.entries(filteredGroupedBenefits)) {
+      if (myBanks.some(b => bank.toLowerCase().includes(b.toLowerCase()) || b.toLowerCase().includes(bank.toLowerCase()))) {
+        result[bank] = benefits;
+      }
+    }
+    return result;
+  }, [filteredGroupedBenefits, filterMyBanks, myBanks]);
+
+  const displayedSortedBenefits = useMemo(() => {
+    if (!filterMyBanks || myBanks.length === 0) return filteredSortedBenefits;
+    return filteredSortedBenefits.filter(b =>
+      myBanks.some(m => b.bankName.toLowerCase().includes(m.toLowerCase()) || m.toLowerCase().includes(b.bankName.toLowerCase()))
+    );
+  }, [filteredSortedBenefits, filterMyBanks, myBanks]);
+
   const handleBenefitSelect = (selectedBenefit: BankBenefit, position: number) => {
     if (!business || isScrollingRef.current) return;
     const selectedIndex = business.benefits.indexOf(selectedBenefit);
@@ -306,23 +328,42 @@ function BusinessDetailPage() {
           </div>
         </div>
 
-        {/* Filter pills — same style as SearchPage */}
+        {/* Filter pills */}
         <div className="w-full overflow-x-auto no-scrollbar py-3 px-4" style={{ borderTop: '1px solid #E8E6E1' }}>
           <div className="flex gap-2 min-w-max items-center">
-            {TABS.map(tab => (
-              <button
-                key={tab.key}
-                onClick={() => setActiveTab(tab.key)}
-                className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
-                  activeTab === tab.key
-                    ? 'bg-primary text-white'
-                    : 'bg-blink-bg border border-blink-border text-blink-ink'
-                }`}
-              >
-                <span className="material-symbols-outlined" style={{ fontSize: 16 }}>{tab.icon}</span>
-                {tab.label}
-              </button>
-            ))}
+            <button
+              onClick={() => setFilterMyBanks(f => !f)}
+              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                filterMyBanks
+                  ? 'bg-primary text-white'
+                  : 'bg-blink-bg border border-blink-border text-blink-ink'
+              }`}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>person</span>
+              Mis beneficios
+            </button>
+            <button
+              onClick={() => setViewMode(v => v === 'por-beneficio' ? null : 'por-beneficio')}
+              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                viewMode === 'por-beneficio'
+                  ? 'bg-primary text-white'
+                  : 'bg-blink-bg border border-blink-border text-blink-ink'
+              }`}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>visibility</span>
+              Por beneficio
+            </button>
+            <button
+              onClick={() => setViewMode(v => v === 'sucursal' ? null : 'sucursal')}
+              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                viewMode === 'sucursal'
+                  ? 'bg-primary text-white'
+                  : 'bg-blink-bg border border-blink-border text-blink-ink'
+              }`}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>storefront</span>
+              Sucursal
+            </button>
             <button
               onClick={() => setFilterToday(f => !f)}
               className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
@@ -345,10 +386,10 @@ function BusinessDetailPage() {
         style={{ overflowY: 'auto', overscrollBehavior: 'contain' }}
       >
 
-        {/* Mis beneficios — grouped by bank */}
-        {activeTab === 'mis-beneficios' && (
+        {/* Grouped by bank — default view */}
+        {viewMode !== 'por-beneficio' && viewMode !== 'sucursal' && (
           <div className="space-y-3 pt-3 px-4">
-            {Object.entries(filteredGroupedBenefits).map(([bankName, bankBenefits]) => {
+            {Object.entries(displayedGroupedBenefits).map(([bankName, bankBenefits]) => {
               const accent = getBankAccent(bankName);
               const expanded = expandedGroups[bankName];
               const visible = expanded ? bankBenefits : bankBenefits.slice(0, INITIAL_SHOW);
@@ -493,9 +534,9 @@ function BusinessDetailPage() {
         )}
 
         {/* Por beneficio — flat sorted list */}
-        {activeTab === 'por-beneficio' && (
+        {viewMode === 'por-beneficio' && (
           <div className="space-y-2 pt-3 px-4">
-            {filteredSortedBenefits.map((benefit, idx) => {
+            {displayedSortedBenefits.map((benefit, idx) => {
               const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
               const hasDiscount = !!(discount && parseInt(discount) > 0);
               const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;
@@ -544,7 +585,7 @@ function BusinessDetailPage() {
         )}
 
         {/* Sucursal — map CTA */}
-        {activeTab === 'sucursal' && (
+        {viewMode === 'sucursal' && (
           <div className="flex flex-col items-center gap-5 pt-14 px-6">
             <div className="w-20 h-20 rounded-2xl bg-indigo-50 flex items-center justify-center">
               <span className="material-symbols-outlined text-primary" style={{ fontSize: 40 }}>map</span>

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -97,6 +97,13 @@ function BusinessDetailPage() {
   const secondaryRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    // Only enable in standalone PWA — browser chrome causes viewport resize
+    // events at page bottom that make the animation shake.
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      (navigator as unknown as { standalone?: boolean }).standalone === true;
+    if (!isStandalone) return;
+
     let compact = false;
     const apply = (next: boolean) => {
       if (next === compact) return;
@@ -117,13 +124,9 @@ function BusinessDetailPage() {
         secondaryRef.current.style.opacity = next ? '0' : '1';
       }
     };
-    let rafId = 0;
-    const onScroll = () => {
-      cancelAnimationFrame(rafId);
-      rafId = requestAnimationFrame(() => apply(window.scrollY > 56));
-    };
+    const onScroll = () => apply(window.scrollY > 56);
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => { window.removeEventListener('scroll', onScroll); cancelAnimationFrame(rafId); };
+    return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
   useSEO({

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -221,7 +221,7 @@ function BusinessDetailPage() {
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
 
         {/* Top row */}
-        <div className="flex items-center gap-2 px-3 pt-3 pb-2">
+        <div className="flex items-center gap-3 px-4 py-4">
           <button
             onClick={() => navigate(-1)}
             className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
@@ -230,19 +230,23 @@ function BusinessDetailPage() {
           </button>
 
           <div
-            className="flex-shrink-0 w-12 h-12 rounded-xl bg-gray-50 flex items-center justify-center overflow-hidden"
-            style={{ border: '1px solid #E8E6E1' }}
+            className="flex-shrink-0 w-[64px] h-[64px] rounded-2xl bg-white flex items-center justify-center overflow-hidden"
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.10)', border: '1px solid #E8E6E1' }}
           >
             {business.image ? (
-              <img alt={business.name} className="w-full h-full object-contain p-1" src={business.image} />
+              <img alt={business.name} className="w-full h-full object-contain p-1.5" src={business.image} />
             ) : (
-              <span className="font-black text-xl text-blink-muted">{business.name?.charAt(0)}</span>
+              <span className="font-black text-2xl text-blink-muted">{business.name?.charAt(0)}</span>
             )}
           </div>
 
           <div className="flex-1 min-w-0">
-            <h1 className="font-bold text-[16px] text-blink-ink leading-tight truncate">{business.name}</h1>
-            <p className="text-xs text-blink-muted capitalize">{business.category || 'Comercio'}</p>
+            <h1 className="font-bold text-[17px] text-blink-ink leading-tight truncate">{business.name}</h1>
+            <p className="text-xs text-blink-muted capitalize mt-0.5">{business.category || 'Comercio'}</p>
+            <div className="flex items-center gap-1.5 mt-1.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
+              <span className="text-xs font-medium text-blink-muted">{businessBenefitCount} beneficio{businessBenefitCount !== 1 ? 's' : ''} activo{businessBenefitCount !== 1 ? 's' : ''}</span>
+            </div>
           </div>
 
           <div className="flex items-center gap-0.5 flex-shrink-0">

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -82,6 +82,7 @@ function BusinessDetailPage() {
   const [loading, setLoading] = useState(!passedBusiness);
   const [error, setError] = useState<string | null>(null);
   const businessViewSignatureRef = useRef('');
+  const containerRef = useRef<HTMLDivElement>(null);
   const isScrollingRef = useRef(false);
   const scrollTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const businessCategory = business?.category?.toLowerCase() || 'comercios';
@@ -163,14 +164,16 @@ function BusinessDetailPage() {
   }, [id, passedBusiness]);
 
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
     const onScroll = () => {
       isScrollingRef.current = true;
       clearTimeout(scrollTimerRef.current);
       scrollTimerRef.current = setTimeout(() => { isScrollingRef.current = false; }, 300);
     };
-    window.addEventListener('scroll', onScroll, { passive: true });
+    container.addEventListener('scroll', onScroll, { passive: true });
     return () => {
-      window.removeEventListener('scroll', onScroll);
+      container.removeEventListener('scroll', onScroll);
       clearTimeout(scrollTimerRef.current);
     };
   }, []);
@@ -256,7 +259,11 @@ function BusinessDetailPage() {
   const branchLabel = branchCount > 1 ? `${branchCount} sucursales` : branchCount === 1 ? '1 sucursal' : '';
 
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col">
+    <div
+      ref={containerRef}
+      className="bg-blink-bg text-blink-ink font-body flex flex-col"
+      style={{ height: '100dvh', overflowY: 'auto', overscrollBehavior: 'contain' }}
+    >
 
       {/* ── Sticky header ── */}
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -320,7 +320,7 @@ function BusinessDetailPage() {
       </header>
 
       {/* ── Content ── */}
-      <main className="flex-1 pb-24">
+      <main className="flex-1 pb-10">
 
         {/* Mis beneficios — grouped by bank */}
         {activeTab === 'mis-beneficios' && (

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -55,6 +55,14 @@ const formatDistanceText = (business: Business): string => {
 const bankShortName = (name: string) =>
   name.replace(/banco\s*/i, '').trim().substring(0, 8).toUpperCase() || name.substring(0, 8).toUpperCase();
 
+const TODAY_ABBR = (() => {
+  const names = ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'];
+  return DAY_ABBR[names[new Date().getDay()]] || '';
+})();
+
+const isBenefitAvailableToday = (b: BankBenefit): boolean =>
+  isAllDays(b.cuando) || getActiveDays(b.cuando).has(TODAY_ABBR);
+
 const INITIAL_SHOW = 2;
 
 type ActiveTab = 'mis-beneficios' | 'por-beneficio' | 'sucursal';
@@ -80,6 +88,7 @@ function BusinessDetailPage() {
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('mis-beneficios');
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const [filterToday, setFilterToday] = useState(false);
 
   useSEO({
     title: business
@@ -179,6 +188,21 @@ function BusinessDetailPage() {
     });
   }, [business]);
 
+  const filteredGroupedBenefits = useMemo(() => {
+    if (!filterToday) return groupedBenefits;
+    const result: Record<string, BankBenefit[]> = {};
+    for (const [bank, benefits] of Object.entries(groupedBenefits)) {
+      const filtered = benefits.filter(isBenefitAvailableToday);
+      if (filtered.length > 0) result[bank] = filtered;
+    }
+    return result;
+  }, [groupedBenefits, filterToday]);
+
+  const filteredSortedBenefits = useMemo(
+    () => filterToday ? sortedBenefits.filter(isBenefitAvailableToday) : sortedBenefits,
+    [sortedBenefits, filterToday],
+  );
+
   const handleBenefitSelect = (selectedBenefit: BankBenefit, position: number) => {
     if (!business) return;
     const selectedIndex = business.benefits.indexOf(selectedBenefit);
@@ -262,26 +286,35 @@ function BusinessDetailPage() {
           </div>
         </div>
 
-        {/* Tab row */}
-        <div className="flex items-center overflow-x-auto" style={{ borderTop: '1px solid #E8E6E1' }}>
-          {TABS.map(tab => (
+        {/* Filter pills — same style as SearchPage */}
+        <div className="w-full overflow-x-auto no-scrollbar py-3 px-4" style={{ borderTop: '1px solid #E8E6E1' }}>
+          <div className="flex gap-2 min-w-max items-center">
+            {TABS.map(tab => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                  activeTab === tab.key
+                    ? 'bg-primary text-white'
+                    : 'bg-blink-bg border border-blink-border text-blink-ink'
+                }`}
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: 16 }}>{tab.icon}</span>
+                {tab.label}
+              </button>
+            ))}
             <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className="flex items-center gap-1.5 px-3 py-3 text-[13px] font-medium whitespace-nowrap transition-colors flex-shrink-0"
-              style={{
-                color: activeTab === tab.key ? '#1C1C1E' : '#9CA3AF',
-                borderBottom: activeTab === tab.key ? '2px solid #1C1C1E' : '2px solid transparent',
-              }}
+              onClick={() => setFilterToday(f => !f)}
+              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
+                filterToday
+                  ? 'bg-primary text-white'
+                  : 'bg-blink-bg border border-blink-border text-blink-ink'
+              }`}
             >
-              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>{tab.icon}</span>
-              {tab.label}
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>today</span>
+              Hoy
             </button>
-          ))}
-          <div className="flex-1" />
-          <button className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
-            <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 20 }}>calendar_month</span>
-          </button>
+          </div>
         </div>
       </header>
 
@@ -291,7 +324,7 @@ function BusinessDetailPage() {
         {/* Mis beneficios — grouped by bank */}
         {activeTab === 'mis-beneficios' && (
           <div className="space-y-3 pt-3 px-4">
-            {Object.entries(groupedBenefits).map(([bankName, bankBenefits]) => {
+            {Object.entries(filteredGroupedBenefits).map(([bankName, bankBenefits]) => {
               const accent = getBankAccent(bankName);
               const expanded = expandedGroups[bankName];
               const visible = expanded ? bankBenefits : bankBenefits.slice(0, INITIAL_SHOW);
@@ -438,7 +471,7 @@ function BusinessDetailPage() {
         {/* Por beneficio — flat sorted list */}
         {activeTab === 'por-beneficio' && (
           <div className="space-y-2 pt-3 px-4">
-            {sortedBenefits.map((benefit, idx) => {
+            {filteredSortedBenefits.map((benefit, idx) => {
               const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
               const hasDiscount = !!(discount && parseInt(discount) > 0);
               const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -8,41 +8,62 @@ import { SkeletonBusinessDetailPage } from '../components/skeletons';
 
 const ALL_DAYS = ['lunes', 'martes', 'miércoles', 'miercoles', 'jueves', 'viernes', 'sábado', 'sabado', 'domingo'];
 const DAY_ABBR: Record<string, string> = {
-  lunes: 'Lun', martes: 'Mar', 'miércoles': 'Mié', miercoles: 'Mié',
-  jueves: 'Jue', viernes: 'Vie', 'sábado': 'Sáb', sabado: 'Sáb', domingo: 'Dom',
+  lunes: 'L', martes: 'M', 'miércoles': 'X', miercoles: 'X',
+  jueves: 'J', viernes: 'V', 'sábado': 'S', sabado: 'S', domingo: 'D',
 };
+const DAY_ORDER = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
 
-const formatCuando = (cuando?: string): string => {
-  if (!cuando) return 'Todos los días';
+const isAllDays = (cuando?: string): boolean => {
+  if (!cuando) return true;
   const lower = cuando.toLowerCase();
-  const uniqueDays = new Set(ALL_DAYS.filter((d) => lower.includes(d)).map((d) => DAY_ABBR[d]));
-  if (uniqueDays.size >= 7) return 'Todos los días';
-  let result = cuando;
-  Object.entries(DAY_ABBR).forEach(([full, abbr]) => {
-    result = result.replace(new RegExp(full, 'gi'), abbr);
-  });
-  return result;
+  const found = new Set(ALL_DAYS.filter(d => lower.includes(d)).map(d => DAY_ABBR[d]));
+  return found.size >= 7;
 };
 
+const getActiveDays = (cuando?: string): Set<string> => {
+  if (!cuando) return new Set(DAY_ORDER);
+  const lower = cuando.toLowerCase();
+  return new Set(ALL_DAYS.filter(d => lower.includes(d)).map(d => DAY_ABBR[d]));
+};
 
-// Bank accent colors (soft versions)
 const getBankAccent = (name: string): { bg: string; text: string } => {
   const lower = name.toLowerCase();
   if (lower.includes('galicia')) return { bg: '#EEF2FF', text: '#4338CA' };
   if (lower.includes('santander')) return { bg: '#FEE2E2', text: '#991B1B' };
   if (lower.includes('bbva')) return { bg: '#DBEAFE', text: '#1E40AF' };
-  if (lower.includes('macro')) return { bg: '#EEF2FF', text: '#78350F' };
+  if (lower.includes('macro')) return { bg: '#FEF3C7', text: '#92400E' };
   if (lower.includes('nacion')) return { bg: '#DBEAFE', text: '#1D4ED8' };
   if (lower.includes('hsbc')) return { bg: '#FEE2E2', text: '#B91C1C' };
   if (lower.includes('icbc')) return { bg: '#FEE2E2', text: '#991B1B' };
   if (lower.includes('modo')) return { bg: '#EDE9FE', text: '#5B21B6' };
   if (lower.includes('naranja')) return { bg: '#FED7AA', text: '#9A3412' };
   if (lower.includes('ciudad')) return { bg: '#D1FAE5', text: '#065F46' };
+  if (lower.includes('personal')) return { bg: '#EDE9FE', text: '#5B21B6' };
+  if (lower.includes('patagonia')) return { bg: '#DBEAFE', text: '#1E40AF' };
   return { bg: '#F3F4F6', text: '#374151' };
 };
 
-const bankAbbr = (name: string) => name.replace(/banco\s*/i, '').substring(0, 6).toUpperCase();
+const formatDistanceText = (business: Business): string => {
+  if (business.distance === undefined || business.distance === null) {
+    return business.hasOnline ? 'Online' : '';
+  }
+  const km = business.distance;
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  return `${km.toFixed(1)} km`;
+};
 
+const bankShortName = (name: string) =>
+  name.replace(/banco\s*/i, '').trim().substring(0, 8).toUpperCase() || name.substring(0, 8).toUpperCase();
+
+const INITIAL_SHOW = 2;
+
+type ActiveTab = 'mis-beneficios' | 'por-beneficio' | 'sucursal';
+
+const TABS: { key: ActiveTab; label: string; icon: string }[] = [
+  { key: 'mis-beneficios', label: 'Mis beneficios', icon: 'person' },
+  { key: 'por-beneficio', label: 'Por beneficio', icon: 'visibility' },
+  { key: 'sucursal', label: 'Sucursal', icon: 'storefront' },
+];
 
 function BusinessDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -56,6 +77,9 @@ function BusinessDetailPage() {
   const businessCategory = business?.category?.toLowerCase() || 'comercios';
   const businessBenefitCount = business?.benefits.length || 0;
   const businessPath = id ? `/business/${id}` : '/business';
+
+  const [activeTab, setActiveTab] = useState<ActiveTab>('mis-beneficios');
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
 
   useSEO({
     title: business
@@ -119,17 +143,12 @@ function BusinessDetailPage() {
         setBusiness(null);
         setError('Error al cargar');
       } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        if (!cancelled) setLoading(false);
       }
     };
 
     load();
-
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [id, passedBusiness]);
 
   useEffect(() => {
@@ -138,6 +157,16 @@ function BusinessDetailPage() {
     if (businessViewSignatureRef.current === signature) return;
     businessViewSignatureRef.current = signature;
     trackSelectBusiness({ source: 'business_detail_page', businessId: business.id, category: business.category });
+  }, [business]);
+
+  const groupedBenefits = useMemo(() => {
+    if (!business) return {} as Record<string, BankBenefit[]>;
+    return business.benefits.reduce((acc, benefit) => {
+      const bank = benefit.bankName;
+      if (!acc[bank]) acc[bank] = [];
+      acc[bank].push(benefit);
+      return acc;
+    }, {} as Record<string, BankBenefit[]>);
   }, [business]);
 
   const sortedBenefits = useMemo(() => {
@@ -149,9 +178,6 @@ function BusinessDetailPage() {
       return (b.installments || 0) - (a.installments || 0);
     });
   }, [business]);
-
-  const topBenefits = sortedBenefits.slice(0, 2);
-  const otherBenefits = sortedBenefits.slice(2);
 
   const handleBenefitSelect = (selectedBenefit: BankBenefit, position: number) => {
     if (!business) return;
@@ -167,9 +193,10 @@ function BusinessDetailPage() {
     navigate(`/map?business=${business.id}`);
   };
 
-  if (loading) {
-    return <SkeletonBusinessDetailPage />;
-  }
+  const toggleGroup = (bankName: string) =>
+    setExpandedGroups(prev => ({ ...prev, [bankName]: !prev[bankName] }));
+
+  if (loading) return <SkeletonBusinessDetailPage />;
 
   if (error || !business) {
     return (
@@ -183,261 +210,302 @@ function BusinessDetailPage() {
     );
   }
 
+  const distanceText = formatDistanceText(business);
+  const branchCount = business.location.length;
+  const branchLabel = branchCount > 1 ? `${branchCount} sucursales` : branchCount === 1 ? '1 sucursal' : '';
 
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col relative overflow-x-hidden">
-      <main className="flex-1 pb-32">
-        {/* Unified hero header */}
-        <div
-          className="relative overflow-hidden"
-          style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #C7D2FE 100%)', minHeight: 260 }}
-        >
-          {/* Floating nav buttons */}
-          <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-4 pt-6 z-20">
-            <button
-              onClick={() => navigate(-1)}
-              className="w-10 h-10 rounded-full flex items-center justify-center active:scale-95 transition-transform"
-              style={{ background: 'rgba(255,255,255,0.70)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }}
-            >
-              <span className="material-symbols-outlined text-blink-ink" style={{ fontSize: 20 }}>arrow_back</span>
-            </button>
-            <button
-              className="w-10 h-10 rounded-full flex items-center justify-center active:scale-95 transition-transform"
-              style={{ background: 'rgba(255,255,255,0.70)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)' }}
-            >
-              <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 20 }}>favorite_border</span>
-            </button>
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col">
+
+      {/* ── Sticky header ── */}
+      <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
+
+        {/* Top row */}
+        <div className="flex items-center gap-2 px-3 pt-3 pb-2">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
+          >
+            <span className="material-symbols-outlined text-blink-ink" style={{ fontSize: 22 }}>arrow_back</span>
+          </button>
+
+          <div
+            className="flex-shrink-0 w-12 h-12 rounded-xl bg-gray-50 flex items-center justify-center overflow-hidden"
+            style={{ border: '1px solid #E8E6E1' }}
+          >
+            {business.image ? (
+              <img alt={business.name} className="w-full h-full object-contain p-1" src={business.image} />
+            ) : (
+              <span className="font-black text-xl text-blink-muted">{business.name?.charAt(0)}</span>
+            )}
           </div>
 
-          {/* Logo + name + badges — all inside the hero */}
-          <div className="relative z-10 flex flex-col items-center justify-end pt-24 pb-8 px-6 text-center">
-            <div
-              className="w-[84px] h-[84px] rounded-[22px] bg-white flex items-center justify-center overflow-hidden mb-4"
-              style={{ boxShadow: '0 8px 28px rgba(99,102,241,0.18)', border: '2px solid rgba(255,255,255,0.95)' }}
-            >
-              {business.image ? (
-                <img alt={business.name} className="w-full h-full object-contain p-2" src={business.image} />
-              ) : (
-                <span className="font-black text-3xl text-blink-muted">{business.name?.charAt(0)}</span>
-              )}
-            </div>
+          <div className="flex-1 min-w-0">
+            <h1 className="font-bold text-[16px] text-blink-ink leading-tight truncate">{business.name}</h1>
+            <p className="text-xs text-blink-muted capitalize">{business.category || 'Comercio'}</p>
+          </div>
 
-            <h1 className="font-black text-[22px] text-blink-ink leading-tight mb-3">
-              {business.name}
-            </h1>
-
-            <div className="flex items-center justify-center gap-2 flex-wrap">
-              <span
-                className="text-[11px] font-semibold px-3 py-1.5 rounded-full capitalize"
-                style={{ background: 'rgba(255,255,255,0.72)', color: '#374151' }}
-              >
-                {business.category || 'Comercio'}
-              </span>
-              <span
-                className="flex items-center gap-1.5 text-[11px] font-semibold px-3 py-1.5 rounded-full"
-                style={{ background: 'rgba(255,255,255,0.72)', color: '#065F46' }}
-              >
-                <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
-                Activo
-              </span>
-              {business.rating > 0 && (
-                <span
-                  className="flex items-center gap-1 text-[11px] font-semibold px-3 py-1.5 rounded-full"
-                  style={{ background: 'rgba(255,255,255,0.72)', color: '#4338CA' }}
-                >
-                  <span className="material-symbols-outlined text-amber-500" style={{ fontSize: 12 }}>star</span>
-                  {business.rating.toFixed(1)}
-                </span>
-              )}
-            </div>
+          <div className="flex items-center gap-0.5 flex-shrink-0">
+            <button className="w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors">
+              <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 22 }}>notifications</span>
+            </button>
+            <button className="w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors">
+              <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 22 }}>favorite_border</span>
+            </button>
+            <button className="w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors">
+              <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 22 }}>more_vert</span>
+            </button>
           </div>
         </div>
 
-        <div className="px-4 pt-6 space-y-6">
-          {/* Top Benefits */}
-          {topBenefits.length > 0 && (
-            <section className="space-y-3">
-              <div className="flex items-center gap-2 mb-1">
-                <h2 className="font-semibold text-base text-blink-ink">Mis beneficios</h2>
-                <span className="text-base">✦</span>
-              </div>
+        {/* Tab row */}
+        <div className="flex items-center overflow-x-auto" style={{ borderTop: '1px solid #E8E6E1' }}>
+          {TABS.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className="flex items-center gap-1.5 px-3 py-3 text-[13px] font-medium whitespace-nowrap transition-colors flex-shrink-0"
+              style={{
+                color: activeTab === tab.key ? '#1C1C1E' : '#9CA3AF',
+                borderBottom: activeTab === tab.key ? '2px solid #1C1C1E' : '2px solid transparent',
+              }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>{tab.icon}</span>
+              {tab.label}
+            </button>
+          ))}
+          <div className="flex-1" />
+          <button className="flex-shrink-0 w-10 h-10 flex items-center justify-center">
+            <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 20 }}>calendar_month</span>
+          </button>
+        </div>
+      </header>
 
-              {topBenefits.map((benefit, idx) => {
-                const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
-                const isFirst = idx === 0;
-                const bankAccent = getBankAccent(benefit.bankName);
-                return (
-                  <div
-                    key={`${benefit.bankName}-${idx}`}
-                    onClick={() => handleBenefitSelect(benefit, idx + 1)}
-                    className="w-full bg-white rounded-2xl overflow-hidden cursor-pointer transition-all duration-200 active:scale-[0.98]"
-                    style={{ boxShadow: isFirst ? '0 4px 20px rgba(99,102,241,0.12)' : '0 2px 8px rgba(0,0,0,0.06)', border: isFirst ? '1.5px solid #C7D2FE' : '1px solid #E8E6E1' }}
-                  >
-                    {/* Card top - colored band */}
+      {/* ── Content ── */}
+      <main className="flex-1 pb-10">
+
+        {/* Mis beneficios — grouped by bank */}
+        {activeTab === 'mis-beneficios' && (
+          <div className="space-y-3 pt-3 px-4">
+            {Object.entries(groupedBenefits).map(([bankName, bankBenefits]) => {
+              const accent = getBankAccent(bankName);
+              const expanded = expandedGroups[bankName];
+              const visible = expanded ? bankBenefits : bankBenefits.slice(0, INITIAL_SHOW);
+              const hiddenCount = bankBenefits.length - INITIAL_SHOW;
+
+              return (
+                <div
+                  key={bankName}
+                  className="bg-white rounded-2xl overflow-hidden"
+                  style={{ border: '1px solid #E8E6E1', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}
+                >
+                  {/* Bank section header */}
+                  <div className="flex items-center gap-2.5 px-4 py-3" style={{ background: accent.bg }}>
                     <div
-                      className="px-4 pt-4 pb-5"
-                      style={{ background: isFirst ? 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' : '#FAFAFA' }}
+                      className="w-7 h-7 rounded-md flex items-center justify-center text-[9px] font-black text-white flex-shrink-0"
+                      style={{ background: accent.text }}
                     >
-                      {isFirst && (
-                        <div className="flex items-center justify-between mb-3">
-                          <span
-                            className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                            style={{ background: bankAccent.bg, color: bankAccent.text }}
-                          >
-                            {bankAbbr(benefit.bankName)}
-                          </span>
-                          <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-primary text-white">Mejor opción</span>
-                        </div>
-                      )}
-                      {!isFirst && (
-                        <div className="flex items-center justify-between mb-3">
-                          <span
-                            className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                            style={{ background: bankAccent.bg, color: bankAccent.text }}
-                          >
-                            {bankAbbr(benefit.bankName)}
-                          </span>
-                          {benefit.cardName && (
-                            <span className="text-xs text-blink-muted font-medium">{String(benefit.cardName).replace(/ any$/i, '')}</span>
-                          )}
-                        </div>
-                      )}
-
-                      {discount && parseInt(discount) > 0 ? (
-                        <div>
-                          <div className="flex items-baseline gap-1">
-                            <span
-                              className="font-bold leading-none"
-                              style={{
-                                fontSize: isFirst ? 52 : 40,
-                                background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)',
-                                WebkitBackgroundClip: 'text',
-                                WebkitTextFillColor: 'transparent',
-                                backgroundClip: 'text',
-                              }}
-                            >
-                              {discount}%
-                            </span>
-                            <span className="font-semibold text-blink-muted text-lg">OFF</span>
-                          </div>
-                          {!!benefit.tope && (
-                            <p className="text-xs font-medium mt-1" style={{ color: '#4338CA' }}>
-                              {String(benefit.tope).toUpperCase().includes('SIN TOPE') ? 'Sin tope de reintegro' : `Tope: ${benefit.tope}`}
-                            </p>
-                          )}
-                          {(benefit.installments ?? 0) > 0 && (
-                            <p className="text-sm font-medium text-blink-muted mt-0.5">+ {benefit.installments} cuotas s/int.</p>
-                          )}
-                        </div>
-                      ) : benefit.installments && benefit.installments > 0 ? (
-                        <div>
-                          <div className="flex items-baseline gap-1">
-                            <span
-                              className="font-bold leading-none"
-                              style={{
-                                fontSize: isFirst ? 52 : 40,
-                                background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)',
-                                WebkitBackgroundClip: 'text',
-                                WebkitTextFillColor: 'transparent',
-                                backgroundClip: 'text',
-                              }}
-                            >
-                              {benefit.installments}
-                            </span>
-                            <span className="font-semibold text-blink-muted text-lg">cuotas</span>
-                          </div>
-                          <p className="text-sm font-medium text-primary mt-0.5">Sin interés</p>
-                        </div>
-                      ) : (
-                        <p className="font-semibold text-blink-ink leading-snug">{benefit.benefit}</p>
-                      )}
+                      {bankShortName(bankName).substring(0, 2)}
                     </div>
+                    <span className="font-bold text-[13px] tracking-wide uppercase" style={{ color: accent.text }}>
+                      {bankName}
+                    </span>
+                  </div>
 
-                    {/* Card bottom */}
-                    <div className="px-4 py-3 flex justify-between items-center" style={{ borderTop: '1px solid #E8E6E1' }}>
-                      <div>
-                        <p className="text-[10px] text-blink-muted font-medium uppercase tracking-wide">Disponible</p>
-                        <p className="text-sm font-semibold text-blink-ink">{formatCuando(benefit.cuando)}</p>
-                      </div>
-                      <span
-                        className="text-xs font-semibold px-3 py-1.5 rounded-xl transition-colors"
-                        style={{ background: '#EEF2FF', color: '#4338CA' }}
+                  {/* Benefit rows */}
+                  {visible.map((benefit, i) => {
+                    const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
+                    const hasDiscount = !!(discount && parseInt(discount) > 0);
+                    const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;
+                    const allDays = isAllDays(benefit.cuando);
+                    const activeDays = !allDays ? getActiveDays(benefit.cuando) : new Set<string>();
+                    const benefitIdx = business.benefits.indexOf(benefit);
+
+                    return (
+                      <div
+                        key={`${bankName}-${i}`}
+                        onClick={() => { if (benefitIdx >= 0) handleBenefitSelect(benefit, benefitIdx + 1); }}
+                        className="px-4 py-4 cursor-pointer active:bg-gray-50 transition-colors"
+                        style={{ borderTop: '1px solid #E8E6E1' }}
                       >
-                        Ver detalles →
-                      </span>
+                        <div className="flex items-start gap-2">
+
+                          {/* Left content */}
+                          <div className="flex-1 min-w-0">
+                            <p className="font-bold text-[15px] text-blink-ink leading-tight mb-1">
+                              {benefit.benefit || benefit.cardName}
+                            </p>
+
+                            {(distanceText || branchLabel) && (
+                              <div className="flex items-center gap-1 mb-1">
+                                <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 12 }}>location_on</span>
+                                <span className="text-xs text-blink-muted">
+                                  {[distanceText, branchLabel].filter(Boolean).join(' • ')}
+                                </span>
+                              </div>
+                            )}
+
+                            {benefit.cardName && (
+                              <p className="text-xs text-blink-muted mb-2">{benefit.cardName}</p>
+                            )}
+
+                            <div className="flex items-center gap-1.5 flex-wrap">
+                              <span
+                                className="text-[10px] font-bold px-1.5 py-0.5 rounded-md"
+                                style={{ background: accent.bg, color: accent.text }}
+                              >
+                                {bankShortName(bankName)}
+                              </span>
+
+                              {allDays ? (
+                                <span
+                                  className="text-[10px] font-bold px-1.5 py-0.5 rounded-md uppercase tracking-wide"
+                                  style={{ border: '1px solid #DC2626', color: '#DC2626' }}
+                                >
+                                  Todos los días
+                                </span>
+                              ) : activeDays.size > 0 ? (
+                                <div className="flex gap-0.5">
+                                  {DAY_ORDER.map(d => (
+                                    <span
+                                      key={d}
+                                      className="w-[18px] h-[18px] rounded-full flex items-center justify-center text-[8px] font-bold"
+                                      style={
+                                        activeDays.has(d)
+                                          ? { background: accent.text, color: '#fff' }
+                                          : { background: '#F3F4F6', color: '#9CA3AF' }
+                                      }
+                                    >
+                                      {d}
+                                    </span>
+                                  ))}
+                                </div>
+                              ) : null}
+                            </div>
+                          </div>
+
+                          {/* Right content */}
+                          <div className="flex items-center gap-0.5 flex-shrink-0">
+                            <div className="text-right">
+                              {hasDiscount ? (
+                                <>
+                                  <p className="font-black text-[26px] leading-tight text-blink-ink">{discount}%</p>
+                                  <p className="text-[11px] text-blink-muted -mt-0.5">de ahorro</p>
+                                  {benefit.tope && !String(benefit.tope).toUpperCase().includes('SIN TOPE') && (
+                                    <p className="text-[10px] text-blink-muted mt-0.5 leading-tight">
+                                      Tope: {benefit.tope}
+                                    </p>
+                                  )}
+                                </>
+                              ) : hasInstallments ? (
+                                <>
+                                  <p className="font-black text-[22px] leading-tight text-blink-ink">{benefit.installments}</p>
+                                  <p className="text-[11px] text-primary font-semibold -mt-0.5">cuotas sin int.</p>
+                                </>
+                              ) : (
+                                <p className="text-xs font-medium text-blink-muted max-w-[80px] text-right leading-tight">
+                                  {benefit.rewardRate}
+                                </p>
+                              )}
+                            </div>
+                            <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 18 }}>chevron_right</span>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  {/* Expand button */}
+                  {!expanded && hiddenCount > 0 && (
+                    <button
+                      onClick={() => toggleGroup(bankName)}
+                      className="w-full py-3 text-sm font-semibold flex items-center justify-center gap-1"
+                      style={{ color: '#DC2626', borderTop: '1px solid #E8E6E1' }}
+                    >
+                      Ver otros {hiddenCount} beneficio{hiddenCount !== 1 ? 's' : ''} ↓
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Por beneficio — flat sorted list */}
+        {activeTab === 'por-beneficio' && (
+          <div className="space-y-2 pt-3 px-4">
+            {sortedBenefits.map((benefit, idx) => {
+              const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
+              const hasDiscount = !!(discount && parseInt(discount) > 0);
+              const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;
+              const accent = getBankAccent(benefit.bankName);
+              const benefitIdx = business.benefits.indexOf(benefit);
+
+              return (
+                <div
+                  key={`flat-${idx}`}
+                  onClick={() => { if (benefitIdx >= 0) handleBenefitSelect(benefit, idx + 1); }}
+                  className="bg-white rounded-xl px-4 py-3.5 flex items-center justify-between cursor-pointer active:scale-[0.98] transition-all"
+                  style={{ border: '1px solid #E8E6E1', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span
+                      className="text-[10px] font-bold px-2 py-1 rounded-lg flex-shrink-0"
+                      style={{ background: accent.bg, color: accent.text }}
+                    >
+                      {bankShortName(benefit.bankName)}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="font-semibold text-sm text-blink-ink leading-tight truncate">
+                        {benefit.benefit || benefit.cardName}
+                      </p>
+                      {benefit.tope && !String(benefit.tope).toUpperCase().includes('SIN TOPE') && (
+                        <p className="text-[10px] text-blink-muted mt-0.5">{benefit.tope}</p>
+                      )}
                     </div>
                   </div>
-                );
-              })}
-            </section>
-          )}
-
-          {/* Other Benefits */}
-          {otherBenefits.length > 0 && (
-            <section className="space-y-3">
-              <h2 className="font-semibold text-base text-blink-ink">Más beneficios</h2>
-              <div className="space-y-2">
-                {otherBenefits.map((benefit, idx) => {
-                  const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
-                  const bankAccent = getBankAccent(benefit.bankName);
-                  return (
-                    <div
-                      key={`other-${benefit.bankName}-${idx}`}
-                      onClick={() => handleBenefitSelect(benefit, topBenefits.length + idx + 1)}
-                      className="bg-white rounded-xl px-4 py-3 flex items-center justify-between cursor-pointer transition-all duration-150 active:scale-[0.98]"
-                      style={{ border: '1px solid #E8E6E1', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}
-                    >
-                      <div className="flex items-center gap-3">
-                        <span
-                          className="text-xs font-semibold px-2 py-1 rounded-lg"
-                          style={{ background: bankAccent.bg, color: bankAccent.text }}
-                        >
-                          {bankAbbr(benefit.bankName)}
-                        </span>
-                        <div>
-                          <p className="font-semibold text-sm text-blink-ink leading-none">
-                            {discount && parseInt(discount) > 0
-                              ? `${discount}% OFF`
-                              : benefit.installments && benefit.installments > 0
-                                ? `${benefit.installments} cuotas s/int.`
-                                : benefit.benefit}
-                          </p>
-                          {!!benefit.tope && (
-                            <p className="text-[10px] text-blink-muted mt-0.5">{benefit.tope}</p>
-                          )}
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-xs font-medium text-blink-muted">{formatCuando(benefit.cuando)}</p>
-                        <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 16 }}>chevron_right</span>
-                      </div>
+                  <div className="flex items-center gap-0.5 flex-shrink-0 ml-2">
+                    <div className="text-right">
+                      {hasDiscount ? (
+                        <p className="font-bold text-base text-blink-ink">{discount}%</p>
+                      ) : hasInstallments ? (
+                        <p className="font-bold text-sm text-primary">{benefit.installments} cuotas</p>
+                      ) : (
+                        <p className="text-xs text-blink-muted">{benefit.rewardRate}</p>
+                      )}
                     </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
-        </div>
-      </main>
+                    <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 16 }}>chevron_right</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
 
-      {/* Fixed CTA */}
-      <div
-        className="fixed bottom-0 left-0 w-full z-50 p-4"
-        style={{
-          background: 'rgba(255,255,255,0.95)',
-          backdropFilter: 'blur(12px)',
-          borderTop: '1px solid #E8E6E1',
-        }}
-      >
-        <button
-          onClick={handleOpenMap}
-          className="w-full text-white font-semibold py-4 rounded-2xl text-base transition-all duration-200 active:scale-[0.98] flex items-center justify-center gap-2"
-          style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)', boxShadow: '0 4px 16px rgba(99,102,241,0.30)' }}
-        >
-          <span className="material-symbols-outlined" style={{ fontSize: 20 }}>location_on</span>
-          Ver ubicación
-        </button>
-      </div>
+        {/* Sucursal — map CTA */}
+        {activeTab === 'sucursal' && (
+          <div className="flex flex-col items-center gap-5 pt-14 px-6">
+            <div className="w-20 h-20 rounded-2xl bg-indigo-50 flex items-center justify-center">
+              <span className="material-symbols-outlined text-primary" style={{ fontSize: 40 }}>map</span>
+            </div>
+            <div className="text-center">
+              <h3 className="font-bold text-lg text-blink-ink mb-1">
+                {branchCount} sucursal{branchCount !== 1 ? 'es' : ''}
+              </h3>
+              <p className="text-sm text-blink-muted">Encontrá la sucursal más cercana</p>
+            </div>
+            <button
+              onClick={handleOpenMap}
+              className="w-full text-white font-semibold py-4 rounded-2xl text-base active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)', boxShadow: '0 4px 16px rgba(99,102,241,0.30)' }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 20 }}>location_on</span>
+              Ver en el mapa
+            </button>
+          </div>
+        )}
+
+      </main>
     </div>
   );
 }

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -240,7 +240,7 @@ function BusinessDetailPage() {
   const branchLabel = branchCount > 1 ? `${branchCount} sucursales` : branchCount === 1 ? '1 sucursal' : '';
 
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col">
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col" style={{ overscrollBehavior: 'none' }}>
 
       {/* ── Sticky header ── */}
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
@@ -320,7 +320,7 @@ function BusinessDetailPage() {
       </header>
 
       {/* ── Content ── */}
-      <main className="flex-1 pb-10">
+      <main className="flex-1 pb-24">
 
         {/* Mis beneficios — grouped by bank */}
         {activeTab === 'mis-beneficios' && (
@@ -456,6 +456,7 @@ function BusinessDetailPage() {
                   {/* Expand button */}
                   {!expanded && hiddenCount > 0 && (
                     <button
+                      type="button"
                       onClick={() => toggleGroup(bankName)}
                       className="w-full py-3 text-sm font-semibold flex items-center justify-center gap-1"
                       style={{ color: '#DC2626', borderTop: '1px solid #E8E6E1' }}

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -82,6 +82,8 @@ function BusinessDetailPage() {
   const [loading, setLoading] = useState(!passedBusiness);
   const [error, setError] = useState<string | null>(null);
   const businessViewSignatureRef = useRef('');
+  const isScrollingRef = useRef(false);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const businessCategory = business?.category?.toLowerCase() || 'comercios';
   const businessBenefitCount = business?.benefits.length || 0;
   const businessPath = id ? `/business/${id}` : '/business';
@@ -161,6 +163,19 @@ function BusinessDetailPage() {
   }, [id, passedBusiness]);
 
   useEffect(() => {
+    const onScroll = () => {
+      isScrollingRef.current = true;
+      clearTimeout(scrollTimerRef.current);
+      scrollTimerRef.current = setTimeout(() => { isScrollingRef.current = false; }, 300);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      clearTimeout(scrollTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!business) return;
     const signature = `${business.id}|business_detail`;
     if (businessViewSignatureRef.current === signature) return;
@@ -204,7 +219,7 @@ function BusinessDetailPage() {
   );
 
   const handleBenefitSelect = (selectedBenefit: BankBenefit, position: number) => {
-    if (!business) return;
+    if (!business || isScrollingRef.current) return;
     const selectedIndex = business.benefits.indexOf(selectedBenefit);
     if (selectedIndex < 0) return;
     trackViewBenefit({ source: 'business_detail_benefit_list', benefitId: `${business.id}:${selectedIndex}`, businessId: business.id, category: business.category, position });
@@ -217,8 +232,10 @@ function BusinessDetailPage() {
     navigate(`/map?business=${business.id}`);
   };
 
-  const toggleGroup = (bankName: string) =>
+  const toggleGroup = (bankName: string) => {
+    if (isScrollingRef.current) return;
     setExpandedGroups(prev => ({ ...prev, [bankName]: !prev[bankName] }));
+  };
 
   if (loading) return <SkeletonBusinessDetailPage />;
 
@@ -319,7 +336,7 @@ function BusinessDetailPage() {
       </header>
 
       {/* ── Content ── */}
-      <main className="flex-1 pb-10">
+      <main className="flex-1 pb-24">
 
         {/* Mis beneficios — grouped by bank */}
         {activeTab === 'mis-beneficios' && (

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -89,6 +89,13 @@ function BusinessDetailPage() {
   const [activeTab, setActiveTab] = useState<ActiveTab>('mis-beneficios');
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
+  const [isCompact, setIsCompact] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setIsCompact(window.scrollY > 56);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   useSEO({
     title: business
@@ -245,7 +252,14 @@ function BusinessDetailPage() {
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
 
         {/* Top row */}
-        <div className="flex items-center gap-3 px-4 py-4">
+        <div
+          className="flex items-center gap-3 px-4"
+          style={{
+            paddingTop: isCompact ? 8 : 16,
+            paddingBottom: isCompact ? 8 : 16,
+            transition: 'padding 250ms cubic-bezier(0.4,0,0.2,1)',
+          }}
+        >
           <button
             onClick={() => navigate(-1)}
             className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
@@ -253,23 +267,46 @@ function BusinessDetailPage() {
             <span className="material-symbols-outlined text-blink-ink" style={{ fontSize: 22 }}>arrow_back</span>
           </button>
 
+          {/* Logo — shrinks on scroll */}
           <div
-            className="flex-shrink-0 w-[64px] h-[64px] rounded-2xl bg-white flex items-center justify-center overflow-hidden"
-            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.10)', border: '1px solid #E8E6E1' }}
+            className="flex-shrink-0 bg-white flex items-center justify-center overflow-hidden"
+            style={{
+              width: isCompact ? 36 : 64,
+              height: isCompact ? 36 : 64,
+              borderRadius: isCompact ? 10 : 16,
+              border: '1px solid #E8E6E1',
+              boxShadow: isCompact ? 'none' : '0 2px 12px rgba(0,0,0,0.10)',
+              transition: 'width 250ms cubic-bezier(0.4,0,0.2,1), height 250ms cubic-bezier(0.4,0,0.2,1), border-radius 250ms ease, box-shadow 250ms ease',
+            }}
           >
             {business.image ? (
               <img alt={business.name} className="w-full h-full object-contain p-1.5" src={business.image} />
             ) : (
-              <span className="font-black text-2xl text-blink-muted">{business.name?.charAt(0)}</span>
+              <span className="font-black text-blink-muted" style={{ fontSize: isCompact ? 14 : 24 }}>{business.name?.charAt(0)}</span>
             )}
           </div>
 
+          {/* Name + collapsible secondary info */}
           <div className="flex-1 min-w-0">
-            <h1 className="font-bold text-[17px] text-blink-ink leading-tight truncate">{business.name}</h1>
-            <p className="text-xs text-blink-muted capitalize mt-0.5">{business.category || 'Comercio'}</p>
-            <div className="flex items-center gap-1.5 mt-1.5">
-              <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
-              <span className="text-xs font-medium text-blink-muted">{businessBenefitCount} beneficio{businessBenefitCount !== 1 ? 's' : ''} activo{businessBenefitCount !== 1 ? 's' : ''}</span>
+            <h1
+              className="font-bold text-blink-ink leading-tight truncate"
+              style={{ fontSize: isCompact ? 15 : 17, transition: 'font-size 250ms ease' }}
+            >
+              {business.name}
+            </h1>
+            <div
+              style={{
+                maxHeight: isCompact ? 0 : 52,
+                opacity: isCompact ? 0 : 1,
+                overflow: 'hidden',
+                transition: 'max-height 250ms cubic-bezier(0.4,0,0.2,1), opacity 200ms ease',
+              }}
+            >
+              <p className="text-xs text-blink-muted capitalize mt-0.5">{business.category || 'Comercio'}</p>
+              <div className="flex items-center gap-1.5 mt-1.5">
+                <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
+                <span className="text-xs font-medium text-blink-muted">{businessBenefitCount} beneficio{businessBenefitCount !== 1 ? 's' : ''} activo{businessBenefitCount !== 1 ? 's' : ''}</span>
+              </div>
             </div>
           </div>
 

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -259,14 +259,10 @@ function BusinessDetailPage() {
   const branchLabel = branchCount > 1 ? `${branchCount} sucursales` : branchCount === 1 ? '1 sucursal' : '';
 
   return (
-    <div
-      ref={containerRef}
-      className="bg-blink-bg text-blink-ink font-body flex flex-col"
-      style={{ height: '100dvh', overflowY: 'auto', overscrollBehavior: 'contain' }}
-    >
+    <div className="bg-blink-bg text-blink-ink font-body flex flex-col" style={{ height: '100dvh' }}>
 
-      {/* ── Sticky header ── */}
-      <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
+      {/* ── Header ── */}
+      <header className="bg-white flex-shrink-0" style={{ borderBottom: '1px solid #E8E6E1' }}>
 
         {/* Top row */}
         <div className="flex items-center gap-3 px-4 py-4">
@@ -343,7 +339,11 @@ function BusinessDetailPage() {
       </header>
 
       {/* ── Content ── */}
-      <main className="flex-1 pb-24">
+      <main
+        ref={containerRef}
+        className="flex-1 pb-4"
+        style={{ overflowY: 'auto', overscrollBehavior: 'contain' }}
+      >
 
         {/* Mis beneficios — grouped by bank */}
         {activeTab === 'mis-beneficios' && (

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -75,7 +75,7 @@ function BusinessDetailPage() {
   const location = useLocation();
   const passedBusiness = (location.state as { business?: Business } | null)?.business;
   const [business, setBusiness] = useState<Business | null>(passedBusiness || null);
-  const [loading, setLoading] = useState(!passedBusiness);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const businessViewSignatureRef = useRef('');
   const containerRef = useRef<HTMLDivElement>(null);
@@ -124,13 +124,6 @@ function BusinessDetailPage() {
   });
 
   useEffect(() => {
-    if (passedBusiness) {
-      setBusiness(passedBusiness);
-      setError(null);
-      setLoading(false);
-      return;
-    }
-
     let cancelled = false;
 
     const load = async () => {
@@ -144,7 +137,6 @@ function BusinessDetailPage() {
       try {
         setLoading(true);
         setError(null);
-        setBusiness(null);
 
         const resolvedBusiness = await fetchBusinessById(id);
         if (cancelled) return;
@@ -156,7 +148,6 @@ function BusinessDetailPage() {
         }
       } catch {
         if (cancelled) return;
-        setBusiness(null);
         setError('Error al cargar');
       } finally {
         if (!cancelled) setLoading(false);
@@ -165,7 +156,7 @@ function BusinessDetailPage() {
 
     load();
     return () => { cancelled = true; };
-  }, [id, passedBusiness]);
+  }, [id]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -90,62 +90,6 @@ function BusinessDetailPage() {
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
 
-  // Refs for scroll-driven header collapse — no setState, zero re-renders
-  const isCompactRef = useRef(false);
-  const topRowRef = useRef<HTMLDivElement>(null);
-  const logoRef = useRef<HTMLDivElement>(null);
-  const nameRef = useRef<HTMLHeadingElement>(null);
-  const secondaryRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    // Only enable in standalone PWA — browser chrome causes viewport resize
-    // events at page bottom that make the animation shake.
-    const isStandalone =
-      window.matchMedia('(display-mode: standalone)').matches ||
-      window.matchMedia('(display-mode: fullscreen)').matches ||
-      window.matchMedia('(display-mode: minimal-ui)').matches ||
-      (navigator as unknown as { standalone?: boolean }).standalone === true;
-    if (!isStandalone) return;
-
-    const apply = (next: boolean) => {
-      if (next === isCompactRef.current) return;
-      isCompactRef.current = next;
-      if (topRowRef.current) {
-        topRowRef.current.style.paddingTop = next ? '8px' : '16px';
-        topRowRef.current.style.paddingBottom = next ? '8px' : '16px';
-      }
-      if (logoRef.current) {
-        logoRef.current.style.width = next ? '36px' : '64px';
-        logoRef.current.style.height = next ? '36px' : '64px';
-        logoRef.current.style.borderRadius = next ? '10px' : '16px';
-        logoRef.current.style.boxShadow = next ? 'none' : '0 2px 12px rgba(0,0,0,0.10)';
-      }
-      if (nameRef.current) nameRef.current.style.fontSize = next ? '15px' : '17px';
-      if (secondaryRef.current) {
-        secondaryRef.current.style.maxHeight = next ? '0px' : '52px';
-        secondaryRef.current.style.opacity = next ? '0' : '1';
-      }
-    };
-
-    let expandTimer = 0;
-    const onScroll = () => {
-      const y = window.scrollY;
-      // Collapse immediately when scrolled down enough.
-      if (y > 56) { clearTimeout(expandTimer); apply(true); return; }
-      // Expand only after a 200ms quiet period — filters the spurious near-zero
-      // scroll event WebKit fires when the page shrinks after a collapse, which
-      // would otherwise cause an instant expand → grow → collapse → oscillation.
-      if (isCompactRef.current) {
-        clearTimeout(expandTimer);
-        expandTimer = window.setTimeout(() => {
-          if (window.scrollY <= 56) apply(false);
-        }, 200);
-      }
-    };
-
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => { window.removeEventListener('scroll', onScroll); clearTimeout(expandTimer); };
-  }, []);
 
   useSEO({
     title: business
@@ -302,15 +246,7 @@ function BusinessDetailPage() {
       <header className="bg-white sticky top-0 z-40" style={{ borderBottom: '1px solid #E8E6E1' }}>
 
         {/* Top row */}
-        <div
-          ref={topRowRef}
-          className="flex items-center gap-3 px-4"
-          style={{
-            paddingTop: isCompactRef.current ? 8 : 16,
-            paddingBottom: isCompactRef.current ? 8 : 16,
-            transition: 'padding 250ms cubic-bezier(0.4,0,0.2,1)',
-          }}
-        >
+        <div className="flex items-center gap-3 px-4 py-4">
           <button
             onClick={() => navigate(-1)}
             className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
@@ -318,18 +254,9 @@ function BusinessDetailPage() {
             <span className="material-symbols-outlined text-blink-ink" style={{ fontSize: 22 }}>arrow_back</span>
           </button>
 
-          {/* Logo — shrinks on scroll */}
           <div
-            ref={logoRef}
-            className="flex-shrink-0 bg-white flex items-center justify-center overflow-hidden"
-            style={{
-              width: isCompactRef.current ? 36 : 64,
-              height: isCompactRef.current ? 36 : 64,
-              borderRadius: isCompactRef.current ? 10 : 16,
-              border: '1px solid #E8E6E1',
-              boxShadow: isCompactRef.current ? 'none' : '0 2px 12px rgba(0,0,0,0.10)',
-              transition: 'width 250ms cubic-bezier(0.4,0,0.2,1), height 250ms cubic-bezier(0.4,0,0.2,1), border-radius 250ms ease, box-shadow 250ms ease',
-            }}
+            className="flex-shrink-0 w-[64px] h-[64px] rounded-2xl bg-white flex items-center justify-center overflow-hidden"
+            style={{ border: '1px solid #E8E6E1', boxShadow: '0 2px 12px rgba(0,0,0,0.10)' }}
           >
             {business.image ? (
               <img alt={business.name} className="w-full h-full object-contain p-1.5" src={business.image} />
@@ -338,29 +265,12 @@ function BusinessDetailPage() {
             )}
           </div>
 
-          {/* Name + collapsible secondary info */}
           <div className="flex-1 min-w-0">
-            <h1
-              ref={nameRef}
-              className="font-bold text-blink-ink leading-tight truncate"
-              style={{ fontSize: isCompactRef.current ? 15 : 17, transition: 'font-size 250ms ease' }}
-            >
-              {business.name}
-            </h1>
-            <div
-              ref={secondaryRef}
-              style={{
-                maxHeight: isCompactRef.current ? 0 : 52,
-                opacity: isCompactRef.current ? 0 : 1,
-                overflow: 'hidden',
-                transition: 'max-height 250ms cubic-bezier(0.4,0,0.2,1), opacity 200ms ease',
-              }}
-            >
-              <p className="text-xs text-blink-muted capitalize mt-0.5">{business.category || 'Comercio'}</p>
-              <div className="flex items-center gap-1.5 mt-1.5">
-                <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
-                <span className="text-xs font-medium text-blink-muted">{businessBenefitCount} beneficio{businessBenefitCount !== 1 ? 's' : ''} activo{businessBenefitCount !== 1 ? 's' : ''}</span>
-              </div>
+            <h1 className="font-bold text-[17px] text-blink-ink leading-tight truncate">{business.name}</h1>
+            <p className="text-xs text-blink-muted capitalize mt-0.5">{business.category || 'Comercio'}</p>
+            <div className="flex items-center gap-1.5 mt-1.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 flex-shrink-0" />
+              <span className="text-xs font-medium text-blink-muted">{businessBenefitCount} beneficio{businessBenefitCount !== 1 ? 's' : ''} activo{businessBenefitCount !== 1 ? 's' : ''}</span>
             </div>
           </div>
 

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -67,7 +67,6 @@ const INITIAL_SHOW = 2;
 
 type ViewMode = 'por-beneficio' | 'sucursal' | null;
 
-const BANK_STORAGE_KEY = 'blink.search.selectedBanks';
 
 function BusinessDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -86,16 +85,8 @@ function BusinessDetailPage() {
   const businessPath = id ? `/business/${id}` : '/business';
 
   const [viewMode, setViewMode] = useState<ViewMode>(null);
-  const [filterMyBanks, setFilterMyBanks] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
-
-  const myBanks = useMemo<string[]>(() => {
-    try {
-      const stored = localStorage.getItem(BANK_STORAGE_KEY);
-      return stored ? (JSON.parse(stored) as string[]) : [];
-    } catch { return []; }
-  }, []);
 
   useSEO({
     title: business
@@ -216,23 +207,6 @@ function BusinessDetailPage() {
     [sortedBenefits, filterToday],
   );
 
-  const displayedGroupedBenefits = useMemo(() => {
-    if (!filterMyBanks || myBanks.length === 0) return filteredGroupedBenefits;
-    const result: Record<string, BankBenefit[]> = {};
-    for (const [bank, benefits] of Object.entries(filteredGroupedBenefits)) {
-      if (myBanks.some(b => bank.toLowerCase().includes(b.toLowerCase()) || b.toLowerCase().includes(bank.toLowerCase()))) {
-        result[bank] = benefits;
-      }
-    }
-    return result;
-  }, [filteredGroupedBenefits, filterMyBanks, myBanks]);
-
-  const displayedSortedBenefits = useMemo(() => {
-    if (!filterMyBanks || myBanks.length === 0) return filteredSortedBenefits;
-    return filteredSortedBenefits.filter(b =>
-      myBanks.some(m => b.bankName.toLowerCase().includes(m.toLowerCase()) || m.toLowerCase().includes(b.bankName.toLowerCase()))
-    );
-  }, [filteredSortedBenefits, filterMyBanks, myBanks]);
 
   const handleBenefitSelect = (selectedBenefit: BankBenefit, position: number) => {
     if (!business || isScrollingRef.current) return;
@@ -323,15 +297,15 @@ function BusinessDetailPage() {
         <div className="w-full overflow-x-auto no-scrollbar py-3 px-4" style={{ borderTop: '1px solid #E8E6E1' }}>
           <div className="flex gap-2 min-w-max items-center">
             <button
-              onClick={() => setFilterMyBanks(f => !f)}
+              onClick={() => setFilterToday(f => !f)}
               className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
-                filterMyBanks
+                filterToday
                   ? 'bg-primary text-white'
                   : 'bg-blink-bg border border-blink-border text-blink-ink'
               }`}
             >
-              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>person</span>
-              Mis beneficios
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>today</span>
+              Hoy
             </button>
             <button
               onClick={() => setViewMode(v => v === 'por-beneficio' ? null : 'por-beneficio')}
@@ -355,22 +329,11 @@ function BusinessDetailPage() {
               <span className="material-symbols-outlined" style={{ fontSize: 16 }}>storefront</span>
               Sucursal
             </button>
-            <button
-              onClick={() => setFilterToday(f => !f)}
-              className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
-                filterToday
-                  ? 'bg-primary text-white'
-                  : 'bg-blink-bg border border-blink-border text-blink-ink'
-              }`}
-            >
-              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>today</span>
-              Hoy
-            </button>
           </div>
         </div>
       </header>
 
-      {/* ── Content ── */}
+{/* ── Content ── */}
       <main
         ref={containerRef}
         className="flex-1 pb-4"
@@ -380,7 +343,7 @@ function BusinessDetailPage() {
         {/* Grouped by bank — default view */}
         {viewMode !== 'por-beneficio' && viewMode !== 'sucursal' && (
           <div className="space-y-3 pt-3 px-4">
-            {Object.entries(displayedGroupedBenefits).map(([bankName, bankBenefits]) => {
+            {Object.entries(filteredGroupedBenefits).map(([bankName, bankBenefits]) => {
               const accent = getBankAccent(bankName);
               const expanded = expandedGroups[bankName];
               const visible = expanded ? bankBenefits : bankBenefits.slice(0, INITIAL_SHOW);
@@ -527,7 +490,7 @@ function BusinessDetailPage() {
         {/* Por beneficio — flat sorted list */}
         {viewMode === 'por-beneficio' && (
           <div className="space-y-2 pt-3 px-4">
-            {displayedSortedBenefits.map((benefit, idx) => {
+            {filteredSortedBenefits.map((benefit, idx) => {
               const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
               const hasDiscount = !!(discount && parseInt(discount) > 0);
               const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -9,7 +9,7 @@ import UnifiedFilterSheet, { type UnifiedFilterValues } from '../components/neo/
 import { useBenefitsData } from '../hooks/useBenefitsData';
 import { useEnrichedBusinesses } from '../hooks/useEnrichedBusinesses';
 import { useFallbackSearch } from '../hooks/useFallbackSearch';
-import { fetchBanks, fetchBusinessesPaginated } from '../services/api';
+import { fetchBanks, fetchBusinessesPaginated, fetchBusinessById } from '../services/api';
 import { Business } from '../types';
 import { buildBankOptions, toBankDescriptor } from '../utils/banks';
 import {
@@ -183,6 +183,25 @@ function SearchPage() {
 
   const hasSelectedBanks = selectedBanks.length > 0;
   const hasSearchTerm = debouncedSearch.trim().length > 0;
+
+  // When a bank filter is active the API only returns filtered benefits per merchant.
+  // Batch-fetch full business data so cards can show all their bank badges.
+  const [fullBusinessesMap, setFullBusinessesMap] = useState<Map<string, Business>>(new Map());
+  const enrichedIds = useMemo(() => enrichedBusinesses.map(b => b.id).join(','), [enrichedBusinesses]);
+
+  useEffect(() => {
+    if (!hasSelectedBanks || !enrichedIds) { setFullBusinessesMap(new Map()); return; }
+    let cancelled = false;
+    Promise.all(enrichedIds.split(',').map(id => fetchBusinessById(id))).then(results => {
+      if (cancelled) return;
+      setFullBusinessesMap(prev => {
+        const next = new Map(prev);
+        results.forEach(b => { if (b) next.set(b.id, b); });
+        return next;
+      });
+    });
+    return () => { cancelled = true; };
+  }, [enrichedIds, hasSelectedBanks]);
   const primaryResultsEmpty = !isLoading && strictMatches.length === 0 && hasSearchTerm;
 
   // Stable signature to re-trigger fallback queries when intent changes
@@ -597,11 +616,12 @@ function SearchPage() {
     return max;
   };
 
-  // Get abbreviated bank names
+  // Get abbreviated bank names — use full business data when available (bank filter strips benefits)
   const getBankBadges = (business: Business) => {
+    const source = fullBusinessesMap.get(business.id) ?? business;
     const seen = new Set<string>();
     const badges: string[] = [];
-    business.benefits.forEach((benefit) => {
+    source.benefits.forEach((benefit) => {
       if (benefit.bankName && !seen.has(benefit.bankName)) {
         seen.add(benefit.bankName);
         badges.push(toBankDescriptor(benefit.bankName).code);


### PR DESCRIPTION
- Replace gradient hero header with compact inline header (logo + name/category + action buttons)
- Add horizontal scrollable tab bar: Mis beneficios / Por beneficio / Sucursal / calendar
- Group benefits by bank in collapsible sections with colored bank headers
- Each benefit row shows: title, distance + branch count, payment method, bank badge, day availability tag, large discount % on the right
- "Todos los días" shown as red-outlined chip; specific days shown as filled day circles
- "Ver otros X beneficios" expand button per bank group
- "Por beneficio" tab: flat sorted list view
- "Sucursal" tab: branch count + map CTA (replaces fixed bottom button)

https://claude.ai/code/session_01P8e1StrmMAPdjwP7X7fu1v