### PR TITLE
[codex] Allow mobile zoom for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/pwa-192x192.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Encontra descuentos, cuotas y beneficios bancarios en comercios de toda Argentina." />
     <meta name="keywords" content="descuentos bancarios, promociones tarjetas, beneficios bancos, cuotas sin interes" />
     <meta name="robots" content="index, follow" />


### PR DESCRIPTION
## Summary
- Remove the viewport `maximum-scale=1.0` cap so users can pinch-zoom.
- Addresses the Unlighthouse `meta-viewport` accessibility finding affecting every audited page.

## Validation
- `npm run build` passed.
- `npm run test` passed via the pre-push hook.
- `npm run lint` is currently blocked by pre-existing unrelated `@typescript-eslint/no-explicit-any` errors across the repo.