### PR TITLE
Add desktop unsupported page shown to non-mobile visitors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'r
 import { lazy, Suspense, useEffect } from 'react';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
 import RouteSEO from './components/seo/RouteSEO';
+import { useResponsive } from './hooks/useResponsive';
+import DesktopUnsupportedPage from './pages/DesktopUnsupportedPage';
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -28,9 +30,15 @@ const PageLoader = () => (
   </div>
 );
 
-function App() {
+function AppContent() {
+  const { isDesktop } = useResponsive();
+
+  if (isDesktop) {
+    return <DesktopUnsupportedPage />;
+  }
+
   return (
-    <Router>
+    <>
       <ScrollToTop />
       <AnalyticsTracker />
       <RouteSEO />
@@ -48,6 +56,14 @@ function App() {
           <Route path="/descuentos/:bank/:category/:city" element={<LandingPage />} />
         </Routes>
       </Suspense>
+    </>
+  );
+}
+
+function App() {
+  return (
+    <Router>
+      <AppContent />
     </Router>
   );
 }

--- a/src/pages/DesktopUnsupportedPage.tsx
+++ b/src/pages/DesktopUnsupportedPage.tsx
@@ -26,7 +26,7 @@ function DesktopUnsupportedPage() {
           </span>
         </h1>
         <p className="text-blink-muted text-sm leading-relaxed">
-          Blink está hecho para que encuentres tus descuentos en el momento justo, desde tu celu.
+          Por ahora Blink solo está disponible para celulares. Abrilo desde el tuyo y encontrá todos tus descuentos.
         </p>
       </div>
     </div>

--- a/src/pages/DesktopUnsupportedPage.tsx
+++ b/src/pages/DesktopUnsupportedPage.tsx
@@ -1,24 +1,16 @@
 function DesktopUnsupportedPage() {
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col items-center justify-center px-8 gap-8">
-      <div className="w-28 h-28 rounded-full border-2 border-blink-ink bg-blink-accent shadow-hard flex items-center justify-center">
-        <span className="material-symbols-outlined text-white" style={{ fontSize: 56 }}>
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col items-center justify-center px-8 gap-6">
+      <div className="w-24 h-24 border-2 border-blink-ink bg-blink-surface shadow-hard flex items-center justify-center">
+        <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 48 }}>
           smartphone
         </span>
       </div>
 
-      <div className="text-center max-w-sm">
-        <h1 className="font-display text-3xl uppercase tracking-tighter mb-3">
-          Solo Mobile
-        </h1>
+      <div className="text-center max-w-xs">
+        <h1 className="font-display text-2xl uppercase mb-2">Solo Mobile</h1>
         <p className="font-mono text-sm text-blink-muted leading-relaxed">
-          Lo sentimos, esta página solo está disponible en dispositivos móviles por ahora.
-        </p>
-      </div>
-
-      <div className="w-full max-w-xs bg-blink-warning p-4 border-2 border-blink-ink shadow-hard text-center">
-        <p className="font-mono text-xs font-bold uppercase">
-          Por favor abrí Blink desde tu celular
+          Lo sentimos, Blink solo está disponible en dispositivos móviles por ahora.
         </p>
       </div>
     </div>

--- a/src/pages/DesktopUnsupportedPage.tsx
+++ b/src/pages/DesktopUnsupportedPage.tsx
@@ -1,16 +1,32 @@
 function DesktopUnsupportedPage() {
   return (
-    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col items-center justify-center px-8 gap-6">
-      <div className="w-24 h-24 border-2 border-blink-ink bg-blink-surface shadow-hard flex items-center justify-center">
-        <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 48 }}>
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col items-center justify-center px-6 gap-8">
+      <div className="font-bold text-2xl tracking-tight text-blink-ink">Blink</div>
+
+      <div
+        className="w-24 h-24 rounded-3xl flex items-center justify-center"
+        style={{
+          background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)',
+          boxShadow: '0 8px 28px rgba(99,102,241,0.35)',
+        }}
+      >
+        <span className="material-symbols-outlined text-white" style={{ fontSize: 48 }}>
           smartphone
         </span>
       </div>
 
       <div className="text-center max-w-xs">
-        <h1 className="font-display text-2xl uppercase mb-2">Solo Mobile</h1>
-        <p className="font-mono text-sm text-blink-muted leading-relaxed">
-          Lo sentimos, Blink solo está disponible en dispositivos móviles por ahora.
+        <h1 className="text-[2rem] font-bold leading-tight text-blink-ink mb-3">
+          Mucho mejor<br />
+          <span
+            className="text-transparent bg-clip-text"
+            style={{ backgroundImage: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)' }}
+          >
+            desde el celular 📱
+          </span>
+        </h1>
+        <p className="text-blink-muted text-sm leading-relaxed">
+          Blink está hecho para que encuentres tus descuentos en el momento justo, desde tu celu.
         </p>
       </div>
     </div>

--- a/src/pages/DesktopUnsupportedPage.tsx
+++ b/src/pages/DesktopUnsupportedPage.tsx
@@ -1,0 +1,28 @@
+function DesktopUnsupportedPage() {
+  return (
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col items-center justify-center px-8 gap-8">
+      <div className="w-28 h-28 rounded-full border-2 border-blink-ink bg-blink-accent shadow-hard flex items-center justify-center">
+        <span className="material-symbols-outlined text-white" style={{ fontSize: 56 }}>
+          smartphone
+        </span>
+      </div>
+
+      <div className="text-center max-w-sm">
+        <h1 className="font-display text-3xl uppercase tracking-tighter mb-3">
+          Solo Mobile
+        </h1>
+        <p className="font-mono text-sm text-blink-muted leading-relaxed">
+          Lo sentimos, esta página solo está disponible en dispositivos móviles por ahora.
+        </p>
+      </div>
+
+      <div className="w-full max-w-xs bg-blink-warning p-4 border-2 border-blink-ink shadow-hard text-center">
+        <p className="font-mono text-xs font-bold uppercase">
+          Por favor abrí Blink desde tu celular
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default DesktopUnsupportedPage;


### PR DESCRIPTION
Any user accessing from a desktop (viewport ≥ 1024px) now sees a
full-screen message explaining the app is mobile-only, instead of
the regular app routes.

https://claude.ai/code/session_01JW5jvMM3w8bRuoPoWtzDTG