### PR TITLE
Default 'cerca' pill to active when location permission is already granted

### DIFF
--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -111,7 +111,13 @@ function SearchPage() {
   const [cardMode, setCardMode] = useState<'credit' | 'debit' | undefined>((searchParams.get('card') || undefined) as 'credit' | 'debit' | undefined);
   const [network] = useState<string | undefined>(searchParams.get('network') || undefined);
   const [hasInstallments, setHasInstallments] = useState<boolean | undefined>(searchParams.get('installments') === '1' ? true : undefined);
-  const [sortByDistance, setSortByDistance] = useState(searchParams.get('nearby') === '1');
+  const [sortByDistance, setSortByDistance] = useState(() => {
+    if (searchParams.get('nearby') === '1') return true;
+    if (!searchParams.has('nearby')) {
+      return localStorage.getItem('locationPermission') === 'granted';
+    }
+    return false;
+  });
 
   const { data: availableBankNames = [] } = useQuery({
     queryKey: ['availableBanks'],


### PR DESCRIPTION
When a user has previously granted geolocation permission, the 'cerca'
(nearby) quick-filter pill now activates automatically on the search page
instead of requiring an explicit click.

https://claude.ai/code/session_01TtKGfEpTeAGJieaqqaQiQy