### PR TITLE
Add Auth0 JWT verification and server-side favorites/banks sync

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -1,6 +1,6 @@
 import { MongoClient, ObjectId } from 'mongodb';
 import webpush from 'web-push';
-import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+import { createHmac, randomBytes, scryptSync, timingSafeEqual, createPublicKey, createVerify } from 'crypto';
 import { buildSearchDatasetFromMerchantDocs } from './search/entities.js';
 import { resolveIntentTagsFromTokens } from './search/dictionaries.js';
 import { meiliSearch, isMeilisearchConfigured } from './search/meilisearch.js';
@@ -87,6 +87,9 @@ const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || '';
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || '';
 const FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID || '';
 const FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET || '';
+const AUTH0_DOMAIN = (process.env.AUTH0_DOMAIN || process.env.VITE_AUTH0_DOMAIN || '').replace(/\/$/, '');
+
+const USER_DATA_COLLECTION = 'user_data';
 
 const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
 const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
@@ -156,6 +159,141 @@ function getAuthToken(req) {
   const auth = req.headers['authorization'] || '';
   if (auth.startsWith('Bearer ')) return auth.slice(7);
   return null;
+}
+
+const jwksCache = { keys: null, fetchedAt: 0 };
+const JWKS_TTL_MS = 60 * 60 * 1000;
+
+async function getAuth0Jwks() {
+  if (!AUTH0_DOMAIN) throw new Error('Auth0 domain not configured');
+  const now = Date.now();
+  if (jwksCache.keys && now - jwksCache.fetchedAt < JWKS_TTL_MS) return jwksCache.keys;
+  const res = await fetch(`https://${AUTH0_DOMAIN}/.well-known/jwks.json`);
+  if (!res.ok) throw new Error('Failed to fetch JWKS');
+  const data = await res.json();
+  jwksCache.keys = data.keys || [];
+  jwksCache.fetchedAt = now;
+  return jwksCache.keys;
+}
+
+async function verifyAuth0Jwt(token) {
+  const parts = (token || '').split('.');
+  if (parts.length !== 3) throw new Error('Invalid token');
+  const [headerB64, payloadB64, sigB64] = parts;
+  const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString());
+  const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+
+  if (!payload.exp || payload.exp * 1000 < Date.now()) throw new Error('Token expired');
+  if (!payload.iss || !AUTH0_DOMAIN || !payload.iss.includes(AUTH0_DOMAIN)) throw new Error('Invalid issuer');
+  if (header.alg !== 'RS256') throw new Error('Unsupported algorithm');
+
+  const keys = await getAuth0Jwks();
+  const jwk = keys.find((k) => k.kid === header.kid && (k.use === 'sig' || !k.use));
+  if (!jwk) throw new Error('Signing key not found');
+
+  const pubKey = createPublicKey({ key: jwk, format: 'jwk' });
+  const verifier = createVerify('SHA256');
+  verifier.update(`${headerB64}.${payloadB64}`);
+  const ok = verifier.verify(pubKey, Buffer.from(sigB64, 'base64url'));
+  if (!ok) throw new Error('Invalid signature');
+  return payload;
+}
+
+async function getUserIdFromRequest(req) {
+  const token = getAuthToken(req);
+  if (!token) return null;
+  try {
+    const payload = verifyJwt(token);
+    if (payload && payload.sub) return String(payload.sub);
+  } catch {
+    // not a local JWT
+  }
+  try {
+    const payload = await verifyAuth0Jwt(token);
+    if (payload && payload.sub) return String(payload.sub);
+  } catch {
+    // not a valid Auth0 JWT
+  }
+  return null;
+}
+
+async function getUserDataCollection() {
+  const db = await getWriteDb();
+  const col = db.collection(USER_DATA_COLLECTION);
+  await col.createIndex({ userId: 1 }, { unique: true }).catch(() => {});
+  return col;
+}
+
+async function handleGetUserFavorites(req, res) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return json(res, 401, { error: 'No autenticado' });
+  const col = await getUserDataCollection();
+  const doc = await col.findOne({ userId }, { projection: { favoriteMerchantIds: 1 } });
+  return json(res, 200, { success: true, favoriteMerchantIds: doc?.favoriteMerchantIds ?? [] });
+}
+
+async function handleAddUserFavorite(req, res) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return json(res, 401, { error: 'No autenticado' });
+  const body = await readJsonBody(req);
+  const merchantId = body?.merchantId;
+  if (!merchantId || typeof merchantId !== 'string') {
+    return json(res, 400, { error: 'merchantId requerido' });
+  }
+  const col = await getUserDataCollection();
+  await col.updateOne(
+    { userId },
+    {
+      $addToSet: { favoriteMerchantIds: merchantId },
+      $setOnInsert: { userId, createdAt: new Date() },
+      $set: { updatedAt: new Date() }
+    },
+    { upsert: true }
+  );
+  const doc = await col.findOne({ userId }, { projection: { favoriteMerchantIds: 1 } });
+  return json(res, 200, { success: true, favoriteMerchantIds: doc?.favoriteMerchantIds ?? [] });
+}
+
+async function handleRemoveUserFavorite(req, res, merchantId) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return json(res, 401, { error: 'No autenticado' });
+  if (!merchantId) return json(res, 400, { error: 'merchantId requerido' });
+  const col = await getUserDataCollection();
+  await col.updateOne(
+    { userId },
+    { $pull: { favoriteMerchantIds: merchantId }, $set: { updatedAt: new Date() } }
+  );
+  const doc = await col.findOne({ userId }, { projection: { favoriteMerchantIds: 1 } });
+  return json(res, 200, { success: true, favoriteMerchantIds: doc?.favoriteMerchantIds ?? [] });
+}
+
+async function handleGetUserBanks(req, res) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return json(res, 401, { error: 'No autenticado' });
+  const col = await getUserDataCollection();
+  const doc = await col.findOne({ userId }, { projection: { savedBankCodes: 1 } });
+  return json(res, 200, { success: true, savedBankCodes: doc?.savedBankCodes ?? [] });
+}
+
+async function handleUpdateUserBanks(req, res) {
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) return json(res, 401, { error: 'No autenticado' });
+  const body = await readJsonBody(req);
+  const banks = body?.banks;
+  if (!Array.isArray(banks) || banks.some((b) => typeof b !== 'string')) {
+    return json(res, 400, { error: 'banks debe ser un array de strings' });
+  }
+  const unique = Array.from(new Set(banks.map((b) => b.trim()).filter(Boolean)));
+  const col = await getUserDataCollection();
+  await col.updateOne(
+    { userId },
+    {
+      $set: { savedBankCodes: unique, updatedAt: new Date() },
+      $setOnInsert: { userId, createdAt: new Date() }
+    },
+    { upsert: true }
+  );
+  return json(res, 200, { success: true, savedBankCodes: unique });
 }
 
 function buildOAuthState() {
@@ -2903,6 +3041,29 @@ export default async function handler(req, res) {
 
     if (req.method === 'GET' && path === '/api/auth/facebook/callback') {
       return await handleFacebookCallback(req, res, url);
+    }
+
+    if (req.method === 'GET' && path === '/api/user/favorites') {
+      return await handleGetUserFavorites(req, res);
+    }
+
+    if (req.method === 'POST' && path === '/api/user/favorites') {
+      return await handleAddUserFavorite(req, res);
+    }
+
+    if (req.method === 'DELETE') {
+      const favoriteMatch = path.match(/^\/api\/user\/favorites\/([^/]+)$/);
+      if (favoriteMatch) {
+        return await handleRemoveUserFavorite(req, res, decodeURIComponent(favoriteMatch[1]));
+      }
+    }
+
+    if (req.method === 'GET' && path === '/api/user/banks') {
+      return await handleGetUserBanks(req, res);
+    }
+
+    if (req.method === 'PUT' && path === '/api/user/banks') {
+      return await handleUpdateUserBanks(req, res);
     }
 
     if (req.method === 'GET') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import UpdatePrompt from './components/UpdatePrompt';
 import { useResponsive } from './hooks/useResponsive';
 import PhoneMirror from './components/PhoneMirror';
 import { AuthProvider } from './contexts/AuthContext';
+import { FavoritesProvider } from './context/FavoritesContext';
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -96,7 +97,9 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-        <AppContent />
+        <FavoritesProvider>
+          <AppContent />
+        </FavoritesProvider>
       </AuthProvider>
     </Router>
   );

--- a/src/components/BusinessCard.tsx
+++ b/src/components/BusinessCard.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { MapPin } from "lucide-react";
 import { Business } from "../types";
 import { BBVALogo, SantanderLogo, GaliciaLogo, NacionLogo } from "./BankLogos";
 import { useFavorites } from "../context/FavoritesContext";
+import { useAuth } from "../contexts/AuthContext";
 
 export interface PaymentMethod {
   type: "bbva" | "santander" | "galicia" | "nacion";
@@ -24,6 +26,8 @@ const BusinessCard: React.FC<BusinessCardProps> = React.memo(({
   style,
 }) => {
   const { isFavorite, toggleFavorite } = useFavorites();
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
   const getPaymentMethods = (business: Business): PaymentMethod[] => {
     const methods: PaymentMethod[] = [];
 
@@ -195,9 +199,19 @@ const BusinessCard: React.FC<BusinessCardProps> = React.memo(({
         className="absolute top-2 right-2 w-7 h-7 flex items-center justify-center rounded-full transition-colors active:scale-90 z-10"
         onClick={(e) => {
           e.stopPropagation();
+          if (!isAuthenticated) {
+            navigate('/login');
+            return;
+          }
           toggleFavorite(business);
         }}
-        aria-label={isFavorite(business.id) ? 'Quitar de guardados' : 'Guardar'}
+        aria-label={
+          !isAuthenticated
+            ? 'Iniciá sesión para guardar'
+            : isFavorite(business.id)
+              ? 'Quitar de guardados'
+              : 'Guardar'
+        }
       >
         <span
           className="material-symbols-outlined"

--- a/src/components/MerchantCard.tsx
+++ b/src/components/MerchantCard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Business } from '../types';
 import { toBankDescriptor } from '../utils/banks';
 import { useFavorites } from '../context/FavoritesContext';
+import { useAuth } from '../contexts/AuthContext';
 import { formatDistance } from '../utils/distance';
 
 interface MerchantCardProps {
@@ -46,6 +48,8 @@ const getBankBadges = (business: Business): string[] => {
 
 const MerchantCard: React.FC<MerchantCardProps> = React.memo(({ business, onClick }) => {
   const { isFavorite, toggleFavorite } = useFavorites();
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
   const favorited = isFavorite(business.id);
 
   const bankBadges = getBankBadges(business);
@@ -136,9 +140,19 @@ const MerchantCard: React.FC<MerchantCardProps> = React.memo(({ business, onClic
           className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full transition-colors active:scale-90"
           onClick={(e) => {
             e.stopPropagation();
+            if (!isAuthenticated) {
+              navigate('/login');
+              return;
+            }
             toggleFavorite(business);
           }}
-          aria-label={favorited ? 'Quitar de guardados' : 'Guardar'}
+          aria-label={
+            !isAuthenticated
+              ? 'Iniciá sesión para guardar'
+              : favorited
+                ? 'Quitar de guardados'
+                : 'Guardar'
+          }
         >
           <span
             className="material-symbols-outlined"

--- a/src/context/FavoritesContext.tsx
+++ b/src/context/FavoritesContext.tsx
@@ -1,9 +1,11 @@
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 import { Business } from '../types';
+import { useAuth } from '../contexts/AuthContext';
 
 const STORAGE_KEY = 'blink_favorites';
+const TOKEN_KEY = 'blink_id_token';
 
-function loadFavorites(): Business[] {
+function loadCache(): Business[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     return raw ? (JSON.parse(raw) as Business[]) : [];
@@ -12,42 +14,115 @@ function loadFavorites(): Business[] {
   }
 }
 
-function persistFavorites(favorites: Business[]) {
+function persistCache(favorites: Business[]) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
   } catch {
-    // Storage quota exceeded — silently ignore
+    // ignore quota errors
   }
+}
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem(TOKEN_KEY);
+  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 interface FavoritesContextValue {
   favorites: Business[];
   isFavorite: (id: string) => boolean;
-  toggleFavorite: (business: Business) => void;
+  toggleFavorite: (business: Business) => boolean;
+  requiresAuth: boolean;
 }
 
 const FavoritesContext = createContext<FavoritesContextValue | null>(null);
 
 export function FavoritesProvider({ children }: { children: React.ReactNode }) {
-  const [favorites, setFavorites] = useState<Business[]>(loadFavorites);
+  const { isAuthenticated, user } = useAuth();
+  const [favorites, setFavorites] = useState<Business[]>(loadCache);
+  const lastUserId = useRef<string | null>(null);
+
+  // Sync from server when authenticated; clear locally when logged out.
+  useEffect(() => {
+    if (!isAuthenticated || !user) {
+      if (lastUserId.current !== null) {
+        setFavorites([]);
+        persistCache([]);
+        lastUserId.current = null;
+      }
+      return;
+    }
+
+    if (lastUserId.current === user.id) return;
+    lastUserId.current = user.id;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/user/favorites', { headers: authHeaders() });
+        if (!res.ok) return;
+        const data = (await res.json()) as { favoriteMerchantIds?: string[] };
+        const serverIds = new Set(data.favoriteMerchantIds ?? []);
+        if (cancelled) return;
+        setFavorites((prev) => {
+          const byId = new Map(prev.map((b) => [b.id, b]));
+          const merged = Array.from(serverIds)
+            .map((id) => byId.get(id))
+            .filter((b): b is Business => Boolean(b));
+          // Keep any cached business records that match server IDs; drop the rest.
+          persistCache(merged);
+          return merged;
+        });
+      } catch {
+        // network failure — keep local cache as-is
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, user]);
 
   const isFavorite = useCallback(
     (id: string) => favorites.some((b) => b.id === id),
     [favorites],
   );
 
-  const toggleFavorite = useCallback((business: Business) => {
-    setFavorites((prev) => {
-      const next = prev.some((b) => b.id === business.id)
-        ? prev.filter((b) => b.id !== business.id)
-        : [...prev, business];
-      persistFavorites(next);
-      return next;
-    });
-  }, []);
+  const toggleFavorite = useCallback(
+    (business: Business): boolean => {
+      if (!isAuthenticated) return false;
+
+      let added = false;
+      setFavorites((prev) => {
+        const exists = prev.some((b) => b.id === business.id);
+        added = !exists;
+        const next = exists
+          ? prev.filter((b) => b.id !== business.id)
+          : [...prev, business];
+        persistCache(next);
+        return next;
+      });
+
+      const url = added
+        ? '/api/user/favorites'
+        : `/api/user/favorites/${encodeURIComponent(business.id)}`;
+      const init: RequestInit = {
+        method: added ? 'POST' : 'DELETE',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: added ? JSON.stringify({ merchantId: business.id }) : undefined,
+      };
+      fetch(url, init).catch(() => {
+        // best-effort sync; local state remains authoritative until next reload
+      });
+
+      return true;
+    },
+    [isAuthenticated],
+  );
 
   return (
-    <FavoritesContext.Provider value={{ favorites, isFavorite, toggleFavorite }}>
+    <FavoritesContext.Provider
+      value={{ favorites, isFavorite, toggleFavorite, requiresAuth: !isAuthenticated }}
+    >
       {children}
     </FavoritesContext.Provider>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Auth0Provider } from '@auth0/auth0-react';
 import App from './App.tsx';
-import { FavoritesProvider } from './context/FavoritesContext.tsx';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -29,9 +28,7 @@ createRoot(document.getElementById('root')!).render(
       cacheLocation="localstorage"
     >
       <QueryClientProvider client={queryClient}>
-        <FavoritesProvider>
-          <App />
-        </FavoritesProvider>
+        <App />
       </QueryClientProvider>
     </Auth0Provider>
   </StrictMode>

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -7,6 +7,7 @@ import { getBankAccent } from '../utils/bankColors';
 import { useSEO } from '../hooks/useSEO';
 import { SkeletonBusinessDetailPage } from '../components/skeletons';
 import { useFavorites } from '../context/FavoritesContext';
+import { useAuth } from '../contexts/AuthContext';
 import { getMerchantSeoPath, parseMerchantSeoParam } from '../seo/merchantUrls';
 
 const ALL_DAYS = ['lunes', 'martes', 'miércoles', 'miercoles', 'jueves', 'viernes', 'sábado', 'sabado', 'domingo'];
@@ -104,6 +105,7 @@ function BusinessDetailPage() {
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const [filterToday, setFilterToday] = useState(false);
   const { isFavorite, toggleFavorite } = useFavorites();
+  const { isAuthenticated } = useAuth();
 
   const sortedBenefits = useMemo(() => {
     if (!business) return [];
@@ -346,8 +348,20 @@ function BusinessDetailPage() {
 
           <button
             className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
-            onClick={() => toggleFavorite(business)}
-            aria-label={isFavorite(business.id) ? 'Quitar de guardados' : 'Guardar'}
+            onClick={() => {
+              if (!isAuthenticated) {
+                navigate('/login');
+                return;
+              }
+              toggleFavorite(business);
+            }}
+            aria-label={
+              !isAuthenticated
+                ? 'Iniciá sesión para guardar'
+                : isFavorite(business.id)
+                  ? 'Quitar de guardados'
+                  : 'Guardar'
+            }
           >
             <span
               className="material-symbols-outlined"

--- a/src/pages/SavedPage.tsx
+++ b/src/pages/SavedPage.tsx
@@ -2,10 +2,12 @@ import { useNavigate } from 'react-router-dom';
 import BottomNav from '../components/neo/BottomNav';
 import MerchantCard from '../components/MerchantCard';
 import { useFavorites } from '../context/FavoritesContext';
+import { useAuth } from '../contexts/AuthContext';
 import { Business } from '../types';
 
 function SavedPage() {
   const { favorites } = useFavorites();
+  const { isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
   const handleSelect = (business: Business) => {
@@ -29,7 +31,36 @@ function SavedPage() {
       </header>
 
       <main className="flex-1 flex flex-col pb-28">
-        {favorites.length === 0 ? (
+        {!isAuthenticated ? (
+          <div className="flex-1 flex flex-col items-center justify-center gap-5 px-8 py-16">
+            <div
+              className="w-20 h-20 rounded-2xl flex items-center justify-center"
+              style={{ background: 'linear-gradient(135deg, #EEF2FF 0%, #C7D2FE 100%)' }}
+            >
+              <span
+                className="material-symbols-outlined"
+                style={{ fontSize: 40, color: '#6366F1', fontVariationSettings: "'FILL' 0" }}
+              >
+                lock_open
+              </span>
+            </div>
+            <div className="text-center">
+              <p className="font-semibold text-base text-blink-ink mb-1">
+                Creá tu cuenta para guardar comercios
+              </p>
+              <p className="text-sm text-blink-muted max-w-xs">
+                Iniciá sesión para guardar tus comercios favoritos y sincronizarlos en todos tus dispositivos.
+              </p>
+            </div>
+            <button
+              onClick={() => navigate('/login')}
+              className="mt-2 h-11 px-6 rounded-xl font-semibold text-sm text-white transition-all duration-150 active:scale-95"
+              style={{ background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)' }}
+            >
+              Iniciar sesión
+            </button>
+          </div>
+        ) : favorites.length === 0 ? (
           <div className="flex-1 flex flex-col items-center justify-center gap-5 px-8 py-16">
             <div
               className="w-20 h-20 rounded-2xl flex items-center justify-center"

--- a/src/pages/__tests__/BusinessDetailPage.test.tsx
+++ b/src/pages/__tests__/BusinessDetailPage.test.tsx
@@ -28,7 +28,16 @@ vi.mock('../../hooks/useSEO', () => ({
 vi.mock('../../context/FavoritesContext', () => ({
   useFavorites: () => ({
     isFavorite: vi.fn(() => false),
-    toggleFavorite: vi.fn()
+    toggleFavorite: vi.fn(),
+    favorites: [],
+    requiresAuth: false
+  })
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 'test-user', name: 'Test', email: 'test@example.com' }
   })
 }));
 


### PR DESCRIPTION
## Summary
This PR adds Auth0 JWT token verification to the backend and implements server-side persistence of user favorites and saved banks, with client-side caching and synchronization.

## Key Changes

### Backend (api/[...path].js)
- Added Auth0 JWT verification with JWKS caching (1-hour TTL)
- Implemented `verifyAuth0Jwt()` to validate RS256-signed tokens with issuer and expiration checks
- Added `getUserIdFromRequest()` to extract user ID from either local or Auth0 JWTs
- Created `user_data` MongoDB collection with userId unique index for storing user preferences
- Implemented four new API endpoints:
  - `GET /api/user/favorites` - retrieve user's favorite merchant IDs
  - `POST /api/user/favorites` - add a merchant to favorites
  - `DELETE /api/user/favorites/:merchantId` - remove a merchant from favorites
  - `GET /api/user/banks` - retrieve user's saved bank codes
  - `PUT /api/user/banks` - update user's saved bank codes
- All endpoints require authentication and return 401 if user is not authenticated

### Frontend (FavoritesContext.tsx)
- Refactored to sync with server when user authenticates
- Added `useEffect` hook that fetches favorites from server on login and clears on logout
- Modified `toggleFavorite()` to return boolean and make async API calls (POST/DELETE)
- Added `requiresAuth` flag to context to indicate when authentication is required
- Implemented local cache persistence with server-side merge on authentication
- Best-effort sync: local state remains authoritative if network requests fail

### UI Components
- Updated `SavedPage.tsx` to show login prompt when not authenticated
- Modified `BusinessDetailPage.tsx` to redirect to login when favoriting without auth
- Updated `BusinessCard.tsx` and `MerchantCard.tsx` to require login before favoriting
- Updated aria-labels to indicate login requirement when not authenticated

### App Structure
- Moved `FavoritesProvider` from `main.tsx` to `App.tsx` to ensure it wraps components after `AuthProvider`
- This ensures `FavoritesContext` can access `useAuth()` hook

### Testing
- Updated `BusinessDetailPage.test.tsx` to mock `AuthContext` and include required context properties

## Implementation Details
- Auth0 JWKS are cached in memory with 1-hour TTL to minimize external API calls
- User data is stored with `createdAt` and `updatedAt` timestamps
- Favorites are stored as an array of merchant IDs; the context reconstructs Business objects from cache
- Server-side merge on login keeps only cached businesses that match server IDs
- All user data operations are upsert-based to handle first-time users gracefully

https://claude.ai/code/session_01NgQmz7gomzMkXPDx5kV6LC