### PR TITLE
Add service worker update prompt for users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'r
 import { lazy, Suspense, useEffect } from 'react';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
 import RouteSEO from './components/seo/RouteSEO';
+import UpdatePrompt from './components/UpdatePrompt';
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -34,6 +35,7 @@ function App() {
       <ScrollToTop />
       <AnalyticsTracker />
       <RouteSEO />
+      <UpdatePrompt />
       <Suspense fallback={<PageLoader />}>
         <Routes>
           <Route path="/" element={<Navigate to="/home" replace />} />

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useRegisterSW } from 'virtual:pwa-register/react';
+import { RefreshCw, X } from 'lucide-react';
+
+const UpdatePrompt: React.FC = () => {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW();
+
+  if (!needRefresh) return null;
+
+  return (
+    <div className="fixed bottom-20 left-0 right-0 z-[90] flex justify-center px-4 pointer-events-none">
+      <div
+        className="flex items-center gap-3 px-3 py-2.5 rounded-2xl bg-white pointer-events-auto w-full max-w-sm"
+        style={{
+          border: '1.5px solid rgba(99,102,241,0.2)',
+          boxShadow: '0 4px 20px rgba(99,102,241,0.15)',
+        }}
+      >
+        <div className="w-9 h-9 rounded-xl bg-primary/10 flex items-center justify-center flex-shrink-0">
+          <RefreshCw size={18} className="text-primary" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-blink-ink leading-tight">Nueva versión disponible</p>
+          <p className="text-xs text-blink-muted mt-0.5">Actualizá para obtener las últimas mejoras</p>
+        </div>
+
+        <button
+          onClick={() => updateServiceWorker(true)}
+          className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-semibold text-white flex-shrink-0"
+          style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)' }}
+        >
+          Actualizar
+        </button>
+
+        <button
+          onClick={() => setNeedRefresh(false)}
+          className="w-7 h-7 rounded-full flex items-center justify-center text-blink-muted flex-shrink-0"
+          aria-label="Cerrar"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default UpdatePrompt;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       VitePWA({
-        registerType: 'autoUpdate',
+        registerType: 'prompt',
         includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
         workbox: {
           // Smart caching for better mobile performance


### PR DESCRIPTION
When a new version of the app is deployed, show a bottom banner with an "Actualizar" button so users can reload to the latest version instead of having the app silently update behind the scenes.

- Change registerType from 'autoUpdate' to 'prompt' so the SW waits for user action
- Add UpdatePrompt component using vite-plugin-pwa's useRegisterSW hook
- Add vite-plugin-pwa/client types for virtual module resolution

https://claude.ai/code/session_014c421t4ffmtjWpwaZTYS7R