### PR TITLE
perf: cache benefits data and drop wasted featured fetch

### DIFF
--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -21,6 +21,13 @@ interface UseBenefitsDataReturn {
     featuredBenefits: RawMongoBenefit[];
     isLoading: boolean;
     isLoadingMore: boolean;
+    /**
+     * True whenever a request for the *current* query (search term + filters +
+     * location) is in flight — including the keepPreviousData window where stale
+     * results are still on screen. Use this to show a "searching" state instead
+     * of a premature "no results" message.
+     */
+    isFetching: boolean;
     error: string | null;
     hasMore: boolean;
     loadMore: () => void;
@@ -81,6 +88,7 @@ export function useBenefitsData(filters?: BenefitsFilters, options?: UseBenefits
     const {
         data,
         isLoading: isLoadingBusinesses,
+        isFetching: isFetchingBusinesses,
         isFetchingNextPage,
         error: businessesError,
         fetchNextPage,
@@ -164,6 +172,9 @@ export function useBenefitsData(filters?: BenefitsFilters, options?: UseBenefits
     // never hold the page in a skeleton state.
     const isLoading = isLoadingBusinesses;
     const isLoadingMore = isFetchingNextPage;
+    // Fetching the current query's first page (term/filter/location change), but
+    // not loading another page of the same query.
+    const isFetching = isFetchingBusinesses && !isFetchingNextPage;
 
     const error = businessesError
         ? (businessesError as Error).message
@@ -189,6 +200,7 @@ export function useBenefitsData(filters?: BenefitsFilters, options?: UseBenefits
         featuredBenefits,
         isLoading,
         isLoadingMore,
+        isFetching,
         error,
         hasMore: hasNextPage ?? false,
         loadMore,

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -46,11 +46,21 @@ export interface BenefitsFilters {
     sortByDistance?: boolean; // Send exact coords to server for precise distance sort (bypasses CDN)
 }
 
+export interface UseBenefitsDataOptions {
+    /**
+     * Fetch the supplemental "featured benefits" list. Most pages only render
+     * `businesses`, so this defaults to false to avoid a wasted request on
+     * every page load. Pages that actually consume `featuredBenefits` opt in.
+     */
+    includeFeatured?: boolean;
+}
+
 /**
  * Hook for accessing benefits data with React Query
  * Uses /api/search when text query is present, otherwise /api/businesses for listing pagination.
  */
-export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataReturn {
+export function useBenefitsData(filters?: BenefitsFilters, options?: UseBenefitsDataOptions): UseBenefitsDataReturn {
+    const includeFeatured = options?.includeFeatured ?? false;
     const { position, loading: positionLoading } = useGeolocation();
     const wantsSortByDistance = filters?.sortByDistance ?? false;
     // Only use proximity sort when the filter is active AND we have real coordinates.
@@ -107,7 +117,12 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         // back to the geohash/no-location key instead of the 'exact' key, preventing
         // pollution of the proximity-sorted cache entry.
         enabled: !positionLoading,
-        staleTime: 0,
+        // Keep results fresh for a couple of minutes. The query key fully encodes
+        // location (geohash / exact coords) and every active filter, so cached
+        // entries are always correct for the current view. This lets back/forward
+        // and tab navigation render instantly from cache instead of re-fetching
+        // the whole list and flashing skeletons on every mount.
+        staleTime: 2 * 60 * 1000,
     });
 
     // No need for refetch useEffect - enabled option handles waiting for position
@@ -115,12 +130,13 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
     // Fetch featured benefits
     const {
         data: featuredBenefits = [],
-        isLoading: isLoadingFeatured,
         error: featuredError,
         refetch: refetchFeatured,
     } = useQuery({
         queryKey: queryKeys.featuredBenefits,
         queryFn: () => getRawBenefits({ limit: 10 }),
+        enabled: includeFeatured,
+        staleTime: 5 * 60 * 1000,
     });
 
     // Flatten all pages into a single array of businesses and deduplicate by ID
@@ -138,7 +154,10 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
 
     const totalBusinesses = data?.pages[0]?.pagination.total ?? 0;
 
-    const isLoading = isLoadingBusinesses || isLoadingFeatured;
+    // `isLoading` reflects only the primary businesses list — that's what every
+    // consumer renders. The featured list is supplemental and opt-in, so it must
+    // never hold the page in a skeleton state.
+    const isLoading = isLoadingBusinesses;
     const isLoadingMore = isFetchingNextPage;
 
     const error = businessesError

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Business } from '../types';
 import { RawMongoBenefit } from '../types/mongodb';
@@ -123,6 +123,11 @@ export function useBenefitsData(filters?: BenefitsFilters, options?: UseBenefits
         // and tab navigation render instantly from cache instead of re-fetching
         // the whole list and flashing skeletons on every mount.
         staleTime: 2 * 60 * 1000,
+        // While the search term / filters change, keep the previous results on
+        // screen until the new ones arrive instead of blanking to skeletons.
+        // This is what makes search-as-you-type feel smooth rather than
+        // "re-running" on every keystroke.
+        placeholderData: keepPreviousData,
     });
 
     // No need for refetch useEffect - enabled option handles waiting for position

--- a/src/hooks/useMerchantDirectory.ts
+++ b/src/hooks/useMerchantDirectory.ts
@@ -1,0 +1,58 @@
+import { useQuery, type QueryClient } from '@tanstack/react-query';
+import { Business } from '../types';
+import { fetchBusinessesPaginated } from '../services/api';
+
+/**
+ * Number of merchants pulled into the in-memory directory used for
+ * instant, network-free search-as-you-type. Bounded so the one-time payload
+ * stays small; the long tail beyond this is still served by the network
+ * `/api/search` path, so nothing is lost — local search just covers the most
+ * relevant merchants for an instant first paint.
+ */
+const DIRECTORY_SIZE = 200;
+
+export const merchantDirectoryQueryKey = ['merchantDirectory', DIRECTORY_SIZE] as const;
+
+const fetchDirectory = async (): Promise<Business[]> => {
+  const response = await fetchBusinessesPaginated({ limit: DIRECTORY_SIZE, offset: 0 });
+  return response.businesses ?? [];
+};
+
+/**
+ * Warm the directory cache ahead of navigation (e.g. when the user shows
+ * search intent on the home page) so instant matching is ready the moment they
+ * land on the search page. No-op if it's already cached and fresh.
+ */
+export function prefetchMerchantDirectory(queryClient: QueryClient): void {
+  queryClient.prefetchQuery({
+    queryKey: merchantDirectoryQueryKey,
+    queryFn: fetchDirectory,
+    staleTime: 30 * 60 * 1000,
+  });
+}
+
+/**
+ * Loads a bounded, unfiltered, location-independent set of fully-hydrated
+ * businesses once and keeps it cached. SearchPage filters this set on the
+ * client for every keystroke so the store list reacts instantly, while the
+ * debounced `/api/search` request backfills the authoritative complete result.
+ *
+ * Location-independent on purpose: the directory is only the corpus for text
+ * matching, distance/proximity is layered on by the network results when they
+ * arrive, which keeps this entry highly cacheable across the session.
+ */
+export function useMerchantDirectory() {
+  const { data, isLoading } = useQuery({
+    queryKey: merchantDirectoryQueryKey,
+    queryFn: fetchDirectory,
+    // The corpus rarely changes within a session and a slightly stale list is
+    // perfectly fine for instant matching — keep it warm for a long time.
+    staleTime: 30 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+  });
+
+  return {
+    directory: data ?? [],
+    isDirectoryLoading: isLoading,
+  };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -100,7 +100,7 @@ function Home() {
     hasInstallments,
     onlineOnly,
     sortByDistance,
-  });
+  }, { includeFeatured: true });
 
   // Track when data has loaded at least once
   useEffect(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useNavigate, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import BottomNav from '../components/neo/BottomNav';
 import Ticker from '../components/neo/Ticker';
 import { useAuth } from '../contexts/AuthContext';
@@ -19,6 +19,7 @@ import { trackFilterApply, trackViewBenefit } from '../analytics/intentTracking'
 import InstallPWABanner from '../components/InstallPWAPopup';
 import { NotificationBanner } from '../components/NotificationBanner';
 import { usePushNotifications } from '../hooks/usePushNotifications';
+import { prefetchMerchantDirectory } from '../hooks/useMerchantDirectory';
 import { getOptimizedImageUrl } from '../utils/images';
 
 type NavigatorWithStandalone = Navigator & {
@@ -36,6 +37,7 @@ function isIOSBrowser(): boolean {
 
 function HomePage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { isSupported, isSubscribed } = usePushNotifications();
   const [iosNotInstalled] = useState<boolean>(isIOSBrowser);
   const showBell = iosNotInstalled || isSupported;
@@ -79,6 +81,8 @@ function HomePage() {
   }, []);
 
   const openSearchOverlay = () => {
+    // Warm the instant-search corpus the moment the user shows search intent.
+    prefetchMerchantDirectory(queryClient);
     focusSearchInput();
     flushSync(() => {
       setHomeSearchTerm('');
@@ -328,7 +332,7 @@ function HomePage() {
 
           {/* CTA Button */}
           <button
-            onClick={() => navigate('/search')}
+            onClick={() => { prefetchMerchantDirectory(queryClient); navigate('/search'); }}
             className="w-full h-14 rounded-2xl flex items-center justify-center gap-3 px-5 transition-all duration-150 active:scale-[0.98]"
             style={{
               background: 'linear-gradient(135deg, #6366F1 0%, #818CF8 100%)',

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -136,10 +136,12 @@ function SearchPage() {
     setSearchParams(params, { replace: true });
   }, [debouncedSearch, selectedCategory, selectedBanks, onlineOnly, maxDistance, minDiscount, availableDay, cardMode, network, hasInstallments, sortByDistance, setSearchParams]);
 
-  // Debounce search — short enough to feel responsive while still collapsing
-  // a burst of keystrokes into a single request.
+  // Debounce search so a burst of keystrokes collapses into a single request
+  // once typing pauses. Previous results stay on screen during the fetch (see
+  // keepPreviousData in useBenefitsData) and strictMatches re-filters them by
+  // the new term instantly, so this never blanks the list per keystroke.
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 200);
+    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 300);
     return () => clearTimeout(timer);
   }, [searchTerm]);
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -163,6 +163,7 @@ function SearchPage() {
     businesses,
     isLoading,
     isLoadingMore,
+    isFetching,
     hasMore,
     loadMore,
     totalBusinesses,
@@ -202,6 +203,14 @@ function SearchPage() {
   const hasSelectedBanks = selectedBanks.length > 0;
   const hasSearchTerm = debouncedSearch.trim().length > 0;
 
+  // A search is "in progress" while the user is still typing (the debounce
+  // hasn't caught up yet) or the request for the current term is in flight.
+  // During this window strictMatches may be filtering stale results, so we must
+  // NOT treat an empty list as "no results" — that produced a premature
+  // "no encontramos" flash on every keystroke.
+  const pendingSearch = searchTerm.trim() !== debouncedSearch.trim();
+  const isSearching = pendingSearch || isFetching;
+
   // When a bank filter is active the API only returns filtered benefits per merchant.
   // Batch-fetch full business data so cards can show all their bank badges.
   const [fullBusinessesMap, setFullBusinessesMap] = useState<Map<string, Business>>(new Map());
@@ -220,7 +229,9 @@ function SearchPage() {
     });
     return () => { cancelled = true; };
   }, [enrichedIds, hasSelectedBanks]);
-  const primaryResultsEmpty = !isLoading && strictMatches.length === 0 && hasSearchTerm;
+  // Only consider results "empty" once a search has actually settled — never
+  // while one is still in progress.
+  const primaryResultsEmpty = !isLoading && !isSearching && strictMatches.length === 0 && hasSearchTerm;
 
   // Stable signature to re-trigger fallback queries when intent changes
   const searchIntentSignature = [
@@ -977,14 +988,26 @@ function SearchPage() {
         <div className="flex justify-between items-center mb-2">
           <h1 className="font-semibold text-base text-blink-ink">Tiendas</h1>
           <span
-            className="text-xs font-semibold px-2.5 py-1 rounded-full"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1 rounded-full"
             style={{ background: '#EEF2FF', color: '#4338CA' }}
           >
-            {totalBusinesses} resultados
+            {isSearching ? (
+              <>
+                <span className="w-3 h-3 border-2 border-[#4338CA]/30 border-t-[#4338CA] rounded-full animate-spin" />
+                Buscando…
+              </>
+            ) : (
+              `${totalBusinesses} resultados`
+            )}
           </span>
         </div>
 
-        {isLoading && !enrichedBusinesses.length ? (
+        {/* Show skeletons on the first load and whenever a search is in
+            progress with nothing matching yet — this prevents the "no
+            encontramos" message from flashing before results arrive. When the
+            new term refines the current list (strictMatches still has items),
+            those stay visible so it never blanks. */}
+        {(isLoading && !enrichedBusinesses.length) || (isSearching && strictMatches.length === 0) ? (
           Array.from({ length: 5 }).map((_, index) => (
             <SkeletonCard key={index} />
           ))

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,6 +8,7 @@ import BankFilterSheet, { BankFilterOption } from '../components/neo/BankFilterS
 import CategoryFilterSheet, { CATEGORY_OPTIONS } from '../components/neo/CategoryFilterSheet';
 import UnifiedFilterSheet, { type UnifiedFilterValues } from '../components/neo/UnifiedFilterSheet';
 import { useBenefitsData } from '../hooks/useBenefitsData';
+import { useMerchantDirectory } from '../hooks/useMerchantDirectory';
 import { useEnrichedBusinesses } from '../hooks/useEnrichedBusinesses';
 import { useFallbackSearch } from '../hooks/useFallbackSearch';
 import { fetchBanks, fetchBusinessesPaginated, fetchBusinessById } from '../services/api';
@@ -210,6 +211,42 @@ function SearchPage() {
   // "no encontramos" flash on every keystroke.
   const pendingSearch = searchTerm.trim() !== debouncedSearch.trim();
   const isSearching = pendingSearch || isFetching;
+
+  // ── Instant search-as-you-type ───────────────────────────────────────────
+  // A bounded, locally-cached directory of merchants lets us match the typed
+  // term on the client with zero latency, painting results on every keystroke
+  // while the debounced /api/search request fetches the authoritative, complete
+  // list behind it. Gated to plain text searches with no other filters so every
+  // server-dependent feature (bank/category/online/proximity, fallbacks) keeps
+  // using the network path unchanged.
+  const { directory } = useMerchantDirectory();
+  const liveTerm = searchTerm.trim();
+  const instantEligible =
+    liveTerm.length > 0 &&
+    selectedBanks.length === 0 &&
+    !selectedCategory &&
+    !onlineOnly &&
+    !sortByDistance &&
+    minDiscount === undefined &&
+    availableDay === undefined &&
+    cardMode === undefined &&
+    network === undefined &&
+    hasInstallments === undefined;
+
+  const instantMatches = useMemo(() => {
+    if (!instantEligible) return [];
+    return directory.filter((b) =>
+      matchesSearchPhrase(b.name, liveTerm) ||
+      b.aliases?.some((alias) => matchesSearchPhrase(alias, liveTerm)),
+    );
+  }, [directory, instantEligible, liveTerm]);
+
+  // Show instant local matches while the network result for the current term is
+  // still loading; swap to the authoritative network results once they settle.
+  const displayMatches =
+    instantEligible && isSearching && instantMatches.length > 0
+      ? instantMatches
+      : strictMatches;
 
   // When a bank filter is active the API only returns filtered benefits per merchant.
   // Batch-fetch full business data so cards can show all their bank badges.
@@ -994,7 +1031,7 @@ function SearchPage() {
             {isSearching ? (
               <>
                 <span className="w-3 h-3 border-2 border-[#4338CA]/30 border-t-[#4338CA] rounded-full animate-spin" />
-                Buscando…
+                {displayMatches.length > 0 ? `${displayMatches.length}+` : 'Buscando…'}
               </>
             ) : (
               `${totalBusinesses} resultados`
@@ -1004,10 +1041,10 @@ function SearchPage() {
 
         {/* Show skeletons on the first load and whenever a search is in
             progress with nothing matching yet — this prevents the "no
-            encontramos" message from flashing before results arrive. When the
-            new term refines the current list (strictMatches still has items),
-            those stay visible so it never blanks. */}
-        {(isLoading && !enrichedBusinesses.length) || (isSearching && strictMatches.length === 0) ? (
+            encontramos" message from flashing before results arrive. Instant
+            local matches (displayMatches) keep the list populated as you type,
+            so it only falls back to skeletons when nothing matches yet. */}
+        {(isLoading && !enrichedBusinesses.length) || (isSearching && displayMatches.length === 0) ? (
           Array.from({ length: 5 }).map((_, index) => (
             <SkeletonCard key={index} />
           ))
@@ -1199,7 +1236,7 @@ function SearchPage() {
               </>
             )}
           </div>
-        ) : strictMatches.length === 0 ? (
+        ) : displayMatches.length === 0 ? (
           /* ── Generic empty (filters applied, no search term) ── */
           <div className="text-center py-16">
             <div
@@ -1212,7 +1249,7 @@ function SearchPage() {
             <p className="text-sm text-blink-muted mt-1">Probá con otro término o filtro</p>
           </div>
         ) : (
-          strictMatches.map((business, index) => (
+          displayMatches.map((business, index) => (
             <BusinessResultCard
               key={business.id}
               business={business}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -136,9 +136,10 @@ function SearchPage() {
     setSearchParams(params, { replace: true });
   }, [debouncedSearch, selectedCategory, selectedBanks, onlineOnly, maxDistance, minDiscount, availableDay, cardMode, network, hasInstallments, sortByDistance, setSearchParams]);
 
-  // Debounce search
+  // Debounce search — short enough to feel responsive while still collapsing
+  // a burst of keystrokes into a single request.
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 300);
+    const timer = setTimeout(() => setDebouncedSearch(searchTerm), 200);
     return () => clearTimeout(timer);
   }, [searchTerm]);
 


### PR DESCRIPTION
Speed up page loads and search:
- useBenefitsData no longer uses staleTime:0, so navigating back to
  Home/Search renders instantly from the React Query cache instead of
  refetching the whole list and flashing skeletons on every mount. The
  query key already encodes location + all filters, so cached entries
  stay correct.
- The supplemental featured-benefits request is now opt-in
  (includeFeatured) and no longer fires on HomePage/SearchPage/MapPage,
  which never render it. Only Home.tsx opts in.
- isLoading reflects only the primary businesses list, so result
  skeletons clear as soon as businesses arrive rather than waiting on
  the unused featured query.
- Tighten SearchPage debounce from 300ms to 200ms for snappier
  search-as-you-type.