### PR TITLE
fix: prevent repeated iOS PWA location permission dialog

### DIFF
--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -112,14 +112,26 @@ export const useGeolocation = () => {
         if (result.state === 'denied') {
           localStorage.setItem(STORAGE_KEYS.permission, 'denied');
           setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
-        } else {
-          // 'granted' or 'prompt': always request. The 24h cache above prevents spam —
-          // this code only runs when cache is expired or absent (i.e. first visit or stale).
+        } else if (result.state === 'granted') {
+          // Browser confirms the grant — fetch silently, no dialog will appear.
           requestLocation();
+        } else {
+          // 'prompt': the browser will show the native permission dialog if we call
+          // getCurrentPosition(). On iOS this state can reappear after inactivity or
+          // a Settings change even though the user already granted before.
+          // If localStorage records a prior grant, skip the auto-request so we don't
+          // annoy the user with a repeated dialog on every cold start; the dialog will
+          // fire naturally when they explicitly tap the location button instead.
+          const stored = localStorage.getItem(STORAGE_KEYS.permission);
+          if (stored === 'granted') {
+            setState({ position: null, error: null, loading: false, permissionDenied: false });
+          } else {
+            requestLocation();
+          }
         }
       });
     } else {
-      // Fallback for browsers without Permissions API
+      // Fallback for browsers without Permissions API (iOS < 16.4)
       const stored = localStorage.getItem(STORAGE_KEYS.permission);
       if (stored === 'denied') {
         setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -154,7 +154,7 @@ function SearchPage() {
     window.localStorage.setItem(BANK_STORAGE_KEY, JSON.stringify(selectedBanks));
   }, [selectedBanks]);
 
-  const { position, permissionDenied, requestPermission } = useGeolocation();
+  const { position, permissionDenied, requestPermission, loading: locationLoading } = useGeolocation();
 
   const {
     businesses,
@@ -831,7 +831,7 @@ function SearchPage() {
                 <button
                   key="proximity"
                   onClick={() => {
-                    if (permissionDenied) {
+                    if (permissionDenied || (!position && !locationLoading)) {
                       requestPermission();
                       setSortByDistance(true);
                     } else {


### PR DESCRIPTION
On iOS, the native geolocation permission can silently reset to 'prompt'
after inactivity, iOS updates, or a Settings change — even though the user
already granted. When the 24h position cache expired, the hook always called
getCurrentPosition(), which triggered the native dialog on every cold open.

Fix: when navigator.permissions.query returns 'prompt' but localStorage
records a prior 'granted', skip the automatic call and let the dialog fire
only when the user explicitly taps the location ("Cerca") button.

Also update the "Cerca" button in SearchPage to call requestPermission()
when position is null and loading is done (not only when permissionDenied),
so tapping it correctly re-triggers the grant flow after an iOS reset.

https://claude.ai/code/session_017BetSmvFmfUBMA9pieLVK4