### PR TITLE
feat: add PWA push notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,13 @@
 VITE_SITE_URL=https://www.example.com
+# Push notifications — run `node scripts/generate-vapid-keys.mjs` to generate
+VITE_VAPID_PUBLIC_KEY=
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:your-email@example.com
+# Secret to protect POST /api/notifications/send (omit to disable auth)
+NOTIFICATIONS_SECRET=
+# Writable MongoDB URI for push subscriptions (falls back to MONGODB_URI_READ_ONLY)
+MONGODB_URI=
 VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # Optional local Vite proxy target for /api/* (use with `vercel dev` default port)
 VITE_API_BASE_URL=http://localhost:3000

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1,4 +1,5 @@
 import { MongoClient, ObjectId } from 'mongodb';
+import webpush from 'web-push';
 import { buildSearchDatasetFromMerchantDocs } from './search/entities.js';
 import { resolveIntentTagsFromTokens } from './search/dictionaries.js';
 import { meiliSearch, isMeilisearchConfigured } from './search/meilisearch.js';
@@ -14,16 +15,33 @@ const ALLOWED_COLLECTIONS = new Set([
 
 const MERCHANT_ASSETS_COLLECTION = 'merchant_assets';
 const BANK_CARDS_COLLECTION = 'bank_cards';
+const PUSH_SUBSCRIPTIONS_COLLECTION = 'push_subscriptions';
 const DEFAULT_BUSINESS_IMAGE =
   'https://images.pexels.com/photos/4386158/pexels-photo-4386158.jpeg?auto=compress&cs=tinysrgb&w=400';
 
 const MONGODB_URI_READ_ONLY = process.env.MONGODB_URI_READ_ONLY;
+const MONGODB_URI = process.env.MONGODB_URI || MONGODB_URI_READ_ONLY;
 const DATABASE_NAME = process.env.DATABASE_NAME || 'benefitsV3';
 const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || process.env.VITE_GOOGLE_MAPS_API_KEY;
+
+const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:admin@blink.com';
+const NOTIFICATIONS_SECRET = process.env.NOTIFICATIONS_SECRET;
+
+if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+}
 
 const globalState = globalThis;
 if (!globalState.__blinkMongo) {
   globalState.__blinkMongo = {
+    clientPromise: null,
+    dbPromise: null
+  };
+}
+if (!globalState.__blinkMongoWrite) {
+  globalState.__blinkMongoWrite = {
     clientPromise: null,
     dbPromise: null
   };
@@ -1189,6 +1207,23 @@ async function getDb() {
   return globalState.__blinkMongo.dbPromise;
 }
 
+async function getWritableDb() {
+  if (!MONGODB_URI) {
+    throw new Error('MONGODB_URI environment variable is required for write operations');
+  }
+
+  if (!globalState.__blinkMongoWrite.clientPromise) {
+    const client = new MongoClient(MONGODB_URI);
+    globalState.__blinkMongoWrite.clientPromise = client.connect();
+  }
+
+  if (!globalState.__blinkMongoWrite.dbPromise) {
+    globalState.__blinkMongoWrite.dbPromise = globalState.__blinkMongoWrite.clientPromise.then((client) => client.db(DATABASE_NAME));
+  }
+
+  return globalState.__blinkMongoWrite.dbPromise;
+}
+
 async function readJsonBody(req) {
   if (req.body && typeof req.body === 'object') {
     return req.body;
@@ -2030,6 +2065,89 @@ export {
   rehydrateBenefitDoc
 };
 
+async function handleNotificationSubscribe(req, res) {
+  const body = await readJsonBody(req);
+  const { endpoint, keys, expirationTime } = body;
+
+  if (!endpoint || !keys?.p256dh || !keys?.auth) {
+    return json(res, 400, { error: 'Invalid subscription: endpoint, keys.p256dh and keys.auth are required' });
+  }
+
+  const db = await getWritableDb();
+  const collection = db.collection(PUSH_SUBSCRIPTIONS_COLLECTION);
+
+  await collection.updateOne(
+    { endpoint },
+    {
+      $set: { endpoint, keys, expirationTime: expirationTime || null, updatedAt: new Date() },
+      $setOnInsert: { createdAt: new Date() },
+    },
+    { upsert: true }
+  );
+
+  return json(res, 200, { success: true });
+}
+
+async function handleNotificationUnsubscribe(req, res) {
+  const body = await readJsonBody(req);
+  const { endpoint } = body;
+
+  if (!endpoint) {
+    return json(res, 400, { error: 'endpoint is required' });
+  }
+
+  const db = await getWritableDb();
+  await db.collection(PUSH_SUBSCRIPTIONS_COLLECTION).deleteOne({ endpoint });
+
+  return json(res, 200, { success: true });
+}
+
+async function handleNotificationSend(req, res) {
+  if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+    return json(res, 503, { error: 'Push notifications not configured (missing VAPID keys)' });
+  }
+
+  const body = await readJsonBody(req);
+
+  if (NOTIFICATIONS_SECRET && body.secret !== NOTIFICATIONS_SECRET) {
+    return json(res, 401, { error: 'Unauthorized' });
+  }
+
+  const { title, body: notifBody, url, options } = body;
+
+  if (!title) {
+    return json(res, 400, { error: 'title is required' });
+  }
+
+  const db = await getWritableDb();
+  const subscriptions = await db.collection(PUSH_SUBSCRIPTIONS_COLLECTION).find({}).toArray();
+
+  if (subscriptions.length === 0) {
+    return json(res, 200, { success: true, sent: 0, total: 0 });
+  }
+
+  const payload = JSON.stringify({ title, body: notifBody || '', url: url || '/', ...options });
+
+  const results = await Promise.allSettled(
+    subscriptions.map((sub) =>
+      webpush.sendNotification({ endpoint: sub.endpoint, keys: sub.keys }, payload)
+    )
+  );
+
+  // Remove subscriptions that are gone (410) or not found (404)
+  const expiredEndpoints = results
+    .map((result, i) => ({ result, sub: subscriptions[i] }))
+    .filter(({ result }) => result.status === 'rejected' && [410, 404].includes(result.reason?.statusCode))
+    .map(({ sub }) => sub.endpoint);
+
+  if (expiredEndpoints.length > 0) {
+    await db.collection(PUSH_SUBSCRIPTIONS_COLLECTION).deleteMany({ endpoint: { $in: expiredEndpoints } });
+  }
+
+  const sent = results.filter((r) => r.status === 'fulfilled').length;
+  return json(res, 200, { success: true, sent, total: subscriptions.length, expired: expiredEndpoints.length });
+}
+
 export default async function handler(req, res) {
   const url = getParsedUrl(req);
   const path = resolveRequestPath(url);
@@ -2073,6 +2191,18 @@ export default async function handler(req, res) {
       return await handlePlaceDetails(req, res);
     }
 
+    if (req.method === 'POST' && path === '/api/notifications/subscribe') {
+      return await handleNotificationSubscribe(req, res);
+    }
+
+    if (req.method === 'POST' && path === '/api/notifications/unsubscribe') {
+      return await handleNotificationUnsubscribe(req, res);
+    }
+
+    if (req.method === 'POST' && path === '/api/notifications/send') {
+      return await handleNotificationSend(req, res);
+    }
+
     if (req.method === 'GET') {
       const benefitByIdMatch = path.match(/^\/api\/benefits\/([^/]+)$/);
       if (benefitByIdMatch) {
@@ -2093,7 +2223,10 @@ export default async function handler(req, res) {
         'GET /api/banks',
         'GET /api/networks',
         'GET /api/stats',
-        'POST /api/places/details'
+        'POST /api/places/details',
+        'POST /api/notifications/subscribe',
+        'POST /api/notifications/unsubscribe',
+        'POST /api/notifications/send'
       ]
     });
   } catch (error) {

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -29,10 +29,6 @@ const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
 const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:admin@blink.com';
 const NOTIFICATIONS_SECRET = process.env.NOTIFICATIONS_SECRET;
 
-if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
-  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
-}
-
 const globalState = globalThis;
 if (!globalState.__blinkMongo) {
   globalState.__blinkMongo = {
@@ -2105,6 +2101,12 @@ async function handleNotificationUnsubscribe(req, res) {
 async function handleNotificationSend(req, res) {
   if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
     return json(res, 503, { error: 'Push notifications not configured (missing VAPID keys)' });
+  }
+
+  try {
+    webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+  } catch (err) {
+    return json(res, 503, { error: 'Invalid VAPID configuration', detail: err.message });
   }
 
   const body = await readJsonBody(req);

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -16,6 +16,7 @@ const ALLOWED_COLLECTIONS = new Set([
 const MERCHANT_ASSETS_COLLECTION = 'merchant_assets';
 const BANK_CARDS_COLLECTION = 'bank_cards';
 const PUSH_SUBSCRIPTIONS_COLLECTION = 'push_subscriptions';
+const NOTIFICATION_HISTORY_COLLECTION = 'notification_history';
 const DEFAULT_BUSINESS_IMAGE =
   'https://images.pexels.com/photos/4386158/pexels-photo-4386158.jpeg?auto=compress&cs=tinysrgb&w=400';
 
@@ -2147,7 +2148,29 @@ async function handleNotificationSend(req, res) {
   }
 
   const sent = results.filter((r) => r.status === 'fulfilled').length;
+
+  await db.collection(NOTIFICATION_HISTORY_COLLECTION).insertOne({
+    title,
+    body: notifBody || '',
+    url: url || '/',
+    sentAt: new Date(),
+    sent,
+    total: subscriptions.length,
+  });
+
   return json(res, 200, { success: true, sent, total: subscriptions.length, expired: expiredEndpoints.length });
+}
+
+async function handleNotificationHistory(req, res) {
+  const db = await getWritableDb();
+  const notifications = await db
+    .collection(NOTIFICATION_HISTORY_COLLECTION)
+    .find({})
+    .sort({ sentAt: -1 })
+    .limit(100)
+    .toArray();
+
+  return json(res, 200, { notifications });
 }
 
 export default async function handler(req, res) {
@@ -2193,6 +2216,10 @@ export default async function handler(req, res) {
       return await handlePlaceDetails(req, res);
     }
 
+    if (req.method === 'GET' && path === '/api/notifications/history') {
+      return await handleNotificationHistory(req, res);
+    }
+
     if (req.method === 'POST' && path === '/api/notifications/subscribe') {
       return await handleNotificationSubscribe(req, res);
     }
@@ -2226,6 +2253,7 @@ export default async function handler(req, res) {
         'GET /api/networks',
         'GET /api/stats',
         'POST /api/places/details',
+        'GET /api/notifications/history',
         'POST /api/notifications/subscribe',
         'POST /api/notifications/unsubscribe',
         'POST /api/notifications/send'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "mongodb": "^6.21.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -36,6 +37,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-router-dom:
         specifier: ^7.6.2
         version: 7.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@eslint/js':
         specifier: ^9.9.1
@@ -48,9 +51,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.27)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(vite@5.4.21(terser@5.44.1))
+        version: 4.7.0(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -86,13 +92,13 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       vite:
         specifier: ^5.4.2
-        version: 5.4.21(terser@5.44.1)
+        version: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
       vite-plugin-pwa:
         specifier: ^0.17.4
-        version: 0.17.5(vite@5.4.21(terser@5.44.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+        version: 0.17.5(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1)
+        version: 3.2.4(@types/node@25.6.0)(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1)
 
 packages:
 
@@ -996,56 +1002,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1142,6 +1159,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1158,6 +1178,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -1332,6 +1355,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1393,6 +1419,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1411,6 +1440,9 @@ packages:
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1593,6 +1625,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -1905,6 +1940,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -1931,6 +1970,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2132,6 +2174,12 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2225,6 +2273,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
@@ -2239,6 +2290,9 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2581,6 +2635,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2879,6 +2936,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -2994,6 +3054,11 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -4240,6 +4305,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.27)':
@@ -4254,6 +4323,10 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -4352,7 +4425,7 @@ snapshots:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(terser@5.44.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -4360,7 +4433,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4372,13 +4445,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.21(terser@5.44.1))':
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4409,7 +4482,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1)
+      vitest: 3.2.4(@types/node@25.6.0)(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -4483,6 +4556,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
@@ -4548,6 +4628,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bn.js@4.12.3: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -4570,6 +4652,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   bson@6.10.4: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -4742,6 +4826,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ejs@3.1.10:
     dependencies:
@@ -5140,6 +5228,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -5161,6 +5251,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -5366,6 +5458,17 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5440,6 +5543,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -5455,6 +5560,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -5773,6 +5880,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
     dependencies:
@@ -6143,6 +6252,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@7.19.2: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -6174,13 +6285,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(terser@5.44.1):
+  vite-node@3.2.4(@types/node@25.6.0)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6192,31 +6303,32 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pwa@0.17.5(vite@5.4.21(terser@5.44.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
+  vite-plugin-pwa@0.17.5(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       fast-glob: 3.3.3
       pretty-bytes: 6.1.1
-      vite: 5.4.21(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.21(terser@5.44.1):
+  vite@5.4.21(@types/node@25.6.0)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.54.0
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       terser: 5.44.1
 
-  vitest@3.2.4(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1):
+  vitest@3.2.4(@types/node@25.6.0)(@vitest/ui@3.2.4)(jsdom@27.4.0)(terser@5.44.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.21(terser@5.44.1))
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@25.6.0)(terser@5.44.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6234,10 +6346,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.21(terser@5.44.1)
-      vite-node: 3.2.4(terser@5.44.1)
+      vite: 5.4.21(@types/node@25.6.0)(terser@5.44.1)
+      vite-node: 3.2.4(@types/node@25.6.0)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.6.0
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 27.4.0
     transitivePeerDependencies:
@@ -6254,6 +6367,16 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@4.0.2: {}
 

--- a/public/sw-push.js
+++ b/public/sw-push.js
@@ -1,0 +1,52 @@
+// Service worker push notification handlers
+// Imported by the generated service worker via importScripts()
+
+self.addEventListener('push', function (event) {
+  let data = { title: 'Blink', body: 'Nueva notificación' };
+
+  if (event.data) {
+    try {
+      data = event.data.json();
+    } catch (_) {
+      data.body = event.data.text();
+    }
+  }
+
+  const options = {
+    body: data.body || '',
+    icon: '/pwa-192x192.png',
+    badge: '/pwa-192x192.png',
+    vibrate: [100, 50, 100],
+    data: {
+      url: data.url || '/',
+    },
+    actions: data.actions || [],
+  };
+
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'Blink', options)
+  );
+});
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+
+  const url = event.notification.data?.url || '/';
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (windowClients) {
+        for (let i = 0; i < windowClients.length; i++) {
+          const client = windowClients[i];
+          if ('focus' in client) {
+            client.navigate(url);
+            return client.focus();
+          }
+        }
+        if (clients.openWindow) {
+          return clients.openWindow(url);
+        }
+      })
+  );
+});

--- a/scripts/generate-vapid-keys.mjs
+++ b/scripts/generate-vapid-keys.mjs
@@ -1,0 +1,13 @@
+import webpush from 'web-push';
+
+const keys = webpush.generateVAPIDKeys();
+
+console.log('VAPID keys generated. Add these to your .env file:\n');
+console.log(`VITE_VAPID_PUBLIC_KEY=${keys.publicKey}`);
+console.log(`VAPID_PUBLIC_KEY=${keys.publicKey}`);
+console.log(`VAPID_PRIVATE_KEY=${keys.privateKey}`);
+console.log(`VAPID_SUBJECT=mailto:your-email@example.com`);
+console.log(`\n# Optional: secret to protect the /api/notifications/send endpoint`);
+console.log(`NOTIFICATIONS_SECRET=your-random-secret-here`);
+console.log(`\n# Optional: writable MongoDB URI (falls back to MONGODB_URI_READ_ONLY)`);
+console.log(`MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>/<db>?retryWrites=true&w=majority`);

--- a/scripts/generate-vapid-keys.mjs
+++ b/scripts/generate-vapid-keys.mjs
@@ -1,13 +1,32 @@
-import webpush from 'web-push';
+import { generateKeyPairSync } from 'node:crypto';
 
-const keys = webpush.generateVAPIDKeys();
+const { publicKey: pubJwk, privateKey: privJwk } = generateKeyPairSync('ec', {
+  namedCurve: 'P-256',
+  publicKeyEncoding: { format: 'jwk' },
+  privateKeyEncoding: { format: 'jwk' },
+});
 
-console.log('VAPID keys generated. Add these to your .env file:\n');
-console.log(`VITE_VAPID_PUBLIC_KEY=${keys.publicKey}`);
-console.log(`VAPID_PUBLIC_KEY=${keys.publicKey}`);
-console.log(`VAPID_PRIVATE_KEY=${keys.privateKey}`);
+function fromBase64Url(b64) {
+  return Buffer.from(b64.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function toBase64Url(buf) {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+// VAPID public key must be the uncompressed EC point: 04 || x || y
+const pubRaw = Buffer.concat([Buffer.from([0x04]), fromBase64Url(pubJwk.x), fromBase64Url(pubJwk.y)]);
+const privRaw = fromBase64Url(privJwk.d);
+
+const publicKey = toBase64Url(pubRaw);
+const privateKey = toBase64Url(privRaw);
+
+console.log('Add these to your .env file:\n');
+console.log(`VITE_VAPID_PUBLIC_KEY=${publicKey}`);
+console.log(`VAPID_PUBLIC_KEY=${publicKey}`);
+console.log(`VAPID_PRIVATE_KEY=${privateKey}`);
 console.log(`VAPID_SUBJECT=mailto:your-email@example.com`);
-console.log(`\n# Optional: secret to protect the /api/notifications/send endpoint`);
+console.log(`\n# Optional: secret to protect POST /api/notifications/send`);
 console.log(`NOTIFICATIONS_SECRET=your-random-secret-here`);
 console.log(`\n# Optional: writable MongoDB URI (falls back to MONGODB_URI_READ_ONLY)`);
 console.log(`MONGODB_URI=mongodb+srv://<user>:<pass>@<cluster>/<db>?retryWrites=true&w=majority`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const SavedPage = lazy(() => import('./pages/SavedPage'));
 const ProfilePage = lazy(() => import('./pages/ProfilePage'));
 const MapPage = lazy(() => import('./pages/MapPage'));
 const LandingPage = lazy(() => import('./pages/LandingPage'));
+const NotificationsPage = lazy(() => import('./pages/NotificationsPage'));
 
 const PageLoader = () => (
   <div className="min-h-screen bg-blink-bg flex items-center justify-center">
@@ -65,6 +66,7 @@ function AppContent() {
           <Route path="/saved" element={<SavedPage />} />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/map" element={<MapPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/descuentos/:bank/:category" element={<LandingPage />} />
           <Route path="/descuentos/:bank/:category/:city" element={<LandingPage />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,24 +1,28 @@
 import React from "react";
-// import { Bell, User } from "lucide-react";
+import { Bell, BellOff } from "lucide-react";
 import { Link } from "react-router-dom";
+import { usePushNotifications } from "../hooks/usePushNotifications";
 
 interface HeaderProps {
   title?: string;
-  showNotification?: boolean;
-  showProfile?: boolean;
-  notificationCount?: number;
-  onNotificationClick?: () => void;
-  onProfileClick?: () => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({
-  title = "Blink",
-  // showNotification = true,
-  // showProfile = true,
-  // notificationCount = 0,
-  // onNotificationClick,
-  // onProfileClick,
-}) => {
+export const Header: React.FC<HeaderProps> = ({ title = "Blink" }) => {
+  const { isSupported, permission, isSubscribed, isLoading, subscribe, unsubscribe } =
+    usePushNotifications();
+
+  const handleBellClick = () => {
+    if (isSubscribed) {
+      unsubscribe();
+    } else {
+      subscribe();
+    }
+  };
+
+  const bellLabel = isSubscribed
+    ? "Desactivar notificaciones"
+    : "Activar notificaciones";
+
   return (
     <div className="modern-header header safe-area-top header-slide-down">
       {/* Main Header Bar */}
@@ -38,62 +42,28 @@ export const Header: React.FC<HeaderProps> = ({
           </Link>
         </div>
 
-        {/* Right: Notification and Profile */}
+        {/* Right: Notification Bell */}
         <div className="flex items-center gap-2 sm:gap-3">
-          {/* Notification Icon */}
-          {/* {showNotification && (
+          {isSupported && permission !== "denied" && (
             <button
-              onClick={onNotificationClick}
-              className="relative touch-target touch-button p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-full transition-colors"
+              onClick={handleBellClick}
+              disabled={isLoading}
+              className="relative touch-target touch-button p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-full transition-colors disabled:opacity-50"
               style={{
                 minWidth: "var(--touch-target-min)",
                 minHeight: "var(--touch-target-min)",
                 borderRadius: "var(--radius-full)",
               }}
-              aria-label={`Notifications${
-                notificationCount > 0 ? ` (${notificationCount})` : ""
-              }`}
+              aria-label={bellLabel}
+              title={bellLabel}
             >
-              <Bell className="h-5 w-5 sm:h-6 sm:w-6" />
-              {notificationCount > 0 && (
-                <span
-                  className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-medium rounded-full min-w-[18px] sm:min-w-[20px] h-4 sm:h-5 flex items-center justify-center px-1"
-                  style={{
-                    backgroundColor: "var(--color-error)",
-                    color: "var(--color-white)",
-                    fontSize: "var(--text-xs)",
-                    fontWeight: "var(--font-medium)",
-                    borderRadius: "var(--radius-full)",
-                  }}
-                >
-                  {notificationCount > 99 ? "99+" : notificationCount}
-                </span>
+              {isSubscribed ? (
+                <Bell className="h-5 w-5 sm:h-6 sm:w-6 fill-current text-primary-600" />
+              ) : (
+                <BellOff className="h-5 w-5 sm:h-6 sm:w-6" />
               )}
             </button>
-          )} */}
-
-          {/* Profile Picture */}
-          {/* {showProfile && (
-            <button
-              onClick={onProfileClick}
-              className="touch-target touch-button p-1 text-gray-600 hover:text-gray-900 rounded-full transition-colors"
-              style={{
-                minWidth: "var(--touch-target-min)",
-                minHeight: "var(--touch-target-min)",
-              }}
-              aria-label="Profile"
-            >
-              <div
-                className="w-7 h-7 sm:w-8 sm:h-8 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full flex items-center justify-center"
-                style={{
-                  background: "var(--gradient-primary)",
-                  borderRadius: "var(--radius-full)",
-                }}
-              >
-                <User className="h-4 w-4 sm:h-5 sm:w-5 text-white" />
-              </div>
-            </button>
-          )} */}
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,23 +11,16 @@ export const Header: React.FC<HeaderProps> = ({ title = "Blink" }) => {
   const { isSupported, permission, isSubscribed, isLoading, subscribe, unsubscribe } =
     usePushNotifications();
 
-  const handleBellClick = () => {
-    if (isSubscribed) {
-      unsubscribe();
-    } else {
-      subscribe();
-    }
-  };
+  const showBell = isSupported && permission !== "denied";
 
-  const bellLabel = isSubscribed
-    ? "Desactivar notificaciones"
-    : "Activar notificaciones";
+  const handleBellClick = () => {
+    if (isSubscribed) unsubscribe();
+    else subscribe();
+  };
 
   return (
     <div className="modern-header header safe-area-top header-slide-down">
-      {/* Main Header Bar */}
       <div className="flex items-center justify-between px-4 sm:px-6 md:px-8 py-3 sm:py-4 bg-white border-b border-gray-200">
-        {/* Left: App Title */}
         <div className="flex items-center">
           <Link
             to="/"
@@ -42,9 +35,8 @@ export const Header: React.FC<HeaderProps> = ({ title = "Blink" }) => {
           </Link>
         </div>
 
-        {/* Right: Notification Bell */}
         <div className="flex items-center gap-2 sm:gap-3">
-          {isSupported && permission !== "denied" && (
+          {showBell && (
             <button
               onClick={handleBellClick}
               disabled={isLoading}
@@ -54,8 +46,7 @@ export const Header: React.FC<HeaderProps> = ({ title = "Blink" }) => {
                 minHeight: "var(--touch-target-min)",
                 borderRadius: "var(--radius-full)",
               }}
-              aria-label={bellLabel}
-              title={bellLabel}
+              aria-label={isSubscribed ? "Desactivar notificaciones" : "Activar notificaciones"}
             >
               {isSubscribed ? (
                 <Bell className="h-5 w-5 sm:h-6 sm:w-6 fill-current text-primary-600" />

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+import { Bell, X } from "lucide-react";
+import { usePushNotifications } from "../hooks/usePushNotifications";
+
+const DISMISSED_KEY = "blink_notif_banner_dismissed";
+
+export const NotificationBanner: React.FC = () => {
+  const { isSupported, permission, isSubscribed, isLoading, subscribe } =
+    usePushNotifications();
+  const [dismissed, setDismissed] = useState(true); // start hidden to avoid flash
+
+  useEffect(() => {
+    setDismissed(localStorage.getItem(DISMISSED_KEY) === "true");
+  }, []);
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, "true");
+    setDismissed(true);
+  };
+
+  const handleEnable = async () => {
+    await subscribe();
+    // If they granted permission, hide the banner
+    if (Notification.permission === "granted") {
+      handleDismiss();
+    }
+  };
+
+  if (!isSupported || dismissed || isSubscribed || permission === "denied") {
+    return null;
+  }
+
+  return (
+    <div className="mx-4 sm:mx-6 md:mx-8 mt-3 mb-1 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 flex items-center gap-3">
+      <div className="flex-shrink-0 w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
+        <Bell className="w-4 h-4 text-blue-600" />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-blue-900 leading-snug">
+          Activá las notificaciones
+        </p>
+        <p className="text-xs text-blue-700 leading-snug mt-0.5">
+          Enterate primero de nuevas ofertas y descuentos
+        </p>
+      </div>
+
+      <button
+        onClick={handleEnable}
+        disabled={isLoading}
+        className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-60"
+      >
+        {isLoading ? "..." : "Activar"}
+      </button>
+
+      <button
+        onClick={handleDismiss}
+        className="flex-shrink-0 p-1 text-blue-400 hover:text-blue-600 transition-colors"
+        aria-label="Cerrar"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+};

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Bell, X, Download } from "lucide-react";
 import { usePushNotifications } from "../hooks/usePushNotifications";
 
-const DISMISSED_KEY = "blink_notif_banner_dismissed";
+const NOTIF_DISMISSED_KEY = "blink_notif_banner_dismissed";
 const INSTALL_DISMISSED_KEY = "blink_install_popup_dismissed";
 
 function isIOS() {
@@ -76,28 +76,30 @@ export const NotificationBanner: React.FC = () => {
   const { isSupported, permission, isSubscribed, isLoading, subscribe } =
     usePushNotifications();
 
-  const [dismissed, setDismissed] = useState(true);
+  const [ready, setReady] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
   const [showSheet, setShowSheet] = useState(false);
   const [iosNotStandalone, setIosNotStandalone] = useState(false);
 
   useEffect(() => {
-    const notifDismissed = localStorage.getItem(DISMISSED_KEY) === "true";
-    const installDismissed = localStorage.getItem(INSTALL_DISMISSED_KEY) === "1";
     const onIOS = isIOS();
     const standalone = isStandalone();
 
     if (onIOS && !standalone) {
       setIosNotStandalone(true);
-      setDismissed(installDismissed);
+      setDismissed(localStorage.getItem(INSTALL_DISMISSED_KEY) === "1");
     } else {
-      setDismissed(notifDismissed);
+      setDismissed(localStorage.getItem(NOTIF_DISMISSED_KEY) === "true");
     }
+    setReady(true);
   }, []);
 
   const handleDismiss = () => {
-    const key = iosNotStandalone ? INSTALL_DISMISSED_KEY : DISMISSED_KEY;
-    const value = iosNotStandalone ? "1" : "true";
-    localStorage.setItem(key, value);
+    if (iosNotStandalone) {
+      localStorage.setItem(INSTALL_DISMISSED_KEY, "1");
+    } else {
+      localStorage.setItem(NOTIF_DISMISSED_KEY, "true");
+    }
     setDismissed(true);
   };
 
@@ -108,12 +110,10 @@ export const NotificationBanner: React.FC = () => {
     }
   };
 
-  // Hide if dismissed or already handled
-  if (dismissed) return null;
-  if (!iosNotStandalone && (isSubscribed || permission === "denied")) return null;
-  if (!iosNotStandalone && !isSupported) return null;
+  // Don't render until we've read localStorage (avoids flash)
+  if (!ready || dismissed) return null;
 
-  // iOS in browser — prompt to install
+  // iOS in browser — can't use push without installing the PWA
   if (iosNotStandalone) {
     return (
       <>
@@ -131,15 +131,11 @@ export const NotificationBanner: React.FC = () => {
           </div>
           <button
             onClick={() => setShowSheet(true)}
-            className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-lg transition-colors"
+            className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-lg"
           >
             Cómo
           </button>
-          <button
-            onClick={handleDismiss}
-            className="flex-shrink-0 p-1 text-blue-400 hover:text-blue-600 transition-colors"
-            aria-label="Cerrar"
-          >
+          <button onClick={handleDismiss} className="flex-shrink-0 p-1 text-blue-400" aria-label="Cerrar">
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -148,7 +144,9 @@ export const NotificationBanner: React.FC = () => {
     );
   }
 
-  // Normal push notification prompt
+  // Other browsers — only show if push is supported and not already subscribed/denied
+  if (!isSupported || isSubscribed || permission === "denied") return null;
+
   return (
     <div className="mx-4 sm:mx-6 md:mx-8 mt-3 mb-1 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 flex items-center gap-3">
       <div className="flex-shrink-0 w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
@@ -165,15 +163,11 @@ export const NotificationBanner: React.FC = () => {
       <button
         onClick={handleEnable}
         disabled={isLoading}
-        className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-60"
+        className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 px-3 py-1.5 rounded-lg disabled:opacity-60"
       >
         {isLoading ? "..." : "Activar"}
       </button>
-      <button
-        onClick={handleDismiss}
-        className="flex-shrink-0 p-1 text-blue-400 hover:text-blue-600 transition-colors"
-        aria-label="Cerrar"
-      >
+      <button onClick={handleDismiss} className="flex-shrink-0 p-1 text-blue-400" aria-label="Cerrar">
         <X className="w-4 h-4" />
       </button>
     </div>

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -1,41 +1,159 @@
 import React, { useState, useEffect } from "react";
-import { Bell, X } from "lucide-react";
+import { Bell, X, Download } from "lucide-react";
 import { usePushNotifications } from "../hooks/usePushNotifications";
 
 const DISMISSED_KEY = "blink_notif_banner_dismissed";
+const INSTALL_DISMISSED_KEY = "blink_install_popup_dismissed";
+
+function isIOS() {
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+function isStandalone() {
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (window.navigator as any).standalone === true
+  );
+}
+
+const ShareIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="inline mx-0.5">
+    <path d="M7 1v8M4 4l3-3 3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M2 8v4a.5.5 0 00.5.5h9a.5.5 0 00.5-.5V8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const Step: React.FC<{ num: number; children: React.ReactNode }> = ({ num, children }) => (
+  <div className="flex items-start gap-3">
+    <div className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5 text-xs font-bold text-white bg-blue-500">
+      {num}
+    </div>
+    <p className="text-sm text-gray-700 leading-relaxed">{children}</p>
+  </div>
+);
+
+const InstallSheet: React.FC<{ onClose: () => void }> = ({ onClose }) => (
+  <div
+    className="fixed inset-0 z-[100] flex items-end"
+    style={{ backgroundColor: "rgba(0,0,0,0.45)" }}
+    onClick={onClose}
+  >
+    <div
+      className="w-full bg-white rounded-t-3xl"
+      style={{ boxShadow: "0 -8px 40px rgba(0,0,0,0.15)" }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="px-6 pt-5 pb-8 space-y-4">
+        <div className="w-10 h-1 bg-gray-200 rounded-full mx-auto mb-2" />
+        <div className="flex items-center gap-3 mb-2">
+          <img src="/pwa-192x192.png" alt="Blink" className="w-12 h-12 rounded-2xl flex-shrink-0" />
+          <div>
+            <h2 className="font-bold text-gray-900 text-base">Instalá la app de Blink</h2>
+            <p className="text-gray-500 text-sm">Para activar notificaciones</p>
+          </div>
+        </div>
+        <Step num={1}>
+          Tocá <ShareIcon /> <strong>Compartir</strong> en la barra de Safari
+        </Step>
+        <Step num={2}>
+          Tocá <strong>"Agregar a inicio"</strong>
+        </Step>
+        <Step num={3}>
+          Abrí Blink desde tu pantalla de inicio y activá las notificaciones
+        </Step>
+        <button
+          onClick={onClose}
+          className="mt-2 w-full py-3.5 rounded-xl text-sm font-semibold text-white bg-blue-600"
+        >
+          Entendido
+        </button>
+      </div>
+    </div>
+  </div>
+);
 
 export const NotificationBanner: React.FC = () => {
   const { isSupported, permission, isSubscribed, isLoading, subscribe } =
     usePushNotifications();
-  const [dismissed, setDismissed] = useState(true); // start hidden to avoid flash
+
+  const [dismissed, setDismissed] = useState(true);
+  const [showSheet, setShowSheet] = useState(false);
+  const [iosNotStandalone, setIosNotStandalone] = useState(false);
 
   useEffect(() => {
-    setDismissed(localStorage.getItem(DISMISSED_KEY) === "true");
+    const notifDismissed = localStorage.getItem(DISMISSED_KEY) === "true";
+    const installDismissed = localStorage.getItem(INSTALL_DISMISSED_KEY) === "1";
+    const onIOS = isIOS();
+    const standalone = isStandalone();
+
+    if (onIOS && !standalone) {
+      setIosNotStandalone(true);
+      setDismissed(installDismissed);
+    } else {
+      setDismissed(notifDismissed);
+    }
   }, []);
 
   const handleDismiss = () => {
-    localStorage.setItem(DISMISSED_KEY, "true");
+    const key = iosNotStandalone ? INSTALL_DISMISSED_KEY : DISMISSED_KEY;
+    const value = iosNotStandalone ? "1" : "true";
+    localStorage.setItem(key, value);
     setDismissed(true);
   };
 
   const handleEnable = async () => {
     await subscribe();
-    // If they granted permission, hide the banner
     if (Notification.permission === "granted") {
       handleDismiss();
     }
   };
 
-  if (!isSupported || dismissed || isSubscribed || permission === "denied") {
-    return null;
+  // Hide if dismissed or already handled
+  if (dismissed) return null;
+  if (!iosNotStandalone && (isSubscribed || permission === "denied")) return null;
+  if (!iosNotStandalone && !isSupported) return null;
+
+  // iOS in browser — prompt to install
+  if (iosNotStandalone) {
+    return (
+      <>
+        <div className="mx-4 sm:mx-6 md:mx-8 mt-3 mb-1 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 flex items-center gap-3">
+          <div className="flex-shrink-0 w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
+            <Download className="w-4 h-4 text-blue-600" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-blue-900 leading-snug">
+              Instalá la app para notificaciones
+            </p>
+            <p className="text-xs text-blue-700 leading-snug mt-0.5">
+              Agregá Blink a tu pantalla de inicio
+            </p>
+          </div>
+          <button
+            onClick={() => setShowSheet(true)}
+            className="flex-shrink-0 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Cómo
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="flex-shrink-0 p-1 text-blue-400 hover:text-blue-600 transition-colors"
+            aria-label="Cerrar"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        {showSheet && <InstallSheet onClose={() => setShowSheet(false)} />}
+      </>
+    );
   }
 
+  // Normal push notification prompt
   return (
     <div className="mx-4 sm:mx-6 md:mx-8 mt-3 mb-1 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 flex items-center gap-3">
       <div className="flex-shrink-0 w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center">
         <Bell className="w-4 h-4 text-blue-600" />
       </div>
-
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-blue-900 leading-snug">
           Activá las notificaciones
@@ -44,7 +162,6 @@ export const NotificationBanner: React.FC = () => {
           Enterate primero de nuevas ofertas y descuentos
         </p>
       </div>
-
       <button
         onClick={handleEnable}
         disabled={isLoading}
@@ -52,7 +169,6 @@ export const NotificationBanner: React.FC = () => {
       >
         {isLoading ? "..." : "Activar"}
       </button>
-
       <button
         onClick={handleDismiss}
         className="flex-shrink-0 p-1 text-blue-400 hover:text-blue-600 transition-colors"

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,106 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY as string | undefined;
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}
+
+export interface UsePushNotificationsReturn {
+  isSupported: boolean;
+  permission: NotificationPermission;
+  isSubscribed: boolean;
+  isLoading: boolean;
+  subscribe: () => Promise<void>;
+  unsubscribe: () => Promise<void>;
+}
+
+export function usePushNotifications(): UsePushNotificationsReturn {
+  const isSupported =
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window &&
+    !!VAPID_PUBLIC_KEY;
+
+  const [permission, setPermission] = useState<NotificationPermission>(
+    isSupported ? Notification.permission : 'denied'
+  );
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [subscription, setSubscription] = useState<PushSubscription | null>(null);
+
+  useEffect(() => {
+    if (!isSupported) return;
+
+    setPermission(Notification.permission);
+
+    navigator.serviceWorker.ready.then((reg) => {
+      reg.pushManager.getSubscription().then((sub) => {
+        setIsSubscribed(!!sub);
+        setSubscription(sub);
+      });
+    });
+  }, [isSupported]);
+
+  const subscribe = useCallback(async () => {
+    if (!isSupported || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+
+      let perm = Notification.permission;
+      if (perm === 'default') {
+        perm = await Notification.requestPermission();
+        setPermission(perm);
+      }
+
+      if (perm !== 'granted') return;
+
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY!),
+      });
+
+      await fetch('/api/notifications/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sub.toJSON()),
+      });
+
+      setIsSubscribed(true);
+      setSubscription(sub);
+    } catch (err) {
+      console.error('[Push] Failed to subscribe:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isSupported, isLoading]);
+
+  const unsubscribe = useCallback(async () => {
+    if (!subscription || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      await fetch('/api/notifications/unsubscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint: subscription.endpoint }),
+      });
+
+      await subscription.unsubscribe();
+      setIsSubscribed(false);
+      setSubscription(null);
+    } catch (err) {
+      console.error('[Push] Failed to unsubscribe:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [subscription, isLoading]);
+
+  return { isSupported, permission, isSubscribed, isLoading, subscribe, unsubscribe };
+}

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -9,6 +9,16 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
   return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
 }
 
+// Browser supports the Push API — does NOT require VAPID key
+function browserSupportsPush(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
 export interface UsePushNotificationsReturn {
   isSupported: boolean;
   permission: NotificationPermission;
@@ -19,12 +29,7 @@ export interface UsePushNotificationsReturn {
 }
 
 export function usePushNotifications(): UsePushNotificationsReturn {
-  const isSupported =
-    typeof window !== 'undefined' &&
-    'serviceWorker' in navigator &&
-    'PushManager' in window &&
-    'Notification' in window &&
-    !!VAPID_PUBLIC_KEY;
+  const isSupported = browserSupportsPush();
 
   const [permission, setPermission] = useState<NotificationPermission>(
     isSupported ? Notification.permission : 'denied'
@@ -35,9 +40,7 @@ export function usePushNotifications(): UsePushNotificationsReturn {
 
   useEffect(() => {
     if (!isSupported) return;
-
     setPermission(Notification.permission);
-
     navigator.serviceWorker.ready.then((reg) => {
       reg.pushManager.getSubscription().then((sub) => {
         setIsSubscribed(!!sub);
@@ -48,6 +51,10 @@ export function usePushNotifications(): UsePushNotificationsReturn {
 
   const subscribe = useCallback(async () => {
     if (!isSupported || isLoading) return;
+    if (!VAPID_PUBLIC_KEY) {
+      console.error('[Push] VITE_VAPID_PUBLIC_KEY is not set');
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -58,12 +65,11 @@ export function usePushNotifications(): UsePushNotificationsReturn {
         perm = await Notification.requestPermission();
         setPermission(perm);
       }
-
       if (perm !== 'granted') return;
 
       const sub = await reg.pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY!),
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
       });
 
       await fetch('/api/notifications/subscribe', {
@@ -91,7 +97,6 @@ export function usePushNotifications(): UsePushNotificationsReturn {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ endpoint: subscription.endpoint }),
       });
-
       await subscription.unsubscribe();
       setIsSubscribed(false);
       setSubscription(null);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import {
 import { useBenefitsData } from "../hooks/useBenefitsData";
 import { useEnrichedBusinesses } from "../hooks/useEnrichedBusinesses";
 import { CacheNotification } from "../components/CacheNotification";
+import { NotificationBanner } from "../components/NotificationBanner";
 import {
   SkeletonFeaturedBanner,
   SkeletonActiveOffers,
@@ -519,6 +520,7 @@ function Home() {
     <div className="min-h-screen bg-gray-50 pb-20 safe-area-inset">
       <SkipToContent targetId="main-content" />
       <Header />
+      <NotificationBanner />
       <LoadingAnnouncement
         isLoading={isLoading}
         message="Cargando ofertas y descuentos"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,8 +18,8 @@ import { usePushNotifications } from '../hooks/usePushNotifications';
 
 function HomePage() {
   const navigate = useNavigate();
-  const { isSupported, permission, isSubscribed, isLoading: notifLoading, subscribe, unsubscribe } = usePushNotifications();
-  const showBell = isSupported && permission !== 'denied';
+  const { isSupported, isSubscribed } = usePushNotifications();
+  const showBell = isSupported;
   const { businesses, isLoading } = useBenefitsData({});
   const { data: statsResponse } = useQuery({
     queryKey: ['home-ticker-active-benefits-count'],
@@ -129,10 +129,9 @@ function HomePage() {
           <div className="flex items-center gap-2">
             {showBell && (
               <button
-                onClick={() => isSubscribed ? unsubscribe() : subscribe()}
-                disabled={notifLoading}
-                aria-label={isSubscribed ? 'Desactivar notificaciones' : 'Activar notificaciones'}
-                className="w-9 h-9 rounded-xl flex items-center justify-center text-blink-muted hover:bg-blink-bg transition-colors disabled:opacity-50"
+                onClick={() => navigate('/notifications')}
+                aria-label="Ver notificaciones"
+                className="w-9 h-9 rounded-xl flex items-center justify-center text-blink-muted hover:bg-blink-bg transition-colors"
               >
                 <span className="material-symbols-outlined" style={{ fontSize: 22, fontVariationSettings: isSubscribed ? "'FILL' 1" : "'FILL' 0" }}>
                   notifications

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,9 +13,13 @@ import { formatDistance } from '../utils/distance';
 import { buildBankOptions, type BankDescriptor } from '../utils/banks';
 import { trackFilterApply, trackViewBenefit } from '../analytics/intentTracking';
 import InstallPWABanner from '../components/InstallPWAPopup';
+import { NotificationBanner } from '../components/NotificationBanner';
+import { usePushNotifications } from '../hooks/usePushNotifications';
 
 function HomePage() {
   const navigate = useNavigate();
+  const { isSupported, permission, isSubscribed, isLoading: notifLoading, subscribe, unsubscribe } = usePushNotifications();
+  const showBell = isSupported && permission !== 'denied';
   const { businesses, isLoading } = useBenefitsData({});
   const { data: statsResponse } = useQuery({
     queryKey: ['home-ticker-active-benefits-count'],
@@ -123,11 +127,18 @@ function HomePage() {
         <div className="h-14 flex items-center justify-between px-4">
           <div className="font-bold text-xl tracking-tight text-blink-ink">Blink</div>
           <div className="flex items-center gap-2">
-            <button className="w-9 h-9 rounded-xl flex items-center justify-center text-blink-muted hover:bg-blink-bg transition-colors">
-              <span className="material-symbols-outlined" style={{ fontSize: 22 }}>
-                notifications
-              </span>
-            </button>
+            {showBell && (
+              <button
+                onClick={() => isSubscribed ? unsubscribe() : subscribe()}
+                disabled={notifLoading}
+                aria-label={isSubscribed ? 'Desactivar notificaciones' : 'Activar notificaciones'}
+                className="w-9 h-9 rounded-xl flex items-center justify-center text-blink-muted hover:bg-blink-bg transition-colors disabled:opacity-50"
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: 22, fontVariationSettings: isSubscribed ? "'FILL' 1" : "'FILL' 0" }}>
+                  notifications
+                </span>
+              </button>
+            )}
             <div
               className="h-9 w-9 rounded-full overflow-hidden flex items-center justify-center"
               style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)' }}
@@ -141,6 +152,8 @@ function HomePage() {
         {/* Ticker */}
         <Ticker count={activeBenefitsCount} />
       </header>
+
+      <NotificationBanner />
 
       <main className="flex-1 flex flex-col gap-8 pb-32">
         {/* Hero Section */}

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Bell } from 'lucide-react';
+import { usePushNotifications } from '../hooks/usePushNotifications';
+import BottomNav from '../components/neo/BottomNav';
+
+interface StoredNotification {
+  _id: string;
+  title: string;
+  body: string;
+  url: string;
+  sentAt: string;
+}
+
+function groupByDay(notifications: StoredNotification[]): { label: string; items: StoredNotification[] }[] {
+  const map = new Map<string, StoredNotification[]>();
+
+  for (const n of notifications) {
+    const date = new Date(n.sentAt);
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+
+    let label: string;
+    if (date.toDateString() === today.toDateString()) {
+      label = 'Hoy';
+    } else if (date.toDateString() === yesterday.toDateString()) {
+      label = 'Ayer';
+    } else {
+      label = date.toLocaleDateString('es-AR', { weekday: 'long', day: 'numeric', month: 'long' });
+      label = label.charAt(0).toUpperCase() + label.slice(1);
+    }
+
+    if (!map.has(label)) map.set(label, []);
+    map.get(label)!.push(n);
+  }
+
+  return Array.from(map.entries()).map(([label, items]) => ({ label, items }));
+}
+
+function timeLabel(sentAt: string): string {
+  return new Date(sentAt).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function NotificationsPage() {
+  const navigate = useNavigate();
+  const { isSupported, permission, isSubscribed, isLoading, subscribe } = usePushNotifications();
+  const showBanner = isSupported && !isSubscribed && permission !== 'denied';
+
+  const [notifications, setNotifications] = useState<StoredNotification[]>([]);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/notifications/history')
+      .then((r) => r.json())
+      .then((data) => setNotifications(data.notifications ?? []))
+      .catch(() => {})
+      .finally(() => setFetching(false));
+  }, []);
+
+  const groups = groupByDay(notifications);
+
+  return (
+    <div className="bg-blink-bg text-blink-ink font-body min-h-screen flex flex-col overflow-x-hidden">
+      {/* Header */}
+      <header
+        className="sticky top-0 z-50 w-full"
+        style={{
+          background: 'rgba(255,255,255,0.92)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
+          borderBottom: '1px solid rgba(232,230,225,0.8)',
+        }}
+      >
+        <div className="h-14 flex items-center gap-3 px-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="w-9 h-9 rounded-xl flex items-center justify-center text-blink-muted hover:bg-blink-bg transition-colors"
+            aria-label="Volver"
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: 22 }}>arrow_back</span>
+          </button>
+          <h1 className="font-bold text-lg tracking-tight text-blink-ink flex-1">Notificaciones</h1>
+        </div>
+      </header>
+
+      <main className="flex-1 flex flex-col pb-32">
+        {/* Subscribe banner */}
+        {showBanner && (
+          <div className="mx-4 mt-4 rounded-2xl border border-blue-100 bg-blue-50 px-4 py-4 flex gap-3 items-start">
+            <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0 mt-0.5">
+              <Bell className="w-5 h-5 text-blue-600" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-blue-900 leading-snug">
+                No te pierdas ninguna notificación
+              </p>
+              <p className="text-xs text-blue-700 mt-0.5 leading-snug">
+                Activá las notificaciones y recibilas en tu teléfono cuando se envíen.
+              </p>
+              <button
+                onClick={subscribe}
+                disabled={isLoading}
+                className="mt-3 px-4 py-2 rounded-xl text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 active:bg-blue-800 disabled:opacity-60 transition-colors"
+              >
+                {isLoading ? 'Activando...' : 'Activar notificaciones'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        {fetching ? (
+          <div className="flex-1 flex flex-col gap-3 px-4 mt-6">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 rounded-2xl animate-pulse bg-gray-100" />
+            ))}
+          </div>
+        ) : notifications.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center gap-3 px-8 text-center py-20">
+            <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center">
+              <Bell className="w-8 h-8 text-gray-400" />
+            </div>
+            <p className="font-semibold text-blink-ink">Sin notificaciones aún</p>
+            <p className="text-sm text-blink-muted">Cuando se envíen notificaciones aparecerán acá.</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-6 px-4 mt-6">
+            {groups.map(({ label, items }) => (
+              <section key={label}>
+                <p className="text-xs font-semibold text-blink-muted uppercase tracking-wide mb-2 px-1">
+                  {label}
+                </p>
+                <div className="flex flex-col gap-2">
+                  {items.map((n) => (
+                    <button
+                      key={n._id}
+                      onClick={() => navigate(n.url.startsWith('/') ? n.url : '/')}
+                      className="w-full text-left rounded-2xl bg-white border border-gray-100 px-4 py-3 flex items-start gap-3 active:scale-[0.98] transition-transform"
+                      style={{ boxShadow: '0 1px 6px rgba(0,0,0,0.06)' }}
+                    >
+                      <div
+                        className="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5"
+                        style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)' }}
+                      >
+                        <Bell className="w-4 h-4 text-white" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="text-sm font-semibold text-blink-ink truncate">{n.title}</p>
+                          <span className="text-[11px] text-blink-muted flex-shrink-0">{timeLabel(n.sentAt)}</span>
+                        </div>
+                        {n.body && (
+                          <p className="text-xs text-blink-muted mt-0.5 line-clamp-2">{n.body}</p>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,8 @@ export default defineConfig(({ mode }) => {
         registerType: 'autoUpdate',
         includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
         workbox: {
+          // Pull in push notification event handlers
+          importScripts: ['sw-push.js'],
           // Smart caching for better mobile performance
           runtimeCaching: [
             {


### PR DESCRIPTION
- Add web-push dependency for server-side notification delivery
- Create public/sw-push.js: push + notificationclick service worker handlers (imported via workbox importScripts)
- Create src/hooks/usePushNotifications.ts: hook for permission, subscribe, unsubscribe
- Add POST /api/notifications/subscribe, /unsubscribe, /send API endpoints backed by MongoDB push_subscriptions collection
- Add getWritableDb() using MONGODB_URI for subscription persistence
- Wire notification bell into Header (BellOff when unsubscribed, filled Bell when active)
- Add scripts/generate-vapid-keys.mjs for one-time VAPID key generation
- Update .env.example with required VAPID and notification env vars

https://claude.ai/code/session_019H6p1eTqyfgS2TYdeRTiNa