### PR TITLE
Replace desktop unsupported page with phone mirror component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense, useEffect } from 'react';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
 import RouteSEO from './components/seo/RouteSEO';
 import { useResponsive } from './hooks/useResponsive';
-import DesktopUnsupportedPage from './pages/DesktopUnsupportedPage';
+import PhoneMirror from './components/PhoneMirror';
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -33,11 +33,7 @@ const PageLoader = () => (
 function AppContent() {
   const { isDesktop } = useResponsive();
 
-  if (isDesktop) {
-    return <DesktopUnsupportedPage />;
-  }
-
-  return (
+  const mobileContent = (
     <>
       <ScrollToTop />
       <AnalyticsTracker />
@@ -58,6 +54,12 @@ function AppContent() {
       </Suspense>
     </>
   );
+
+  if (isDesktop) {
+    return <PhoneMirror>{mobileContent}</PhoneMirror>;
+  }
+
+  return mobileContent;
 }
 
 function App() {

--- a/src/components/PhoneMirror.tsx
+++ b/src/components/PhoneMirror.tsx
@@ -1,10 +1,14 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 interface PhoneMirrorProps {
   children: ReactNode;
 }
 
+const SHELL_HEIGHT = 864; // outer shell height in px (screen 844 + 10px padding × 2)
+
 function PhoneMirror({ children }: PhoneMirrorProps) {
+  const [scale, setScale] = useState(1);
+
   useEffect(() => {
     const prev = document.body.style.background;
     document.body.style.background = 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)';
@@ -13,20 +17,36 @@ function PhoneMirror({ children }: PhoneMirrorProps) {
     };
   }, []);
 
+  useEffect(() => {
+    const update = () => {
+      // 64px total vertical padding (32px each side)
+      setScale(Math.min(1, (window.innerHeight - 64) / SHELL_HEIGHT));
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
   return (
     <div
-      className="min-h-screen flex items-start justify-center"
       style={{
-        background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+        height: '100dvh',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
         paddingTop: '32px',
-        paddingBottom: '32px',
+        background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
       }}
     >
       {/* Phone outer shell */}
       <div
         style={{
           width: '390px',
-          minHeight: '844px',
+          height: `${SHELL_HEIGHT}px`,
+          flexShrink: 0,
+          transform: `scale(${scale})`,
+          transformOrigin: 'top center',
           borderRadius: '52px',
           background: '#1a1a2e',
           padding: '10px',
@@ -36,59 +56,21 @@ function PhoneMirror({ children }: PhoneMirrorProps) {
         }}
       >
         {/* Side buttons */}
-        <div
-          style={{
-            position: 'absolute',
-            left: '-3px',
-            top: '120px',
-            width: '3px',
-            height: '36px',
-            background: '#2a2a4a',
-            borderRadius: '2px 0 0 2px',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            left: '-3px',
-            top: '168px',
-            width: '3px',
-            height: '64px',
-            background: '#2a2a4a',
-            borderRadius: '2px 0 0 2px',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            left: '-3px',
-            top: '244px',
-            width: '3px',
-            height: '64px',
-            background: '#2a2a4a',
-            borderRadius: '2px 0 0 2px',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            right: '-3px',
-            top: '160px',
-            width: '3px',
-            height: '80px',
-            background: '#2a2a4a',
-            borderRadius: '0 2px 2px 0',
-          }}
-        />
+        <div style={{ position: 'absolute', left: '-3px', top: '120px', width: '3px', height: '36px', background: '#2a2a4a', borderRadius: '2px 0 0 2px' }} />
+        <div style={{ position: 'absolute', left: '-3px', top: '168px', width: '3px', height: '64px', background: '#2a2a4a', borderRadius: '2px 0 0 2px' }} />
+        <div style={{ position: 'absolute', left: '-3px', top: '244px', width: '3px', height: '64px', background: '#2a2a4a', borderRadius: '2px 0 0 2px' }} />
+        <div style={{ position: 'absolute', right: '-3px', top: '160px', width: '3px', height: '80px', background: '#2a2a4a', borderRadius: '0 2px 2px 0' }} />
 
-        {/* Screen area */}
+        {/* Screen area — transform: translateZ(0) makes position:fixed children
+            (like BottomNav) anchor to this container instead of the viewport */}
         <div
           style={{
             borderRadius: '44px',
             overflow: 'hidden',
             background: '#ffffff',
+            height: '844px',
             position: 'relative',
-            minHeight: '824px',
+            transform: 'translateZ(0)',
           }}
         >
           {/* Dynamic island */}
@@ -106,12 +88,17 @@ function PhoneMirror({ children }: PhoneMirrorProps) {
             }}
           />
 
-          {/* Status bar spacer */}
-          <div style={{ height: '54px' }} />
-
-          {/* App content */}
-          <div style={{ position: 'relative', zIndex: 1 }}>
-            {children}
+          {/* Scrollable content area */}
+          <div
+            className="no-scrollbar"
+            style={{ height: '100%', overflowY: 'auto', overflowX: 'hidden' }}
+          >
+            {/* Status bar spacer (sits behind dynamic island) */}
+            <div style={{ height: '54px' }} />
+            {/* Bottom padding so content isn't hidden under the nav */}
+            <div style={{ paddingBottom: '72px' }}>
+              {children}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/PhoneMirror.tsx
+++ b/src/components/PhoneMirror.tsx
@@ -1,0 +1,122 @@
+import { ReactNode, useEffect } from 'react';
+
+interface PhoneMirrorProps {
+  children: ReactNode;
+}
+
+function PhoneMirror({ children }: PhoneMirrorProps) {
+  useEffect(() => {
+    const prev = document.body.style.background;
+    document.body.style.background = 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)';
+    return () => {
+      document.body.style.background = prev;
+    };
+  }, []);
+
+  return (
+    <div
+      className="min-h-screen flex items-start justify-center"
+      style={{
+        background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 50%, #16213e 100%)',
+        paddingTop: '32px',
+        paddingBottom: '32px',
+      }}
+    >
+      {/* Phone outer shell */}
+      <div
+        style={{
+          width: '390px',
+          minHeight: '844px',
+          borderRadius: '52px',
+          background: '#1a1a2e',
+          padding: '10px',
+          boxShadow:
+            '0 0 0 1px #2a2a4a, 0 30px 80px rgba(0,0,0,0.7), 0 0 60px rgba(99,102,241,0.08)',
+          position: 'relative',
+        }}
+      >
+        {/* Side buttons */}
+        <div
+          style={{
+            position: 'absolute',
+            left: '-3px',
+            top: '120px',
+            width: '3px',
+            height: '36px',
+            background: '#2a2a4a',
+            borderRadius: '2px 0 0 2px',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            left: '-3px',
+            top: '168px',
+            width: '3px',
+            height: '64px',
+            background: '#2a2a4a',
+            borderRadius: '2px 0 0 2px',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            left: '-3px',
+            top: '244px',
+            width: '3px',
+            height: '64px',
+            background: '#2a2a4a',
+            borderRadius: '2px 0 0 2px',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            right: '-3px',
+            top: '160px',
+            width: '3px',
+            height: '80px',
+            background: '#2a2a4a',
+            borderRadius: '0 2px 2px 0',
+          }}
+        />
+
+        {/* Screen area */}
+        <div
+          style={{
+            borderRadius: '44px',
+            overflow: 'hidden',
+            background: '#ffffff',
+            position: 'relative',
+            minHeight: '824px',
+          }}
+        >
+          {/* Dynamic island */}
+          <div
+            style={{
+              position: 'absolute',
+              top: '12px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              width: '120px',
+              height: '34px',
+              background: '#1a1a2e',
+              borderRadius: '20px',
+              zIndex: 50,
+            }}
+          />
+
+          {/* Status bar spacer */}
+          <div style={{ height: '54px' }} />
+
+          {/* App content */}
+          <div style={{ position: 'relative', zIndex: 1 }}>
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PhoneMirror;


### PR DESCRIPTION
## Summary
This PR replaces the desktop unsupported page with a new `PhoneMirror` component that displays mobile content within a realistic iPhone mockup when accessed from desktop browsers.

## Key Changes
- **Added `PhoneMirror` component** (`src/components/PhoneMirror.tsx`): A new React component that wraps mobile content in a stylized iPhone frame with:
  - Realistic iPhone 14 Pro dimensions (390x844px)
  - Dynamic island notch at the top
  - Side buttons (volume and power)
  - Gradient background and shadow effects
  - Status bar spacer for proper content positioning
  
- **Updated `App.tsx`**: 
  - Removed import of `DesktopUnsupportedPage`
  - Changed desktop behavior from showing an error page to wrapping mobile content in `PhoneMirror`
  - Mobile users continue to see content normally without the phone frame

## Implementation Details
- The `PhoneMirror` component uses inline styles for the phone frame styling to ensure consistent appearance
- A gradient background is applied both to the component and document body for visual continuity
- The component preserves the previous background on unmount to avoid side effects
- Mobile content is rendered identically on both desktop and mobile, with the phone frame only appearing on desktop

https://claude.ai/code/session_014UA64TAmus4ajAcMZrLvTv