### PR TITLE
[codex] Defer Google Analytics script loading

### DIFF
--- a/src/analytics/__tests__/googleAnalytics.test.ts
+++ b/src/analytics/__tests__/googleAnalytics.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const GA_SCRIPT_SRC = 'https://www.googletagmanager.com/gtag/js?id=G-TEST';
+
+describe('googleAnalytics', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST');
+    document.head.innerHTML = '';
+    window.dataLayer = [];
+    delete window.gtag;
+    Object.defineProperty(window, 'requestIdleCallback', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    document.head.innerHTML = '';
+    window.dataLayer = [];
+    delete window.gtag;
+  });
+
+  it('queues analytics config immediately but defers loading gtag.js', async () => {
+    const { initializeGoogleAnalytics } = await import('../googleAnalytics');
+
+    expect(initializeGoogleAnalytics()).toBe(true);
+    expect(document.querySelector(`script[src="${GA_SCRIPT_SRC}"]`)).toBeNull();
+    expect(window.dataLayer).toHaveLength(2);
+
+    vi.advanceTimersByTime(1499);
+    expect(document.querySelector(`script[src="${GA_SCRIPT_SRC}"]`)).toBeNull();
+
+    vi.advanceTimersByTime(1);
+    const script = document.querySelector<HTMLScriptElement>(`script[src="${GA_SCRIPT_SRC}"]`);
+    expect(script).not.toBeNull();
+    expect(script?.async).toBe(true);
+  });
+});

--- a/src/analytics/googleAnalytics.ts
+++ b/src/analytics/googleAnalytics.ts
@@ -26,6 +26,7 @@ const ATTRIBUTION_QUERY_KEYS = [
 // Maintenance note:
 // If event names/params change here, update /Users/tomas/Dev/Blink/Blink-v2/ANALYTICS_EVENTS.md.
 let isInitialized = false;
+let isScriptLoadScheduled = false;
 let lastTrackedPageView: { path: string; timestamp: number } | null = null;
 let attributionParams: AnalyticsParams = {};
 
@@ -235,6 +236,43 @@ function refreshAttributionFromUrl(): void {
   }
 }
 
+function appendAnalyticsScript(scriptSrc: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${scriptSrc}"]`);
+  if (existingScript) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = scriptSrc;
+  document.head.appendChild(script);
+}
+
+function scheduleAnalyticsScript(scriptSrc: string): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  if (isScriptLoadScheduled || document.querySelector<HTMLScriptElement>(`script[src="${scriptSrc}"]`)) {
+    return;
+  }
+
+  isScriptLoadScheduled = true;
+
+  const appendScript = () => appendAnalyticsScript(scriptSrc);
+
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(appendScript, { timeout: 3000 });
+    return;
+  }
+
+  window.setTimeout(appendScript, 1500);
+}
+
 export function initializeGoogleAnalytics(): boolean {
   if (typeof window === 'undefined' || !isEnabled()) {
     return false;
@@ -256,14 +294,7 @@ export function initializeGoogleAnalytics(): boolean {
   }
 
   const scriptSrc = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
-  const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${scriptSrc}"]`);
-
-  if (!existingScript) {
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = scriptSrc;
-    document.head.appendChild(script);
-  }
+  scheduleAnalyticsScript(scriptSrc);
 
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID, {


### PR DESCRIPTION
## Summary
- Keep the GA command queue/config behavior but defer the external `gtag.js` script injection until idle or a short timeout.
- Adds a focused unit test proving the script is not inserted during initial analytics initialization.
- Targets the Unlighthouse repeated `unused-javascript` and third-party script cost from `www.googletagmanager.com/gtag/js`.

## Validation
- `npm run test -- src/analytics/__tests__/googleAnalytics.test.ts` passed.
- `npm run build` passed.
- Pre-push hook reran full build and tests successfully: 41 files, 493 tests.
- `npm run lint` remains blocked by pre-existing unrelated `@typescript-eslint/no-explicit-any` errors across the repo.