### PR TITLE
Update skeletons to match current business and benefit detail page layouts

### DIFF
--- a/src/components/skeletons/SkeletonAvailableBanks.tsx
+++ b/src/components/skeletons/SkeletonAvailableBanks.tsx
@@ -15,11 +15,6 @@ const SkeletonAvailableBanks: React.FC = () => {
       }}
       aria-hidden="true"
     >
-      {/* Heading */}
-      <div className="flex justify-center mb-4">
-        <Skeleton variant="text" width={260} height={15} />
-      </div>
-
       {/* Pill grid */}
       <div className="flex flex-wrap justify-center gap-2">
         {PILL_WIDTHS.map((w, i) => (

--- a/src/components/skeletons/SkeletonAvailableBanks.tsx
+++ b/src/components/skeletons/SkeletonAvailableBanks.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Skeleton from '../ui/Skeleton';
+
+// Pill widths that approximate real bank name lengths
+const PILL_WIDTHS = [96, 72, 110, 84, 64, 120, 88, 76, 104, 68, 92, 80];
+
+const SkeletonAvailableBanks: React.FC = () => {
+  return (
+    <div
+      className="mt-4 rounded-[28px] px-4 py-4"
+      style={{
+        background: 'linear-gradient(180deg, rgba(238,242,255,0.9) 0%, rgba(255,255,255,0.96) 100%)',
+        border: '1px solid rgba(99,102,241,0.18)',
+        boxShadow: '0 10px 28px rgba(99,102,241,0.08)',
+      }}
+      aria-hidden="true"
+    >
+      {/* Heading */}
+      <div className="flex justify-center mb-4">
+        <Skeleton variant="text" width={260} height={15} />
+      </div>
+
+      {/* Pill grid */}
+      <div className="flex flex-wrap justify-center gap-2">
+        {PILL_WIDTHS.map((w, i) => (
+          <Skeleton
+            key={i}
+            variant="rectangular"
+            width={w}
+            height={36}
+            className="rounded-full"
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonAvailableBanks;

--- a/src/components/skeletons/SkeletonBenefitDetailPage.tsx
+++ b/src/components/skeletons/SkeletonBenefitDetailPage.tsx
@@ -1,116 +1,175 @@
 import React from 'react';
 import Skeleton from '../ui/Skeleton';
 
-/**
- * Full-page skeleton for the BenefitDetailPage
- */
 const SkeletonBenefitDetailPage: React.FC = () => {
   return (
-    <div className="bg-blink-bg min-h-screen flex flex-col relative overflow-x-hidden" aria-hidden="true">
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col relative overflow-x-hidden" aria-hidden="true">
       <main className="flex-1 overflow-y-auto pb-32">
-        {/* Hero — dark indigo gradient */}
+
+        {/* Hero — bank accent bg (light indigo placeholder) */}
         <div
-          className="relative overflow-hidden"
-          style={{ background: 'linear-gradient(135deg, #3730A3 0%, #4F46E5 100%)', minHeight: 240 }}
+          className="relative"
+          style={{
+            background: '#EEF2FF',
+            minHeight: 220,
+            position: 'sticky',
+            top: 0,
+            zIndex: 50,
+            boxShadow: '0 2px 12px rgba(0,0,0,0.07)',
+          }}
         >
           {/* Floating nav buttons */}
           <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-4 pt-6 z-20">
             <div
               className="w-10 h-10 rounded-full flex items-center justify-center"
-              style={{ background: 'rgba(255,255,255,0.15)', border: '1px solid rgba(255,255,255,0.25)' }}
+              style={{ background: 'rgba(0,0,0,0.07)', border: '1px solid rgba(99,102,241,0.2)' }}
             >
-              <Skeleton variant="circular" width={20} height={20} style={{ opacity: 0.5 }} />
+              <Skeleton variant="circular" width={20} height={20} />
             </div>
             <div
               className="w-10 h-10 rounded-full flex items-center justify-center"
-              style={{ background: 'rgba(255,255,255,0.15)', border: '1px solid rgba(255,255,255,0.25)' }}
+              style={{ background: 'rgba(0,0,0,0.07)', border: '1px solid rgba(99,102,241,0.2)' }}
             >
-              <Skeleton variant="circular" width={20} height={20} style={{ opacity: 0.5 }} />
+              <Skeleton variant="circular" width={20} height={20} />
             </div>
           </div>
 
-          {/* Logo + business name + bank badge */}
-          <div className="relative z-10 flex flex-col items-center pt-20 pb-8 px-6 text-center gap-3">
-            <Skeleton
-              variant="rectangular"
-              width={72}
-              height={72}
-              className="rounded-[20px]"
-              style={{ opacity: 0.5 }}
-            />
-            <Skeleton variant="text" width={130} height={22} style={{ opacity: 0.5 }} />
-            <Skeleton variant="rectangular" width={120} height={28} className="rounded-full" style={{ opacity: 0.5 }} />
+          {/* Logo + bank badge + business name + tags */}
+          <div className="relative z-10 flex flex-col items-center pt-20 pb-7 px-6 text-center">
+            <div className="relative mb-3">
+              <Skeleton variant="rectangular" width={72} height={72} className="rounded-[20px]" />
+              {/* Bank badge */}
+              <div
+                className="absolute -bottom-2 -right-2 w-[26px] h-[26px] rounded-full"
+                style={{ background: '#C7D2FE', border: '2.5px solid white' }}
+              />
+            </div>
+
+            <Skeleton variant="text" width={130} height={22} className="mb-3" />
+
+            <div className="flex items-center gap-2 flex-wrap justify-center">
+              <Skeleton variant="rectangular" width={120} height={28} className="rounded-full" />
+              <Skeleton variant="rectangular" width={80} height={28} className="rounded-full" />
+            </div>
           </div>
         </div>
 
         <div className="p-4 space-y-3">
-          {/* Main Benefit Card */}
+
+          {/* Discount hero card */}
           <div
             className="bg-white rounded-2xl overflow-hidden"
             style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.06)', border: '1px solid #E8E6E1' }}
           >
-            {/* Discount hero */}
-            <div className="flex flex-col items-center text-center px-6 pt-8 pb-7">
-              <Skeleton variant="text" width={70} height={12} className="mb-4" />
-              {/* Big number */}
-              <Skeleton variant="text" width={120} height={96} className="mb-2" />
-              <Skeleton variant="text" width={80} height={14} className="mb-5" />
-              {/* Bank badges */}
-              <div className="flex items-center gap-2">
-                <Skeleton variant="rectangular" width={90} height={30} className="rounded-full" />
-                <Skeleton variant="rectangular" width={70} height={30} className="rounded-full" />
-              </div>
-            </div>
-
-            {/* Days of week */}
-            <div className="px-5 py-4" style={{ borderBottom: '1px solid #E8E6E1' }}>
-              <Skeleton variant="text" width={80} height={10} className="mb-2.5" />
-              <div className="flex gap-1.5">
-                {Array.from({ length: 7 }).map((_, i) => (
-                  <Skeleton key={i} variant="rectangular" width="100%" height={32} className="rounded-xl flex-1" />
-                ))}
-              </div>
-            </div>
-
-            {/* Description */}
-            <div className="px-5 py-4" style={{ borderBottom: '1px solid #E8E6E1' }}>
-              <Skeleton variant="text" width="90%" height={14} className="mb-1.5" />
-              <Skeleton variant="text" width="70%" height={14} />
-            </div>
-
-            {/* Footer */}
-            <div className="px-5 py-4 flex items-center justify-between">
-              <Skeleton variant="text" width={120} height={10} />
-              <Skeleton variant="text" width={80} height={10} />
+            <div className="flex flex-col items-center text-center px-6 pt-7 pb-7">
+              <Skeleton variant="text" width={160} height={13} className="mb-5" />
+              {/* Big discount number */}
+              <Skeleton variant="rectangular" width={140} height={96} className="rounded-xl mb-3" />
+              <Skeleton variant="text" width={80} height={14} />
             </div>
           </div>
 
-          {/* Expandable sections */}
-          {['Términos y condiciones', 'Sucursales adheridas', 'Tarjetas adheridas'].map((_, i) => (
-            <div
-              key={i}
-              className="bg-white rounded-2xl overflow-hidden"
-              style={{ border: '1px solid #E8E6E1' }}
-            >
-              <div className="w-full px-4 py-3.5 flex justify-between items-center">
-                <div className="flex items-center gap-2.5">
-                  <Skeleton variant="rectangular" width={32} height={32} className="rounded-xl" />
-                  <Skeleton variant="text" width={160} height={14} />
+          {/* Condiciones card */}
+          <div
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.06)', border: '1px solid #E8E6E1' }}
+          >
+            <div className="px-5 pt-5 pb-4">
+              <Skeleton variant="text" width={100} height={15} className="mb-4" />
+
+              <div className="divide-y divide-blink-border">
+                {/* Condition rows */}
+                {[100, 130, 90, 110].map((w, i) => (
+                  <div key={i} className="flex items-center justify-between py-3">
+                    <Skeleton variant="text" width={w} height={13} />
+                    <Skeleton variant="text" width={80} height={13} />
+                  </div>
+                ))}
+
+                {/* Days of week */}
+                <div className="flex items-center justify-between py-3 gap-3">
+                  <Skeleton variant="text" width={100} height={13} className="flex-shrink-0" />
+                  <div className="flex gap-1">
+                    {Array.from({ length: 7 }).map((_, i) => (
+                      <Skeleton key={i} variant="rectangular" width={28} height={28} className="rounded-lg" />
+                    ))}
+                  </div>
                 </div>
-                <Skeleton variant="circular" width={20} height={20} />
               </div>
+
+              <Skeleton variant="text" width="80%" height={11} className="mt-5" />
             </div>
-          ))}
+          </div>
+
+          {/* Savings simulator placeholder */}
+          <div
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.06)', border: '1px solid #E8E6E1' }}
+          >
+            <div className="px-5 py-5 space-y-3">
+              <Skeleton variant="text" width={140} height={15} />
+              <Skeleton variant="rectangular" width="100%" height={48} className="rounded-xl" />
+              <Skeleton variant="rectangular" width="100%" height={36} className="rounded-xl" />
+            </div>
+          </div>
+
+          {/* Locations card */}
+          <div
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.06)', border: '1px solid #E8E6E1' }}
+          >
+            <div className="px-5 pt-5 pb-3">
+              <Skeleton variant="text" width={110} height={15} className="mb-3" />
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex items-start gap-3 py-3" style={{ borderTop: i > 0 ? '1px solid #E8E6E1' : undefined }}>
+                  <Skeleton variant="circular" width={18} height={18} className="flex-shrink-0 mt-0.5" />
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton variant="text" width="70%" height={13} />
+                    <Skeleton variant="text" width="50%" height={11} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Accede al beneficio card */}
+          <div
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.06)', border: '1px solid #E8E6E1' }}
+          >
+            <div className="px-5 pt-5 pb-5 space-y-3">
+              <Skeleton variant="text" width={150} height={15} />
+              <Skeleton variant="text" width={130} height={11} />
+              {[0, 1].map((i) => (
+                <Skeleton key={i} variant="rectangular" width="100%" height={48} className="rounded-xl" />
+              ))}
+            </div>
+          </div>
+
+          {/* Terms card */}
+          <div
+            className="bg-white rounded-2xl overflow-hidden"
+            style={{ border: '1px solid #E8E6E1' }}
+          >
+            <div className="w-full px-5 py-4 flex items-center justify-between">
+              <div className="flex items-center gap-2.5">
+                <Skeleton variant="rectangular" width={32} height={32} className="rounded-xl flex-shrink-0" />
+                <Skeleton variant="text" width={170} height={15} />
+              </div>
+              <Skeleton variant="circular" width={20} height={20} />
+            </div>
+          </div>
+
         </div>
       </main>
 
-      {/* Fixed Bottom CTA */}
+      {/* Fixed bottom CTA */}
       <div
         className="fixed bottom-0 left-0 right-0 p-4 flex gap-3 z-20"
-        style={{ background: 'rgba(255,255,255,0.95)', borderTop: '1px solid #E8E6E1' }}
+        style={{ background: 'rgba(255,255,255,0.95)', backdropFilter: 'blur(12px)', borderTop: '1px solid #E8E6E1' }}
       >
         <Skeleton variant="rectangular" width="100%" height={56} className="rounded-2xl flex-1" />
-        <Skeleton variant="rectangular" width={56} height={56} className="rounded-2xl" />
+        <Skeleton variant="rectangular" width={56} height={56} className="rounded-2xl flex-shrink-0" />
       </div>
     </div>
   );

--- a/src/components/skeletons/SkeletonBusinessDetailPage.tsx
+++ b/src/components/skeletons/SkeletonBusinessDetailPage.tsx
@@ -1,128 +1,101 @@
 import React from 'react';
 import Skeleton from '../ui/Skeleton';
 
-/**
- * Full-page skeleton for the BusinessDetailPage
- */
 const SkeletonBusinessDetailPage: React.FC = () => {
   return (
-    <div className="bg-blink-bg min-h-screen flex flex-col relative overflow-x-hidden" aria-hidden="true">
-      <main className="flex-1 pb-32">
-        {/* Hero — light indigo gradient */}
-        <div
-          className="relative overflow-hidden"
-          style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #C7D2FE 100%)', minHeight: 260 }}
-        >
-          {/* Floating nav buttons */}
-          <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-4 pt-6 z-20">
-            <div
-              className="w-10 h-10 rounded-full flex items-center justify-center"
-              style={{ background: 'rgba(255,255,255,0.70)' }}
-            >
-              <Skeleton variant="circular" width={20} height={20} />
-            </div>
-            <div
-              className="w-10 h-10 rounded-full flex items-center justify-center"
-              style={{ background: 'rgba(255,255,255,0.70)' }}
-            >
-              <Skeleton variant="circular" width={20} height={20} />
-            </div>
+    <div className="bg-blink-bg text-blink-ink font-body flex flex-col" style={{ height: '100dvh' }} aria-hidden="true">
+
+      {/* Header */}
+      <header className="bg-white flex-shrink-0" style={{ borderBottom: '1px solid #E8E6E1' }}>
+
+        {/* Top row */}
+        <div className="flex items-center gap-3 px-4 py-4">
+          {/* Back button */}
+          <div className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full">
+            <Skeleton variant="circular" width={22} height={22} />
           </div>
 
-          {/* Logo + name + badges */}
-          <div className="relative z-10 flex flex-col items-center pt-24 pb-8 px-6 text-center gap-3">
-            <Skeleton variant="rectangular" width={84} height={84} className="rounded-[22px]" />
-            <Skeleton variant="text" width={140} height={26} />
-            <div className="flex items-center gap-2">
-              <Skeleton variant="rectangular" width={80} height={28} className="rounded-full" />
-              <Skeleton variant="rectangular" width={65} height={28} className="rounded-full" />
-            </div>
+          {/* Business logo */}
+          <Skeleton
+            variant="rectangular"
+            width={64}
+            height={64}
+            className="rounded-2xl flex-shrink-0"
+          />
+
+          {/* Name / category / benefit count */}
+          <div className="flex-1 min-w-0 space-y-2">
+            <Skeleton variant="text" width={140} height={17} />
+            <Skeleton variant="text" width={80} height={12} />
+            <Skeleton variant="text" width={110} height={12} />
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-0.5 flex-shrink-0">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="w-9 h-9 flex items-center justify-center">
+                <Skeleton variant="circular" width={22} height={22} />
+              </div>
+            ))}
           </div>
         </div>
 
-        <div className="px-4 pt-6 space-y-6">
-          {/* "Mis beneficios" heading */}
-          <div className="flex items-center gap-2 mb-1">
-            <Skeleton variant="text" width={120} height={18} />
-          </div>
+        {/* Filter pills */}
+        <div className="px-4 py-3 flex gap-2" style={{ borderTop: '1px solid #E8E6E1' }}>
+          <Skeleton variant="rectangular" width={72} height={36} className="rounded-xl flex-shrink-0" />
+          <Skeleton variant="rectangular" width={110} height={36} className="rounded-xl flex-shrink-0" />
+          <Skeleton variant="rectangular" width={90} height={36} className="rounded-xl flex-shrink-0" />
+        </div>
+      </header>
 
-          {/* Top benefit card — large, highlighted */}
-          <div
-            className="bg-white rounded-2xl overflow-hidden"
-            style={{ border: '1.5px solid #C7D2FE', boxShadow: '0 4px 20px rgba(99,102,241,0.12)' }}
-          >
-            <div className="px-4 pt-4 pb-5" style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #E0E7FF 100%)' }}>
-              <div className="flex items-center justify-between mb-3">
-                <Skeleton variant="rectangular" width={54} height={26} className="rounded-full" />
-                <Skeleton variant="rectangular" width={80} height={26} className="rounded-full" />
-              </div>
-              <Skeleton variant="text" width={100} height={52} className="mb-1" />
-              <Skeleton variant="text" width={80} height={14} />
-            </div>
-            <div className="px-4 py-3 flex justify-between items-center" style={{ borderTop: '1px solid #E8E6E1' }}>
-              <div className="space-y-1">
-                <Skeleton variant="text" width={60} height={10} />
-                <Skeleton variant="text" width={100} height={16} />
-              </div>
-              <Skeleton variant="rectangular" width={90} height={32} className="rounded-xl" />
-            </div>
-          </div>
+      {/* Content */}
+      <main className="flex-1 overflow-y-auto pb-4">
+        <div className="space-y-3 pt-3 px-4">
 
-          {/* Second benefit card */}
-          <div
-            className="bg-white rounded-2xl overflow-hidden"
-            style={{ border: '1px solid #E8E6E1', boxShadow: '0 2px 8px rgba(0,0,0,0.06)' }}
-          >
-            <div className="px-4 pt-4 pb-5" style={{ background: '#FAFAFA' }}>
-              <div className="flex items-center justify-between mb-3">
-                <Skeleton variant="rectangular" width={54} height={26} className="rounded-full" />
-                <Skeleton variant="text" width={60} height={14} />
-              </div>
-              <Skeleton variant="text" width={80} height={40} className="mb-1" />
-              <Skeleton variant="text" width={70} height={14} />
-            </div>
-            <div className="px-4 py-3 flex justify-between items-center" style={{ borderTop: '1px solid #E8E6E1' }}>
-              <div className="space-y-1">
-                <Skeleton variant="text" width={60} height={10} />
-                <Skeleton variant="text" width={100} height={16} />
-              </div>
-              <Skeleton variant="rectangular" width={90} height={32} className="rounded-xl" />
-            </div>
-          </div>
-
-          {/* "Más beneficios" heading */}
-          <Skeleton variant="text" width={110} height={18} />
-
-          {/* Other benefit rows */}
-          {Array.from({ length: 3 }).map((_, i) => (
+          {/* Bank group cards */}
+          {[2, 3, 2].map((rowCount, gi) => (
             <div
-              key={i}
-              className="bg-white rounded-xl px-4 py-3 flex items-center justify-between"
-              style={{ border: '1px solid #E8E6E1' }}
+              key={gi}
+              className="bg-white rounded-2xl overflow-hidden"
+              style={{ border: '1px solid #E8E6E1', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}
             >
-              <div className="flex items-center gap-3">
-                <Skeleton variant="rectangular" width={44} height={26} className="rounded-lg" />
-                <div className="space-y-1">
-                  <Skeleton variant="text" width={90} height={14} />
-                  <Skeleton variant="text" width={60} height={10} />
+              {/* Bank header */}
+              <div className="flex items-center gap-2.5 px-4 py-3" style={{ background: '#F3F4F6' }}>
+                <Skeleton variant="rectangular" width={28} height={28} className="rounded-md flex-shrink-0" />
+                <Skeleton variant="text" width={90} height={13} />
+              </div>
+
+              {/* Benefit rows */}
+              {Array.from({ length: rowCount }).map((_, ri) => (
+                <div
+                  key={ri}
+                  className="px-4 py-4"
+                  style={{ borderTop: '1px solid #E8E6E1' }}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <Skeleton variant="text" width="75%" height={15} />
+                      <Skeleton variant="text" width="50%" height={11} />
+                      <div className="flex gap-1.5">
+                        <Skeleton variant="rectangular" width={44} height={18} className="rounded-md" />
+                        <Skeleton variant="rectangular" width={100} height={18} className="rounded-md" />
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-0.5 flex-shrink-0">
+                      <div className="text-right space-y-1">
+                        <Skeleton variant="text" width={48} height={26} />
+                        <Skeleton variant="text" width={40} height={11} />
+                      </div>
+                      <Skeleton variant="circular" width={18} height={18} />
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="flex flex-col items-end gap-1">
-                <Skeleton variant="text" width={50} height={12} />
-                <Skeleton variant="circular" width={16} height={16} />
-              </div>
+              ))}
             </div>
           ))}
+
         </div>
       </main>
-
-      {/* Fixed CTA bar */}
-      <div
-        className="fixed bottom-0 left-0 w-full z-50 p-4"
-        style={{ background: 'rgba(255,255,255,0.95)', borderTop: '1px solid #E8E6E1' }}
-      >
-        <Skeleton variant="rectangular" width="100%" height={56} className="rounded-2xl" />
-      </div>
     </div>
   );
 };

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -7,3 +7,4 @@ export { default as SkeletonHomePage } from './SkeletonHomePage';
 export { default as SkeletonSearchPage } from './SkeletonSearchPage';
 export { default as SkeletonBusinessDetailPage } from './SkeletonBusinessDetailPage';
 export { default as SkeletonBenefitDetailPage } from './SkeletonBenefitDetailPage';
+export { default as SkeletonAvailableBanks } from './SkeletonAvailableBanks';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -176,20 +176,20 @@ function HomePage() {
           </button>
 
           {/* Indexed Entities */}
-          {isBanksLoading ? (
-            <SkeletonAvailableBanks />
-          ) : (
-            <div
-              className="mt-4 rounded-[28px] px-4 py-4"
-              style={{
-                background: 'linear-gradient(180deg, rgba(238,242,255,0.9) 0%, rgba(255,255,255,0.96) 100%)',
-                border: '1px solid rgba(99,102,241,0.18)',
-                boxShadow: '0 10px 28px rgba(99,102,241,0.08)',
-              }}
-            >
-              <p className="text-center text-[15px] font-semibold leading-snug text-blink-ink mb-4">
-                Estamos en Beta! Estos son los emisores disponibles hoy en Blink.
-              </p>
+          <div
+            className="mt-4 rounded-[28px] px-4 py-4"
+            style={{
+              background: 'linear-gradient(180deg, rgba(238,242,255,0.9) 0%, rgba(255,255,255,0.96) 100%)',
+              border: '1px solid rgba(99,102,241,0.18)',
+              boxShadow: '0 10px 28px rgba(99,102,241,0.08)',
+            }}
+          >
+            <p className="text-center text-[15px] font-semibold leading-snug text-blink-ink mb-4">
+              Estamos en Beta! Estos son los emisores disponibles hoy en Blink.
+            </p>
+            {isBanksLoading ? (
+              <SkeletonAvailableBanks />
+            ) : (
               <div className="flex flex-wrap justify-center gap-2">
                 {indexedEntities.map((entity) => (
                   <button
@@ -202,8 +202,8 @@ function HomePage() {
                   </button>
                 ))}
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </section>
 
         {/* Top 5 Hoy - Bento Cards */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,6 +6,7 @@ import Ticker from '../components/neo/Ticker';
 import CategoryMarquee from '../components/neo/CategoryMarquee';
 import ComingSoonSection from '../components/ComingSoonSection';
 import { useBenefitsData } from '../hooks/useBenefitsData';
+import { SkeletonAvailableBanks } from '../components/skeletons';
 import { fetchBanks, fetchMongoStats } from '../services/api';
 import { Business } from '../types';
 import { formatDistance } from '../utils/distance';
@@ -19,7 +20,7 @@ function HomePage() {
     queryKey: ['home-ticker-active-benefits-count'],
     queryFn: fetchMongoStats,
   });
-  const { data: availableBankNames = [] } = useQuery({
+  const { data: availableBankNames = [], isLoading: isBanksLoading } = useQuery({
     queryKey: ['availableBanks'],
     queryFn: fetchBanks,
     staleTime: 1000 * 60 * 30,
@@ -175,30 +176,34 @@ function HomePage() {
           </button>
 
           {/* Indexed Entities */}
-          <div
-            className="mt-4 rounded-[28px] px-4 py-4"
-            style={{
-              background: 'linear-gradient(180deg, rgba(238,242,255,0.9) 0%, rgba(255,255,255,0.96) 100%)',
-              border: '1px solid rgba(99,102,241,0.18)',
-              boxShadow: '0 10px 28px rgba(99,102,241,0.08)',
-            }}
-          >
-            <p className="text-center text-[15px] font-semibold leading-snug text-blink-ink mb-4">
-              Estamos en Beta! Estos son los emisores disponibles hoy en Blink.
-            </p>
-            <div className="flex flex-wrap justify-center gap-2">
-              {indexedEntities.map((entity) => (
-                <button
-                  key={entity.token}
-                  onClick={() => handleEntityClick(entity)}
-                  className="px-4 py-2 rounded-full text-sm font-medium text-blink-ink transition-all duration-150 active:scale-95"
-                  style={{ background: '#FFFFFF', border: '1.5px solid #E8E6E1' }}
-                >
-                  {entity.label}
-                </button>
-              ))}
+          {isBanksLoading ? (
+            <SkeletonAvailableBanks />
+          ) : (
+            <div
+              className="mt-4 rounded-[28px] px-4 py-4"
+              style={{
+                background: 'linear-gradient(180deg, rgba(238,242,255,0.9) 0%, rgba(255,255,255,0.96) 100%)',
+                border: '1px solid rgba(99,102,241,0.18)',
+                boxShadow: '0 10px 28px rgba(99,102,241,0.08)',
+              }}
+            >
+              <p className="text-center text-[15px] font-semibold leading-snug text-blink-ink mb-4">
+                Estamos en Beta! Estos son los emisores disponibles hoy en Blink.
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {indexedEntities.map((entity) => (
+                  <button
+                    key={entity.token}
+                    onClick={() => handleEntityClick(entity)}
+                    className="px-4 py-2 rounded-full text-sm font-medium text-blink-ink transition-all duration-150 active:scale-95"
+                    style={{ background: '#FFFFFF', border: '1.5px solid #E8E6E1' }}
+                  >
+                    {entity.label}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
         </section>
 
         {/* Top 5 Hoy - Bento Cards */}


### PR DESCRIPTION
SkeletonBusinessDetailPage now mirrors the header-with-filter-pills layout
(back button, logo, name/category/badge row, 3 action icons, pill filters)
and grouped-by-bank benefit rows instead of the old hero gradient design.

SkeletonBenefitDetailPage now matches the sticky accent-color hero, large
discount number card, condiciones rows with day pills, savings simulator
placeholder, locations list, card access section, and collapsible terms row.

https://claude.ai/code/session_01HH5btVAuXS2iWqo61Vn1oo