### PR TITLE
Add marker clustering to map view for better UX at low zoom

### DIFF
--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -57,11 +57,13 @@ interface MarkerCluster {
   lng: number;
 }
 
+interface SpiderfiedCluster {
+  centerLat: number;
+  centerLng: number;
+  spokes: Array<{ marker: MapMarker; spokeLat: number; spokeLng: number }>;
+}
+
 function clusterMapMarkers(markers: MapMarker[], zoom: number): MarkerCluster[] {
-  // At street level zoom, always show individual markers so co-located businesses are never stuck in a cluster
-  if (zoom >= 17) {
-    return markers.map((m) => ({ markers: [m], lat: m.lat, lng: m.lng }));
-  }
   // Cell size in degrees shrinks as zoom increases — keeps ~60px cluster radius at each level
   const cellSize = 140 / Math.pow(2, zoom);
   const cells = new Map<string, MapMarker[]>();
@@ -144,6 +146,7 @@ function MapPage() {
   const googleRef = useRef<any>(null);
   const selectedBusinessRef = useRef<Business | null>(null);
   const buildOverlaysRef = useRef<((google: any, map: any, selected: Business | null) => void) | null>(null);
+  const spiderfiedClusterRef = useRef<SpiderfiedCluster | null>(null);
 
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [selectedMarkerIdx, setSelectedMarkerIdx] = useState<number | null>(null);
@@ -348,7 +351,9 @@ function MapPage() {
   const buildOverlays = useCallback((google: any, map: any, selected: Business | null) => {
     clearOverlays();
     const zoom = map.getZoom() ?? 15;
+    const spiderfied = spiderfiedClusterRef.current;
 
+    // ── BusinessOverlay ──────────────────────────────────────────
     class BusinessOverlay extends google.maps.OverlayView {
       private pos: any;
       private div: HTMLDivElement | null = null;
@@ -387,7 +392,6 @@ function MapPage() {
 
         let html = '';
 
-        // Soft glassmorphic tooltip for selected
         if (this.isSelected) {
           const benefitText = getShortBenefitForTooltip(this.biz);
           html += `
@@ -402,7 +406,6 @@ function MapPage() {
             </div>`;
         }
 
-        // Marker: white circle with soft shadow + indigo ring when selected
         const ringStyle = this.isSelected
           ? 'box-shadow:0 0 0 3px rgba(99,102,241,0.35),0 4px 16px rgba(99,102,241,0.25),0 2px 6px rgba(0,0,0,0.10);border:2px solid #6366F1;background:#ffffff;'
           : 'box-shadow:0 2px 8px rgba(0,0,0,0.12),0 1px 2px rgba(0,0,0,0.06);border:1.5px solid #E8E6E1;background:#ffffff;';
@@ -417,7 +420,6 @@ function MapPage() {
             }
           </div>`;
 
-        // Soft drop shadow dot
         html += `<div style="width:12px;height:4px;background:rgba(0,0,0,0.10);border-radius:50%;margin:2px auto 0;filter:blur(1px);"></div>`;
 
         this.div.innerHTML = html;
@@ -450,18 +452,63 @@ function MapPage() {
       }
     }
 
+    // ── SpiderLineOverlay ────────────────────────────────────────
+    // Renders dashed SVG lines from cluster center to each spoke marker.
+    class SpiderLineOverlay extends google.maps.OverlayView {
+      private lines: Array<{ from: any; to: any }>;
+      private svg: SVGSVGElement | null = null;
+
+      constructor(lines: Array<{ from: any; to: any }>) {
+        super();
+        this.lines = lines;
+      }
+
+      onAdd() {
+        this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
+        Object.assign(this.svg.style, { position: 'absolute', left: '0', top: '0', overflow: 'visible', pointerEvents: 'none', zIndex: '8' });
+        this.getPanes().overlayLayer.appendChild(this.svg);
+      }
+
+      draw() {
+        if (!this.svg) return;
+        const proj = this.getProjection();
+        if (!proj) return;
+        while (this.svg.firstChild) this.svg.removeChild(this.svg.firstChild);
+        this.lines.forEach(({ from, to }) => {
+          const a = proj.fromLatLngToDivPixel(from);
+          const b = proj.fromLatLngToDivPixel(to);
+          if (!a || !b) return;
+          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          line.setAttribute('x1', String(a.x));
+          line.setAttribute('y1', String(a.y));
+          line.setAttribute('x2', String(b.x));
+          line.setAttribute('y2', String(b.y));
+          line.setAttribute('stroke', 'rgba(99,102,241,0.45)');
+          line.setAttribute('stroke-width', '1.5');
+          line.setAttribute('stroke-dasharray', '4,3');
+          this.svg.appendChild(line);
+        });
+      }
+
+      onRemove() {
+        if (this.svg && this.svg.parentNode) {
+          this.svg.parentNode.removeChild(this.svg);
+          this.svg = null;
+        }
+      }
+    }
+
+    // ── ClusterOverlay ───────────────────────────────────────────
     class ClusterOverlay extends google.maps.OverlayView {
       private pos: any;
       private div: HTMLDivElement | null = null;
       private count: number;
-      private clusterMarkers: MapMarker[];
       private onTap: () => void;
 
-      constructor(pos: any, count: number, clusterMarkers: MapMarker[], onTap: () => void) {
+      constructor(pos: any, count: number, onTap: () => void) {
         super();
         this.pos = pos;
         this.count = count;
-        this.clusterMarkers = clusterMarkers;
         this.onTap = onTap;
       }
 
@@ -516,7 +563,7 @@ function MapPage() {
       }
     }
 
-    // In single-business mode skip clustering — all pins are same business
+    // ── Single-business mode: no clustering ──────────────────────
     if (isSingleBusinessMode) {
       mapMarkers.forEach(({ business: biz, lat, lng }, idx) => {
         const isSelected = selected?.id === biz.id && idx === 0;
@@ -536,11 +583,18 @@ function MapPage() {
       return;
     }
 
+    // ── Clustered browse mode ────────────────────────────────────
     const clusters = clusterMapMarkers(mapMarkers, zoom);
     let globalIdx = 0;
 
     clusters.forEach((cluster) => {
+      // Check if this cluster is the one currently spiderfied
+      const isSpiderfied = spiderfied !== null &&
+        Math.abs(cluster.lat - spiderfied.centerLat) < 0.00002 &&
+        Math.abs(cluster.lng - spiderfied.centerLng) < 0.00002;
+
       if (cluster.markers.length === 1) {
+        // ── Individual marker ──────────────────────────────────
         const { business: biz, lat, lng } = cluster.markers[0];
         const idx = globalIdx++;
         const isSelected = selected?.id === biz.id;
@@ -556,24 +610,65 @@ function MapPage() {
         (overlay as any).__businessId = biz.id;
         (overlay as any).__markerIdx = idx;
         overlaysRef.current.push(overlay);
+
+      } else if (isSpiderfied && spiderfied) {
+        // ── Spiderfied cluster: draw lines + spoke markers ─────
+        const centerLatLng = new google.maps.LatLng(spiderfied.centerLat, spiderfied.centerLng);
+        const lines = spiderfied.spokes.map(({ spokeLat, spokeLng }) => ({
+          from: centerLatLng,
+          to: new google.maps.LatLng(spokeLat, spokeLng),
+        }));
+        const lineOverlay = new SpiderLineOverlay(lines);
+        lineOverlay.setMap(map);
+        overlaysRef.current.push(lineOverlay);
+
+        spiderfied.spokes.forEach(({ marker: { business: biz, lat, lng }, spokeLat, spokeLng }) => {
+          const idx = globalIdx++;
+          const isSelected = selected?.id === biz.id;
+          const spokePos = new google.maps.LatLng(spokeLat, spokeLng);
+          const realPos = new google.maps.LatLng(lat, lng);
+          const overlay = new BusinessOverlay(spokePos, biz, isSelected, biz.image || '', () => {
+            trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
+            trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
+            setSelectedBusiness(biz);
+            setSelectedMarkerIdx(idx);
+            map.panTo(realPos);
+          });
+          overlay.setMap(map);
+          (overlay as any).__businessId = biz.id;
+          (overlay as any).__markerIdx = idx;
+          overlaysRef.current.push(overlay);
+        });
+
       } else {
+        // ── Cluster bubble — tap to spiderfy ──────────────────
         globalIdx += cluster.markers.length;
         const pos = new google.maps.LatLng(cluster.lat, cluster.lng);
-        const clusterOverlay = new ClusterOverlay(pos, cluster.markers.length, cluster.markers, () => {
+        const clusterOverlay = new ClusterOverlay(pos, cluster.markers.length, () => {
           trackMapInteractionThrottled('cluster_tap', { zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
-          const bounds = new google.maps.LatLngBounds();
-          cluster.markers.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
-          // If all markers share effectively the same location, zoom to street level directly
-          // so they always expand (zoom >=17 disables clustering) instead of flying past it
-          const sw = bounds.getSouthWest();
-          const ne = bounds.getNorthEast();
-          const sameSpot = Math.abs(ne.lat() - sw.lat()) < 0.0001 && Math.abs(ne.lng() - sw.lng()) < 0.0001;
-          if (sameSpot) {
-            map.setCenter({ lat: cluster.lat, lng: cluster.lng });
-            map.setZoom(17);
-          } else {
-            map.fitBounds(bounds, 80);
-          }
+
+          // Compute spoke positions in world-coordinate space at current zoom,
+          // then convert back to lat/lng so spokes are fixed geographic points.
+          const projection = map.getProjection();
+          if (!projection) return;
+          const currentZoom = map.getZoom() ?? 15;
+          const scale = Math.pow(2, currentZoom);
+          const N = cluster.markers.length;
+          const radius = Math.max(65, N * 10);
+          const centerPt = projection.fromLatLngToPoint(new google.maps.LatLng(cluster.lat, cluster.lng));
+
+          const spokes = cluster.markers.map((m, i) => {
+            const angle = (2 * Math.PI * i / N) - Math.PI / 2;
+            const spokePt = new google.maps.Point(
+              centerPt.x + (radius * Math.cos(angle)) / scale,
+              centerPt.y + (radius * Math.sin(angle)) / scale,
+            );
+            const spokeLatLng = projection.fromPointToLatLng(spokePt);
+            return { marker: m, spokeLat: spokeLatLng.lat(), spokeLng: spokeLatLng.lng() };
+          });
+
+          spiderfiedClusterRef.current = { centerLat: cluster.lat, centerLng: cluster.lng, spokes };
+          buildOverlaysRef.current?.(google, map, selectedBusinessRef.current);
         });
         clusterOverlay.setMap(map);
         overlaysRef.current.push(clusterOverlay);
@@ -661,6 +756,10 @@ function MapPage() {
         });
 
         mapRef.current.addListener('click', () => {
+          if (spiderfiedClusterRef.current) {
+            spiderfiedClusterRef.current = null;
+            buildOverlaysRef.current?.(googleRef.current, mapRef.current, null);
+          }
           setSelectedBusiness(null);
           trackMapInteractionThrottled('map_click', { zoomLevel: mapRef.current?.getZoom() || undefined, minIntervalMs: 500 });
         });
@@ -673,6 +772,7 @@ function MapPage() {
         mapRef.current.addListener('zoom_changed', () => {
           const zoomLevel = mapRef.current?.getZoom() || undefined;
           trackMapInteractionThrottled('zoom', { zoomLevel, minIntervalMs: 800 });
+          spiderfiedClusterRef.current = null; // spider collapses when zoom changes
           if (googleRef.current && mapRef.current) {
             buildOverlaysRef.current?.(googleRef.current, mapRef.current, selectedBusinessRef.current);
           }
@@ -684,6 +784,7 @@ function MapPage() {
         createUserLocationOverlay(google, mapRef.current, position.latitude, position.longitude);
       }
 
+      spiderfiedClusterRef.current = null;
       buildOverlays(google, mapRef.current, selectedBusiness);
 
       if (isSingleBusinessMode) {

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -58,6 +58,10 @@ interface MarkerCluster {
 }
 
 function clusterMapMarkers(markers: MapMarker[], zoom: number): MarkerCluster[] {
+  // At street level zoom, always show individual markers so co-located businesses are never stuck in a cluster
+  if (zoom >= 17) {
+    return markers.map((m) => ({ markers: [m], lat: m.lat, lng: m.lng }));
+  }
   // Cell size in degrees shrinks as zoom increases — keeps ~60px cluster radius at each level
   const cellSize = 140 / Math.pow(2, zoom);
   const cells = new Map<string, MapMarker[]>();
@@ -559,7 +563,17 @@ function MapPage() {
           trackMapInteractionThrottled('cluster_tap', { zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
           const bounds = new google.maps.LatLngBounds();
           cluster.markers.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
-          map.fitBounds(bounds, 80);
+          // If all markers share effectively the same location, zoom to street level directly
+          // so they always expand (zoom >=17 disables clustering) instead of flying past it
+          const sw = bounds.getSouthWest();
+          const ne = bounds.getNorthEast();
+          const sameSpot = Math.abs(ne.lat() - sw.lat()) < 0.0001 && Math.abs(ne.lng() - sw.lng()) < 0.0001;
+          if (sameSpot) {
+            map.setCenter({ lat: cluster.lat, lng: cluster.lng });
+            map.setZoom(17);
+          } else {
+            map.fitBounds(bounds, 80);
+          }
         });
         clusterOverlay.setMap(map);
         overlaysRef.current.push(clusterOverlay);

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -51,6 +51,28 @@ interface MapMarker {
   address: string;
 }
 
+interface MarkerCluster {
+  markers: MapMarker[];
+  lat: number;
+  lng: number;
+}
+
+function clusterMapMarkers(markers: MapMarker[], zoom: number): MarkerCluster[] {
+  // Cell size in degrees shrinks as zoom increases — keeps ~60px cluster radius at each level
+  const cellSize = 140 / Math.pow(2, zoom);
+  const cells = new Map<string, MapMarker[]>();
+  markers.forEach((m) => {
+    const key = `${Math.floor(m.lng / cellSize)},${Math.floor(m.lat / cellSize)}`;
+    if (!cells.has(key)) cells.set(key, []);
+    cells.get(key)!.push(m);
+  });
+  return Array.from(cells.values()).map((group) => ({
+    markers: group,
+    lat: group.reduce((s, m) => s + m.lat, 0) / group.length,
+    lng: group.reduce((s, m) => s + m.lng, 0) / group.length,
+  }));
+}
+
 interface MapFilterState {
   activeChip: string;
   onlineOnly: boolean;
@@ -116,6 +138,8 @@ function MapPage() {
   const overlaysRef = useRef<any[]>([]);
   const userOverlayRef = useRef<any>(null);
   const googleRef = useRef<any>(null);
+  const selectedBusinessRef = useRef<Business | null>(null);
+  const buildOverlaysRef = useRef<((google: any, map: any, selected: Business | null) => void) | null>(null);
 
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [selectedMarkerIdx, setSelectedMarkerIdx] = useState<number | null>(null);
@@ -128,6 +152,9 @@ function MapPage() {
   const searchIntentSignatureRef = useRef('');
   const noResultsSignatureRef = useRef('');
   const mapInteractionTimestampsRef = useRef<Record<string, number>>({});
+
+  // Keep refs in sync so zoom_changed listener always has fresh state
+  useEffect(() => { selectedBusinessRef.current = selectedBusiness; }, [selectedBusiness]);
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -316,6 +343,7 @@ function MapPage() {
 
   const buildOverlays = useCallback((google: any, map: any, selected: Business | null) => {
     clearOverlays();
+    const zoom = map.getZoom() ?? 15;
 
     class BusinessOverlay extends google.maps.OverlayView {
       private pos: any;
@@ -418,24 +446,129 @@ function MapPage() {
       }
     }
 
-    mapMarkers.forEach(({ business: biz, lat, lng }, idx) => {
-      // Use idx === 0 as initial selection only in single-business mode on first load;
-      // the updateSelection effect will immediately reconcile once selectedMarkerIdx is set.
-      const isSelected = selected?.id === biz.id && (isSingleBusinessMode ? idx === 0 : false);
-      const pos = new google.maps.LatLng(lat, lng);
-      const overlay = new BusinessOverlay(pos, biz, isSelected, biz.image || '', () => {
-        trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
-        trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
-        setSelectedBusiness(biz);
-        setSelectedMarkerIdx(idx);
-        map.panTo(pos);
+    class ClusterOverlay extends google.maps.OverlayView {
+      private pos: any;
+      private div: HTMLDivElement | null = null;
+      private count: number;
+      private clusterMarkers: MapMarker[];
+      private onTap: () => void;
+
+      constructor(pos: any, count: number, clusterMarkers: MapMarker[], onTap: () => void) {
+        super();
+        this.pos = pos;
+        this.count = count;
+        this.clusterMarkers = clusterMarkers;
+        this.onTap = onTap;
+      }
+
+      onAdd() {
+        this.div = document.createElement('div');
+        this.div.style.position = 'absolute';
+        this.div.style.cursor = 'pointer';
+        this.div.style.zIndex = '15';
+        this.div.addEventListener('click', (e) => {
+          e.stopPropagation();
+          this.onTap();
+        });
+        this.render();
+        this.getPanes().overlayMouseTarget.appendChild(this.div);
+      }
+
+      render() {
+        if (!this.div) return;
+        const n = this.count;
+        const size = n < 5 ? 44 : n < 10 ? 50 : 58;
+        const fontSize = n < 10 ? 15 : n < 100 ? 13 : 11;
+        this.div.innerHTML = `
+          <div style="width:${size}px;height:${size}px;border-radius:50%;
+            background:linear-gradient(135deg,#6366F1 0%,#818CF8 100%);
+            display:flex;align-items:center;justify-content:center;
+            box-shadow:0 4px 16px rgba(99,102,241,0.40),0 2px 6px rgba(0,0,0,0.10);
+            border:2.5px solid #ffffff;position:relative;z-index:20;">
+            <span style="color:#ffffff;font-size:${fontSize}px;font-weight:700;
+              font-family:'Space Grotesk',sans-serif;line-height:1;">${n}</span>
+          </div>
+          <div style="width:12px;height:4px;background:rgba(0,0,0,0.10);border-radius:50%;margin:2px auto 0;filter:blur(1px);"></div>`;
+      }
+
+      draw() {
+        if (!this.div) return;
+        const proj = this.getProjection();
+        if (!proj) return;
+        const px = proj.fromLatLngToDivPixel(this.pos);
+        if (px) {
+          const n = this.count;
+          const size = n < 5 ? 44 : n < 10 ? 50 : 58;
+          this.div.style.left = (px.x - size / 2) + 'px';
+          this.div.style.top = (px.y - size - 4) + 'px';
+        }
+      }
+
+      onRemove() {
+        if (this.div && this.div.parentNode) {
+          this.div.parentNode.removeChild(this.div);
+          this.div = null;
+        }
+      }
+    }
+
+    // In single-business mode skip clustering — all pins are same business
+    if (isSingleBusinessMode) {
+      mapMarkers.forEach(({ business: biz, lat, lng }, idx) => {
+        const isSelected = selected?.id === biz.id && idx === 0;
+        const pos = new google.maps.LatLng(lat, lng);
+        const overlay = new BusinessOverlay(pos, biz, isSelected, biz.image || '', () => {
+          trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
+          trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
+          setSelectedBusiness(biz);
+          setSelectedMarkerIdx(idx);
+          map.panTo(pos);
+        });
+        overlay.setMap(map);
+        (overlay as any).__businessId = biz.id;
+        (overlay as any).__markerIdx = idx;
+        overlaysRef.current.push(overlay);
       });
-      overlay.setMap(map);
-      (overlay as any).__businessId = biz.id;
-      (overlay as any).__markerIdx = idx;
-      overlaysRef.current.push(overlay);
+      return;
+    }
+
+    const clusters = clusterMapMarkers(mapMarkers, zoom);
+    let globalIdx = 0;
+
+    clusters.forEach((cluster) => {
+      if (cluster.markers.length === 1) {
+        const { business: biz, lat, lng } = cluster.markers[0];
+        const idx = globalIdx++;
+        const isSelected = selected?.id === biz.id;
+        const pos = new google.maps.LatLng(lat, lng);
+        const overlay = new BusinessOverlay(pos, biz, isSelected, biz.image || '', () => {
+          trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
+          trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
+          setSelectedBusiness(biz);
+          setSelectedMarkerIdx(idx);
+          map.panTo(pos);
+        });
+        overlay.setMap(map);
+        (overlay as any).__businessId = biz.id;
+        (overlay as any).__markerIdx = idx;
+        overlaysRef.current.push(overlay);
+      } else {
+        globalIdx += cluster.markers.length;
+        const pos = new google.maps.LatLng(cluster.lat, cluster.lng);
+        const clusterOverlay = new ClusterOverlay(pos, cluster.markers.length, cluster.markers, () => {
+          trackMapInteractionThrottled('cluster_tap', { zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
+          const bounds = new google.maps.LatLngBounds();
+          cluster.markers.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
+          map.fitBounds(bounds, 80);
+        });
+        clusterOverlay.setMap(map);
+        overlaysRef.current.push(clusterOverlay);
+      }
     });
   }, [mapMarkers, clearOverlays, isSingleBusinessMode, trackMapInteractionThrottled]);
+
+  // Keep ref current so the zoom_changed listener always calls the latest version
+  useEffect(() => { buildOverlaysRef.current = buildOverlays; }, [buildOverlays]);
 
   // ─── User location overlay ────────────────────────────────────
 
@@ -524,7 +657,11 @@ function MapPage() {
           trackMapInteractionThrottled('pan', { zoomLevel: mapRef.current?.getZoom() || undefined, minIntervalMs: 1500 });
         });
         mapRef.current.addListener('zoom_changed', () => {
-          trackMapInteractionThrottled('zoom', { zoomLevel: mapRef.current?.getZoom() || undefined, minIntervalMs: 800 });
+          const zoomLevel = mapRef.current?.getZoom() || undefined;
+          trackMapInteractionThrottled('zoom', { zoomLevel, minIntervalMs: 800 });
+          if (googleRef.current && mapRef.current) {
+            buildOverlaysRef.current?.(googleRef.current, mapRef.current, selectedBusinessRef.current);
+          }
         });
         (mapRef.current as { __intentListenersAttached?: boolean }).__intentListenersAttached = true;
       }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -57,13 +57,10 @@ interface MarkerCluster {
   lng: number;
 }
 
-interface SpiderfiedCluster {
-  centerLat: number;
-  centerLng: number;
-  spokes: Array<{ marker: MapMarker; spokeLat: number; spokeLng: number }>;
-}
 
 function clusterMapMarkers(markers: MapMarker[], zoom: number): MarkerCluster[] {
+  // At street level, always show individual markers so co-located businesses are never stuck
+  if (zoom >= 17) return markers.map((m) => ({ markers: [m], lat: m.lat, lng: m.lng }));
   // Cell size in degrees shrinks as zoom increases — keeps ~60px cluster radius at each level
   const cellSize = 140 / Math.pow(2, zoom);
   const cells = new Map<string, MapMarker[]>();
@@ -146,7 +143,6 @@ function MapPage() {
   const googleRef = useRef<any>(null);
   const selectedBusinessRef = useRef<Business | null>(null);
   const buildOverlaysRef = useRef<((google: any, map: any, selected: Business | null) => void) | null>(null);
-  const spiderfiedClusterRef = useRef<SpiderfiedCluster | null>(null);
 
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [selectedMarkerIdx, setSelectedMarkerIdx] = useState<number | null>(null);
@@ -351,9 +347,7 @@ function MapPage() {
   const buildOverlays = useCallback((google: any, map: any, selected: Business | null) => {
     clearOverlays();
     const zoom = map.getZoom() ?? 15;
-    const spiderfied = spiderfiedClusterRef.current;
 
-    // ── BusinessOverlay ──────────────────────────────────────────
     class BusinessOverlay extends google.maps.OverlayView {
       private pos: any;
       private div: HTMLDivElement | null = null;
@@ -452,52 +446,6 @@ function MapPage() {
       }
     }
 
-    // ── SpiderLineOverlay ────────────────────────────────────────
-    // Renders dashed SVG lines from cluster center to each spoke marker.
-    class SpiderLineOverlay extends google.maps.OverlayView {
-      private lines: Array<{ from: any; to: any }>;
-      private svg: SVGSVGElement | null = null;
-
-      constructor(lines: Array<{ from: any; to: any }>) {
-        super();
-        this.lines = lines;
-      }
-
-      onAdd() {
-        this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
-        Object.assign(this.svg.style, { position: 'absolute', left: '0', top: '0', overflow: 'visible', pointerEvents: 'none', zIndex: '8' });
-        this.getPanes().overlayLayer.appendChild(this.svg);
-      }
-
-      draw() {
-        if (!this.svg) return;
-        const proj = this.getProjection();
-        if (!proj) return;
-        while (this.svg.firstChild) this.svg.removeChild(this.svg.firstChild);
-        this.lines.forEach(({ from, to }) => {
-          const a = proj.fromLatLngToDivPixel(from);
-          const b = proj.fromLatLngToDivPixel(to);
-          if (!a || !b) return;
-          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-          line.setAttribute('x1', String(a.x));
-          line.setAttribute('y1', String(a.y));
-          line.setAttribute('x2', String(b.x));
-          line.setAttribute('y2', String(b.y));
-          line.setAttribute('stroke', 'rgba(99,102,241,0.45)');
-          line.setAttribute('stroke-width', '1.5');
-          line.setAttribute('stroke-dasharray', '4,3');
-          this.svg.appendChild(line);
-        });
-      }
-
-      onRemove() {
-        if (this.svg && this.svg.parentNode) {
-          this.svg.parentNode.removeChild(this.svg);
-          this.svg = null;
-        }
-      }
-    }
-
     // ── ClusterOverlay ───────────────────────────────────────────
     class ClusterOverlay extends google.maps.OverlayView {
       private pos: any;
@@ -588,13 +536,7 @@ function MapPage() {
     let globalIdx = 0;
 
     clusters.forEach((cluster) => {
-      // Check if this cluster is the one currently spiderfied
-      const isSpiderfied = spiderfied !== null &&
-        Math.abs(cluster.lat - spiderfied.centerLat) < 0.00002 &&
-        Math.abs(cluster.lng - spiderfied.centerLng) < 0.00002;
-
       if (cluster.markers.length === 1) {
-        // ── Individual marker ──────────────────────────────────
         const { business: biz, lat, lng } = cluster.markers[0];
         const idx = globalIdx++;
         const isSelected = selected?.id === biz.id;
@@ -610,65 +552,22 @@ function MapPage() {
         (overlay as any).__businessId = biz.id;
         (overlay as any).__markerIdx = idx;
         overlaysRef.current.push(overlay);
-
-      } else if (isSpiderfied && spiderfied) {
-        // ── Spiderfied cluster: draw lines + spoke markers ─────
-        const centerLatLng = new google.maps.LatLng(spiderfied.centerLat, spiderfied.centerLng);
-        const lines = spiderfied.spokes.map(({ spokeLat, spokeLng }) => ({
-          from: centerLatLng,
-          to: new google.maps.LatLng(spokeLat, spokeLng),
-        }));
-        const lineOverlay = new SpiderLineOverlay(lines);
-        lineOverlay.setMap(map);
-        overlaysRef.current.push(lineOverlay);
-
-        spiderfied.spokes.forEach(({ marker: { business: biz, lat, lng }, spokeLat, spokeLng }) => {
-          const idx = globalIdx++;
-          const isSelected = selected?.id === biz.id;
-          const spokePos = new google.maps.LatLng(spokeLat, spokeLng);
-          const realPos = new google.maps.LatLng(lat, lng);
-          const overlay = new BusinessOverlay(spokePos, biz, isSelected, biz.image || '', () => {
-            trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
-            trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
-            setSelectedBusiness(biz);
-            setSelectedMarkerIdx(idx);
-            map.panTo(realPos);
-          });
-          overlay.setMap(map);
-          (overlay as any).__businessId = biz.id;
-          (overlay as any).__markerIdx = idx;
-          overlaysRef.current.push(overlay);
-        });
-
       } else {
-        // ── Cluster bubble — tap to spiderfy ──────────────────
         globalIdx += cluster.markers.length;
         const pos = new google.maps.LatLng(cluster.lat, cluster.lng);
         const clusterOverlay = new ClusterOverlay(pos, cluster.markers.length, () => {
           trackMapInteractionThrottled('cluster_tap', { zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
-
-          // Compute spoke positions in world-coordinate space at current zoom,
-          // then convert back to lat/lng so spokes are fixed geographic points.
-          const projection = map.getProjection();
-          if (!projection) return;
-          const currentZoom = map.getZoom() ?? 15;
-          const scale = Math.pow(2, currentZoom);
-          const N = cluster.markers.length;
-          const radius = Math.max(65, N * 10);
-          const centerPt = projection.fromLatLngToPoint(new google.maps.LatLng(cluster.lat, cluster.lng));
-
-          const spokes = cluster.markers.map((m, i) => {
-            const angle = (2 * Math.PI * i / N) - Math.PI / 2;
-            const spokePt = new google.maps.Point(
-              centerPt.x + (radius * Math.cos(angle)) / scale,
-              centerPt.y + (radius * Math.sin(angle)) / scale,
-            );
-            const spokeLatLng = projection.fromPointToLatLng(spokePt);
-            return { marker: m, spokeLat: spokeLatLng.lat(), spokeLng: spokeLatLng.lng() };
-          });
-
-          spiderfiedClusterRef.current = { centerLat: cluster.lat, centerLng: cluster.lng, spokes };
-          buildOverlaysRef.current?.(google, map, selectedBusinessRef.current);
+          const bounds = new google.maps.LatLngBounds();
+          cluster.markers.forEach((m) => bounds.extend({ lat: m.lat, lng: m.lng }));
+          const sw = bounds.getSouthWest();
+          const ne = bounds.getNorthEast();
+          const sameSpot = Math.abs(ne.lat() - sw.lat()) < 0.0001 && Math.abs(ne.lng() - sw.lng()) < 0.0001;
+          if (sameSpot) {
+            map.setCenter({ lat: cluster.lat, lng: cluster.lng });
+            map.setZoom(17);
+          } else {
+            map.fitBounds(bounds, 80);
+          }
         });
         clusterOverlay.setMap(map);
         overlaysRef.current.push(clusterOverlay);
@@ -756,10 +655,6 @@ function MapPage() {
         });
 
         mapRef.current.addListener('click', () => {
-          if (spiderfiedClusterRef.current) {
-            spiderfiedClusterRef.current = null;
-            buildOverlaysRef.current?.(googleRef.current, mapRef.current, null);
-          }
           setSelectedBusiness(null);
           trackMapInteractionThrottled('map_click', { zoomLevel: mapRef.current?.getZoom() || undefined, minIntervalMs: 500 });
         });
@@ -772,7 +667,6 @@ function MapPage() {
         mapRef.current.addListener('zoom_changed', () => {
           const zoomLevel = mapRef.current?.getZoom() || undefined;
           trackMapInteractionThrottled('zoom', { zoomLevel, minIntervalMs: 800 });
-          spiderfiedClusterRef.current = null; // spider collapses when zoom changes
           if (googleRef.current && mapRef.current) {
             buildOverlaysRef.current?.(googleRef.current, mapRef.current, selectedBusinessRef.current);
           }
@@ -784,7 +678,6 @@ function MapPage() {
         createUserLocationOverlay(google, mapRef.current, position.latitude, position.longitude);
       }
 
-      spiderfiedClusterRef.current = null;
       buildOverlays(google, mapRef.current, selectedBusiness);
 
       if (isSingleBusinessMode) {


### PR DESCRIPTION
## Summary
Implements marker clustering on the map to improve performance and usability when viewing multiple businesses at lower zoom levels. Individual markers are shown at higher zoom levels, while clusters appear at lower zoom levels with dynamic sizing based on marker count.

## Key Changes
- **New clustering algorithm**: Added `clusterMapMarkers()` function that groups markers into cells based on zoom level, maintaining approximately 60px cluster radius across all zoom levels
- **ClusterOverlay class**: New custom Google Maps overlay for rendering cluster badges with:
  - Dynamic sizing (44-58px) based on marker count
  - Gradient background with shadow effects
  - Click handler to zoom/pan to cluster bounds
- **Conditional rendering logic**: 
  - Single-business mode skips clustering entirely (all pins are same business)
  - Multi-business mode uses clustering at all zoom levels
- **Dynamic overlay rebuilding**: Map now rebuilds overlays on zoom changes to switch between cluster and individual marker views
- **State synchronization**: Added refs (`selectedBusinessRef`, `buildOverlaysRef`) to keep zoom_changed listener in sync with current state

## Implementation Details
- Cluster cell size is calculated as `140 / 2^zoom` to maintain consistent visual spacing
- Cluster count display uses responsive font sizing (15px for <10 items, 13px for <100, 11px for 100+)
- Cluster tap event tracked separately from marker clicks for analytics
- Uses `fitBounds()` with 80px padding when zooming into a cluster
- Maintains backward compatibility with existing single-business mode behavior

https://claude.ai/code/session_01PWGEAAhKXqyUKKBiiPDzx2