### PR TITLE
[codex] Optimize remote image URLs

### DIFF
--- a/src/components/BusinessResultCard.tsx
+++ b/src/components/BusinessResultCard.tsx
@@ -3,6 +3,7 @@ import { Business } from '../types';
 import { formatDistance } from '../utils/distance';
 import { toBankDescriptor } from '../utils/banks';
 import { getBenefitProviderDisplayName } from '../utils/benefitDisplay';
+import { getOptimizedImageUrl } from '../utils/images';
 
 interface BusinessResultCardProps {
   business: Business;
@@ -75,6 +76,7 @@ function BusinessResultCard({
   const maxDiscount = getBusinessMaxDiscount(business);
   const maxInstallments = getBusinessMaxInstallments(business);
   const categoryStyle = getCategoryStyle(business.category);
+  const imageSrc = getOptimizedImageUrl(business.image, { width: 96 });
   const baseClassName = `w-full bg-white rounded-2xl cursor-pointer transition-all duration-200 active:scale-[0.98] overflow-hidden flex text-left ${className}`;
   const style = {
     border: '1px solid #E8E6E1',
@@ -86,16 +88,18 @@ function BusinessResultCard({
       <div
         className="w-11 h-11 shrink-0 rounded-xl flex items-center justify-center overflow-hidden"
         style={{
-          background: business.image ? '#F7F6F4' : categoryStyle.bg,
+          background: imageSrc ? '#F7F6F4' : categoryStyle.bg,
           border: '1px solid rgba(0,0,0,0.07)',
         }}
       >
-        {business.image ? (
+        {imageSrc ? (
           <img
             alt=""
             className="w-full h-full object-cover"
-            src={business.image}
+            src={imageSrc}
             loading="lazy"
+            decoding="async"
+            referrerPolicy="no-referrer"
           />
         ) : (
           <span className="font-black text-base leading-none" style={{ color: categoryStyle.color }}>

--- a/src/components/MerchantCard.tsx
+++ b/src/components/MerchantCard.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { formatDistance } from '../utils/distance';
 import { filterActiveBenefits } from '../utils/benefits';
 import { getBenefitProviderDisplayName } from '../utils/benefitDisplay';
+import { getOptimizedImageUrl } from '../utils/images';
 
 interface MerchantCardProps {
   business: Business;
@@ -64,6 +65,7 @@ const MerchantCard: React.FC<MerchantCardProps> = React.memo(({ business, onClic
   const maxDiscount = getMaxDiscount(activeBenefits);
   const maxInstallments = getMaxInstallments(activeBenefits);
   const categoryStyle = CATEGORY_STYLE[business.category] ?? { bg: '#DCFCE7', color: '#16A34A' };
+  const imageSrc = getOptimizedImageUrl(business.image, { width: 96 });
 
   return (
     <div
@@ -76,10 +78,10 @@ const MerchantCard: React.FC<MerchantCardProps> = React.memo(({ business, onClic
         {/* Logo */}
         <div
           className="w-11 h-11 shrink-0 rounded-xl flex items-center justify-center overflow-hidden"
-          style={{ background: business.image ? '#F7F6F4' : categoryStyle.bg, border: '1px solid rgba(0,0,0,0.07)' }}
+          style={{ background: imageSrc ? '#F7F6F4' : categoryStyle.bg, border: '1px solid rgba(0,0,0,0.07)' }}
         >
-          {business.image ? (
-            <img alt={business.name} className="w-full h-full object-cover" src={business.image} loading="lazy" />
+          {imageSrc ? (
+            <img alt={business.name} className="w-full h-full object-cover" src={imageSrc} loading="lazy" decoding="async" referrerPolicy="no-referrer" />
           ) : (
             <span className="font-black text-base leading-none" style={{ color: categoryStyle.color }}>
               {business.name?.charAt(0)}

--- a/src/components/StoreHeader.tsx
+++ b/src/components/StoreHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ArrowLeft, MapPin } from "lucide-react";
 import { Business } from "../types";
+import { getOptimizedImageUrl } from "../utils/images";
 
 interface StoreHeaderProps {
   business: Business;
@@ -41,9 +42,11 @@ const StoreHeader: React.FC<StoreHeaderProps> = ({
         <div className="flex items-start gap-4">
           <div className="w-16 h-16 rounded-xl overflow-hidden bg-gray-100 flex-shrink-0">
             <img
-              src={business.image}
+              src={getOptimizedImageUrl(business.image, { width: 160 })}
               alt={`${business.name} logo`}
               className="w-full h-full object-cover"
+              decoding="async"
+              referrerPolicy="no-referrer"
               onError={(e) => {
                 const target = e.target as HTMLImageElement;
                 target.style.display = "none";

--- a/src/pages/BenefitDetailPage.tsx
+++ b/src/pages/BenefitDetailPage.tsx
@@ -34,6 +34,7 @@ import {
   getBenefitEligibilityBankNames,
   isModoSourcedBenefit,
 } from '../utils/benefitDisplay';
+import { getOptimizedImageUrl } from '../utils/images';
 
 const BENEFIT_DAYS = [
   { key: 'monday' as const, abbr: 'L' },
@@ -496,7 +497,7 @@ function BenefitDetailPage() {
                 style={{ boxShadow: '0 6px 24px rgba(0,0,0,0.12)', border: `2px solid ${bankAccent.border}` }}
               >
                 {business.image ? (
-                  <img alt={business.name} className="w-full h-full object-cover" src={business.image} />
+                  <img alt={business.name} className="w-full h-full object-cover" src={getOptimizedImageUrl(business.image, { width: 160 })} decoding="async" referrerPolicy="no-referrer" />
                 ) : (
                   <span className="font-black text-2xl" style={{ color: bankAccent.text }}>{business.name?.charAt(0)}</span>
                 )}
@@ -800,9 +801,12 @@ function BenefitDetailPage() {
                       >
                         {subscription.icon ? (
                           <img
-                            src={subscription.icon}
+                            src={getOptimizedImageUrl(subscription.icon, { width: 64 })}
                             alt={subscription.name}
                             className="w-6 h-6 rounded object-contain flex-shrink-0"
+                            loading="lazy"
+                            decoding="async"
+                            referrerPolicy="no-referrer"
                           />
                         ) : (
                           <span

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -12,6 +12,7 @@ import { getMerchantSeoPath, parseMerchantSeoParam } from '../seo/merchantUrls';
 import { formatLocalDateOnly, isBenefitActive } from '../utils/benefits';
 import { buildBenefitPath } from '../utils/benefitIdentity';
 import { getBenefitProviderDisplayName, getBenefitProviderSummary } from '../utils/benefitDisplay';
+import { getOptimizedImageUrl } from '../utils/images';
 
 const ALL_DAYS = ['lunes', 'martes', 'miércoles', 'miercoles', 'jueves', 'viernes', 'sábado', 'sabado', 'domingo'];
 const DAY_ABBR: Record<string, string> = {
@@ -429,7 +430,7 @@ function BusinessDetailPage() {
             style={{ boxShadow: '0 2px 12px rgba(0,0,0,0.10)', border: '1px solid #E8E6E1' }}
           >
             {business.image ? (
-              <img alt={business.name} className="w-full h-full object-cover" src={business.image} />
+              <img alt={business.name} className="w-full h-full object-cover" src={getOptimizedImageUrl(business.image, { width: 160 })} decoding="async" referrerPolicy="no-referrer" />
             ) : (
               <span className="font-black text-2xl text-blink-muted">{business.name?.charAt(0)}</span>
             )}

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -5,6 +5,7 @@ import { useSEO } from '../hooks/useSEO';
 import { fetchBusinessesPaginated } from '../services/api';
 import { getCategorySeoPath, resolveSeoCategory, type SeoCategoryLink } from '../seo/categoryPages';
 import { getMerchantSeoPath } from '../seo/merchantUrls';
+import { getOptimizedImageUrl } from '../utils/images';
 
 const PAGE_SIZE = 50;
 
@@ -112,7 +113,7 @@ function CategoryPageContent({ category, page }: { category: SeoCategoryLink; pa
                     <div className="flex items-start gap-3">
                       <div className="w-12 h-12 rounded-2xl bg-blink-bg overflow-hidden flex items-center justify-center shrink-0">
                         {business.image ? (
-                          <img src={business.image} alt="" className="w-full h-full object-cover" loading="lazy" />
+                          <img src={getOptimizedImageUrl(business.image, { width: 96 })} alt="" className="w-full h-full object-cover" loading="lazy" decoding="async" referrerPolicy="no-referrer" />
                         ) : (
                           <span className="text-xl">{category.emoji}</span>
                         )}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,6 +19,7 @@ import { trackFilterApply, trackViewBenefit } from '../analytics/intentTracking'
 import InstallPWABanner from '../components/InstallPWAPopup';
 import { NotificationBanner } from '../components/NotificationBanner';
 import { usePushNotifications } from '../hooks/usePushNotifications';
+import { getOptimizedImageUrl } from '../utils/images';
 
 type NavigatorWithStandalone = Navigator & {
   standalone?: boolean;
@@ -430,8 +431,10 @@ function HomePage() {
                       <img
                         alt={item.business.name}
                         className="absolute inset-0 w-full h-full object-cover"
-                        src={item.business.image}
+                        src={getOptimizedImageUrl(item.business.image, { width: 480 })}
                         loading="lazy"
+                        decoding="async"
+                        referrerPolicy="no-referrer"
                       />
                     )}
                     {/* Dark scrim */}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -15,6 +15,7 @@ import {
   trackSelectBusiness,
 } from '../analytics/intentTracking';
 import { getMerchantSeoPath } from '../seo/merchantUrls';
+import { getOptimizedImageUrl } from '../utils/images';
 
 const DEFAULT_CENTER = { lat: -34.6037, lng: -58.3816 };
 
@@ -415,7 +416,7 @@ function MapPage() {
             display:flex;align-items:center;justify-content:center;position:relative;z-index:20;
             transition:all 0.15s;">
             ${this.imgSrc
-              ? `<img src="${this.imgSrc}" alt="" style="width:${imgSize}px;height:${imgSize}px;object-fit:contain;border-radius:50%;${this.isSelected ? '' : 'opacity:0.75;'}" />`
+              ? `<img src="${this.imgSrc}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer" style="width:${imgSize}px;height:${imgSize}px;object-fit:contain;border-radius:50%;${this.isSelected ? '' : 'opacity:0.75;'}" />`
               : `<span style="font-family:'Space Grotesk',sans-serif;font-size:${this.isSelected ? 18 : 14}px;font-weight:700;color:${this.isSelected ? '#6366F1' : '#6B7280'};">${this.biz.name?.charAt(0) || '?'}</span>`
             }
           </div>`;
@@ -525,7 +526,7 @@ function MapPage() {
           selected?.id === biz.id &&
           (currentSelectedIdx === null ? idx === 0 : idx === currentSelectedIdx);
         const pos = new google.maps.LatLng(lat, lng);
-        const overlay = new BusinessOverlay(pos, biz, isSelected, biz.image || '', () => {
+        const overlay = new BusinessOverlay(pos, biz, isSelected, getOptimizedImageUrl(biz.image, { width: 96 }), () => {
           trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
           trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
           setSelectedBusiness(biz);
@@ -563,7 +564,7 @@ function MapPage() {
           ? markerKey === currentSelectedKey
           : selected?.id === biz.id && (currentSelectedIdx === null || idx === currentSelectedIdx);
         const pos = new google.maps.LatLng(lat, lng);
-        const overlay = new BusinessOverlay(pos, biz, isSelected, biz.image || '', () => {
+        const overlay = new BusinessOverlay(pos, biz, isSelected, getOptimizedImageUrl(biz.image, { width: 96 }), () => {
           trackMapInteractionThrottled('marker_click', { businessId: biz.id, zoomLevel: map.getZoom() || undefined, minIntervalMs: 400 });
           trackSelectBusiness({ source: 'map_marker', businessId: biz.id, category: biz.category });
           setSelectedBusiness(biz);
@@ -1040,8 +1041,10 @@ function MapPage() {
                       <img
                         alt={biz.name}
                         className="w-full h-full object-cover"
-                        src={biz.image}
+                        src={getOptimizedImageUrl(biz.image, { width: 112 })}
                         loading="lazy"
+                        decoding="async"
+                        referrerPolicy="no-referrer"
                       />
                     ) : (
                       <span className="font-bold text-xl text-blink-muted">{biz.name?.charAt(0)}</span>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -26,6 +26,7 @@ import { encodeGeohash } from '../utils/geohash';
 import { getMerchantSeoPath } from '../seo/merchantUrls';
 import { matchesSearchPhrase } from '../utils/searchNormalization';
 import { getBenefitProviderDisplayName } from '../utils/benefitDisplay';
+import { getOptimizedImageUrl } from '../utils/images';
 
 interface SearchFilterState {
   selectedBanksKey: string;
@@ -1040,7 +1041,7 @@ function SearchPage() {
                         style={{ background: business.image ? '#F7F6F4' : categoryStyle.bg, border: '1px solid rgba(0,0,0,0.07)' }}
                       >
                         {business.image ? (
-                          <img alt={business.name} className="w-full h-full object-cover" src={business.image} loading="lazy" />
+                          <img alt={business.name} className="w-full h-full object-cover" src={getOptimizedImageUrl(business.image, { width: 96 })} loading="lazy" decoding="async" referrerPolicy="no-referrer" />
                         ) : (
                           <span className="font-black text-base leading-none" style={{ color: categoryStyle.color }}>{business.name?.charAt(0)}</span>
                         )}
@@ -1131,7 +1132,7 @@ function SearchPage() {
                             style={{ background: business.image ? '#F7F6F4' : categoryStyle.bg, border: '1px solid rgba(0,0,0,0.07)' }}
                           >
                             {business.image ? (
-                              <img alt={business.name} className="w-full h-full object-cover" src={business.image} loading="lazy" />
+                              <img alt={business.name} className="w-full h-full object-cover" src={getOptimizedImageUrl(business.image, { width: 96 })} loading="lazy" decoding="async" referrerPolicy="no-referrer" />
                             ) : (
                               <span className="font-black text-base leading-none" style={{ color: categoryStyle.color }}>{business.name?.charAt(0)}</span>
                             )}
@@ -1260,8 +1261,10 @@ function SearchPage() {
                             <img
                               alt={business.name}
                               className="w-full h-full object-cover"
-                              src={business.image}
+                              src={getOptimizedImageUrl(business.image, { width: 96 })}
                               loading="lazy"
+                              decoding="async"
+                              referrerPolicy="no-referrer"
                             />
                           ) : (
                             <span className="font-black text-base leading-none" style={{ color: categoryStyle.color }}>

--- a/src/utils/__tests__/images.test.ts
+++ b/src/utils/__tests__/images.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getOptimizedImageUrl, normalizeImageUrl } from '../images';
+
+describe('image URL helpers', () => {
+  it('upgrades insecure image URLs to HTTPS', () => {
+    expect(normalizeImageUrl('http://example.com/image.png')).toBe('https://example.com/image.png');
+  });
+
+  it('adds compressed Pexels parameters for the requested display width', () => {
+    const url = getOptimizedImageUrl('https://images.pexels.com/photos/123/photo.jpeg?w=400', { width: 96 });
+
+    expect(url).toBe('https://images.pexels.com/photos/123/photo.jpeg?w=96&auto=compress&cs=tinysrgb');
+  });
+
+  it('keeps non-Pexels image URLs otherwise unchanged after normalization', () => {
+    expect(getOptimizedImageUrl('http://cdn.example.com/logo.png?size=large', { width: 96 })).toBe(
+      'https://cdn.example.com/logo.png?size=large',
+    );
+  });
+});

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,0 +1,43 @@
+type ImageOptimizationOptions = {
+  width?: number;
+};
+
+export function normalizeImageUrl(src: string | null | undefined): string {
+  const trimmed = src?.trim() ?? '';
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.startsWith('http://')) {
+    return `https://${trimmed.slice('http://'.length)}`;
+  }
+
+  return trimmed;
+}
+
+export function getOptimizedImageUrl(
+  src: string | null | undefined,
+  options: ImageOptimizationOptions = {},
+): string {
+  const normalized = normalizeImageUrl(src);
+  if (!normalized) {
+    return '';
+  }
+
+  try {
+    const url = new URL(normalized);
+
+    if (url.hostname === 'images.pexels.com') {
+      url.searchParams.set('auto', 'compress');
+      url.searchParams.set('cs', 'tinysrgb');
+
+      if (options.width && options.width > 0) {
+        url.searchParams.set('w', String(Math.round(options.width)));
+      }
+    }
+
+    return url.toString();
+  } catch {
+    return normalized;
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared helpers to normalize remote image URLs and optimize Pexels requests by rendered width.
- Upgrade insecure `http://` image URLs to `https://` at render time.
- Apply optimized URLs, async decoding, and no-referrer policy to merchant/card/detail/map image surfaces.
- Targets Unlighthouse `image-delivery-insight` and insecure image subresource findings across repeated merchant/search/category pages.

## Validation
- `npm run test -- src/utils/__tests__/images.test.ts` passed.
- `npm run build` passed.
- Pre-push hook reran full build and tests successfully: 41 files, 495 tests.
- `npm run lint` remains blocked by pre-existing unrelated `@typescript-eslint/no-explicit-any` errors across the repo.