### PR TITLE
[codex] Improve shared contrast tokens

### DIFF
--- a/src/components/BusinessResultCard.tsx
+++ b/src/components/BusinessResultCard.tsx
@@ -15,7 +15,7 @@ interface BusinessResultCardProps {
 
 const getCategoryStyle = (category: string) => {
   return {
-    gastronomia: { bg: '#EEF2FF', color: '#6366F1' },
+  gastronomia: { bg: '#EEF2FF', color: '#4338CA' },
     moda: { bg: '#EDE9FE', color: '#7C3AED' },
     viajes: { bg: '#E0F2FE', color: '#0284C7' },
   }[category] ?? { bg: '#DCFCE7', color: '#16A34A' };
@@ -143,15 +143,15 @@ function BusinessResultCard({
 
       {maxDiscount > 0 ? (
         <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-          <span className="text-[7px] font-bold text-emerald-500 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
+          <span className="text-[7px] font-bold text-emerald-700 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
           <span className="text-[22px] font-black text-emerald-600 leading-none tracking-tight">{maxDiscount}%</span>
-          <span className="text-[8px] font-bold text-emerald-500 leading-none mt-[2px] tracking-wide">OFF</span>
+          <span className="text-[8px] font-bold text-emerald-700 leading-none mt-[2px] tracking-wide">OFF</span>
         </div>
       ) : maxInstallments > 0 ? (
         <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-          <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#818CF8' }}>hasta</span>
+          <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#4338CA' }}>hasta</span>
           <span className="text-[22px] font-black leading-none tracking-tight" style={{ color: '#6366F1' }}>{maxInstallments}</span>
-          <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#818CF8' }}>cuotas</span>
+          <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#4338CA' }}>cuotas</span>
         </div>
       ) : (
         <div className="shrink-0" style={{ minWidth: 38 }} />

--- a/src/components/MerchantCard.tsx
+++ b/src/components/MerchantCard.tsx
@@ -14,7 +14,7 @@ interface MerchantCardProps {
 }
 
 const CATEGORY_STYLE: Record<string, { bg: string; color: string }> = {
-  gastronomia: { bg: '#EEF2FF', color: '#6366F1' },
+  gastronomia: { bg: '#EEF2FF', color: '#4338CA' },
   moda:        { bg: '#EDE9FE', color: '#7C3AED' },
   viajes:      { bg: '#E0F2FE', color: '#0284C7' },
 };
@@ -129,15 +129,15 @@ const MerchantCard: React.FC<MerchantCardProps> = React.memo(({ business, onClic
         {/* Discount / installments */}
         {maxDiscount > 0 ? (
           <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-            <span className="text-[7px] font-bold text-emerald-500 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
+            <span className="text-[7px] font-bold text-emerald-700 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
             <span className="text-[22px] font-black text-emerald-600 leading-none tracking-tight">{maxDiscount}%</span>
-            <span className="text-[8px] font-bold text-emerald-500 leading-none mt-[2px] tracking-wide">OFF</span>
+            <span className="text-[8px] font-bold text-emerald-700 leading-none mt-[2px] tracking-wide">OFF</span>
           </div>
         ) : maxInstallments > 0 ? (
           <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-            <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#818CF8' }}>hasta</span>
+            <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#4338CA' }}>hasta</span>
             <span className="text-[22px] font-black leading-none tracking-tight" style={{ color: '#6366F1' }}>{maxInstallments}</span>
-            <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#818CF8' }}>cuotas</span>
+            <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#4338CA' }}>cuotas</span>
           </div>
         ) : (
           <div className="shrink-0" style={{ minWidth: 38 }} />

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1059,15 +1059,15 @@ function SearchPage() {
                       </div>
                       {maxDiscount > 0 ? (
                         <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                          <span className="text-[7px] font-bold text-emerald-500 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
+                          <span className="text-[7px] font-bold text-emerald-700 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
                           <span className="text-[22px] font-black text-emerald-600 leading-none tracking-tight">{maxDiscount}%</span>
-                          <span className="text-[8px] font-bold text-emerald-500 leading-none mt-[2px] tracking-wide">OFF</span>
+                          <span className="text-[8px] font-bold text-emerald-700 leading-none mt-[2px] tracking-wide">OFF</span>
                         </div>
                       ) : maxInstallments > 0 ? (
                         <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                          <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#818CF8' }}>hasta</span>
+                          <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#4338CA' }}>hasta</span>
                           <span className="text-[22px] font-black leading-none tracking-tight" style={{ color: '#6366F1' }}>{maxInstallments}</span>
-                          <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#818CF8' }}>cuotas</span>
+                          <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#4338CA' }}>cuotas</span>
                         </div>
                       ) : (
                         <div className="shrink-0" style={{ minWidth: 38 }} />
@@ -1150,15 +1150,15 @@ function SearchPage() {
                           </div>
                           {maxDiscount > 0 ? (
                             <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                              <span className="text-[7px] font-bold text-emerald-500 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
+                              <span className="text-[7px] font-bold text-emerald-700 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
                               <span className="text-[22px] font-black text-emerald-600 leading-none tracking-tight">{maxDiscount}%</span>
-                              <span className="text-[8px] font-bold text-emerald-500 leading-none mt-[2px] tracking-wide">OFF</span>
+                              <span className="text-[8px] font-bold text-emerald-700 leading-none mt-[2px] tracking-wide">OFF</span>
                             </div>
                           ) : maxInstallments > 0 ? (
                             <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                              <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#818CF8' }}>hasta</span>
+                              <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#4338CA' }}>hasta</span>
                               <span className="text-[22px] font-black leading-none tracking-tight" style={{ color: '#6366F1' }}>{maxInstallments}</span>
-                              <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#818CF8' }}>cuotas</span>
+                              <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#4338CA' }}>cuotas</span>
                             </div>
                           ) : (
                             <div className="shrink-0" style={{ minWidth: 38 }} />
@@ -1310,15 +1310,15 @@ function SearchPage() {
 
                         {maxDiscount > 0 ? (
                           <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                            <span className="text-[7px] font-bold text-emerald-500 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
+                            <span className="text-[7px] font-bold text-emerald-700 uppercase tracking-[0.12em] leading-none mb-[3px]">hasta</span>
                             <span className="text-[22px] font-black text-emerald-600 leading-none tracking-tight">{maxDiscount}%</span>
-                            <span className="text-[8px] font-bold text-emerald-500 leading-none mt-[2px] tracking-wide">OFF</span>
+                            <span className="text-[8px] font-bold text-emerald-700 leading-none mt-[2px] tracking-wide">OFF</span>
                           </div>
                         ) : maxInstallments > 0 ? (
                           <div className="shrink-0 flex flex-col items-center text-center" style={{ minWidth: 38 }}>
-                            <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#818CF8' }}>hasta</span>
+                            <span className="text-[7px] font-bold uppercase tracking-[0.12em] leading-none mb-[3px]" style={{ color: '#4338CA' }}>hasta</span>
                             <span className="text-[22px] font-black leading-none tracking-tight" style={{ color: '#6366F1' }}>{maxInstallments}</span>
-                            <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#818CF8' }}>cuotas</span>
+                            <span className="text-[7px] font-bold leading-none mt-[2px] tracking-wide" style={{ color: '#4338CA' }}>cuotas</span>
                           </div>
                         ) : (
                           <div className="shrink-0" style={{ minWidth: 38 }} />

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -8,11 +8,11 @@
   --color-primary-100: #e0e7ff;
   --color-primary-200: #c7d2fe;
   --color-primary-300: #a5b4fc;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1; /* Main primary indigo */
-  --color-primary-600: #4f46e5;
-  --color-primary-700: #4338ca;
-  --color-primary-800: #3730a3;
+  --color-primary-400: #6366f1;
+  --color-primary-500: #4338ca; /* Main primary indigo */
+  --color-primary-600: #3730a3;
+  --color-primary-700: #312e81;
+  --color-primary-800: #1e1b4b;
   --color-primary-900: #312e81;
   
   /* Secondary Colors */
@@ -34,7 +34,7 @@
   --color-super: #8b5cf6; /* Purple for Super */
   
   /* Status Colors */
-  --color-success: #10b981;
+  --color-success: #047857;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
   --color-info: #3b82f6;
@@ -52,7 +52,7 @@
   --color-gray-100: #f3f4f6;
   --color-gray-200: #e5e7eb;
   --color-gray-300: #d1d5db;
-  --color-gray-400: #9ca3af;
+  --color-gray-400: #6b7280;
   --color-gray-500: #6b7280;
   --color-gray-600: #4b5563;
   --color-gray-700: #374151;
@@ -159,10 +159,10 @@
   
   /* ===== GRADIENTS ===== */
 
-  --gradient-primary: linear-gradient(135deg, #6366F1 0%, #818CF8 100%);
-  --gradient-featured: linear-gradient(135deg, #6366F1 0%, #4f46e5 100%);
+  --gradient-primary: linear-gradient(135deg, #4338CA 0%, #6366F1 100%);
+  --gradient-featured: linear-gradient(135deg, #4338CA 0%, #3730A3 100%);
   --gradient-card: linear-gradient(145deg, #ffffff 0%, #f7f6f4 100%);
-  --gradient-emerald: linear-gradient(135deg, #10b981 0%, #34d399 100%);
+  --gradient-emerald: linear-gradient(135deg, #047857 0%, #10b981 100%);
   --gradient-amber: linear-gradient(135deg, #f59e0b 0%, #fcd34d 100%);
   --gradient-subtle: linear-gradient(135deg, #f7f6f4 0%, #ffffff 100%);
   
@@ -202,7 +202,7 @@
   /* Input Fields */
   --input-bg: var(--color-white);
   --input-border: #e8e6e1;
-  --input-border-focus: #6366F1;
+  --input-border-focus: #4338CA;
   --input-radius: var(--radius-md);
   --input-padding-x: var(--space-4);
   --input-padding-y: var(--space-3);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,14 +5,14 @@ export default {
     extend: {
       colors: {
         // Minimalist Bento Grid palette
-        primary: '#6366F1',          // Soft indigo - primary accent
+        primary: '#4338CA',          // Accessible indigo - primary accent
         'blink-bg': '#F7F6F4',       // Warm off-white background
         'blink-ink': '#1C1C1E',      // Soft deep (not pure black)
-        'blink-accent': '#6366F1',   // Indigo accent
-        'blink-positive': '#10B981', // Emerald for discounts/savings
+        'blink-accent': '#4338CA',   // Indigo accent
+        'blink-positive': '#047857', // Emerald for discounts/savings
         'blink-warning': '#F59E0B',  // Warm amber (replaces harsh yellow)
         'blink-surface': '#FFFFFF',
-        'blink-muted': '#9CA3AF',
+        'blink-muted': '#6B7280',
         'blink-border': '#E8E6E1',   // Soft warm border
         // Soft category colors for color-coding
         'cat-food': '#FEF3C7',
@@ -79,8 +79,8 @@ export default {
       },
       backgroundImage: {
         'gradient-subtle': 'linear-gradient(135deg, #F7F6F4 0%, #FFFFFF 100%)',
-        'gradient-indigo': 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)',
-        'gradient-emerald': 'linear-gradient(135deg, #10B981 0%, #34D399 100%)',
+        'gradient-indigo': 'linear-gradient(135deg, #4338CA 0%, #6366F1 100%)',
+        'gradient-emerald': 'linear-gradient(135deg, #047857 0%, #10B981 100%)',
         'gradient-amber': 'linear-gradient(135deg, #F59E0B 0%, #FCD34D 100%)',
         'gradient-card': 'linear-gradient(145deg, #FFFFFF 0%, #F7F6F4 100%)',
       },


### PR DESCRIPTION
## Summary
- Darken the shared primary, accent, muted, and positive tokens used across Blink pages.
- Update the repeated merchant/search card micro-label colors flagged by Unlighthouse color-contrast audits.
- Targets the largest repeated `color-contrast` clusters from the Unlighthouse cache, especially `text-blink-muted`, tiny discount labels, and tiny installment labels.

## Validation
- `npm run build` passed.
- `npm run test` passed.
- Pre-push hook reran build and tests successfully.
- `npm run lint` remains blocked by pre-existing unrelated `@typescript-eslint/no-explicit-any` errors across the repo.