### PR TITLE
Preserve MODO source metadata in benefit summaries

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -88,7 +88,10 @@ const BENEFIT_SUMMARY_PROJECTION = {
   description: 1,
   termsAndConditions: 1,
   link: 1,
-  validUntil: 1
+  validUntil: 1,
+  sourceCollection: 1,
+  rawBenefitCollection: 1,
+  source: 1
 };
 
 const REQUIRED_PRODUCTION_ENV_VARS = [
@@ -695,6 +698,9 @@ function buildBusinessBenefitSummary(benefit, cardNameLookup) {
     description: benefit?.description || '',
     installments: Number.isFinite(benefit?.installments) ? Number(benefit.installments) : null,
     validUntil: benefit?.validUntil || null,
+    sourceCollection: benefit?.sourceCollection || null,
+    rawBenefitCollection: benefit?.rawBenefitCollection || null,
+    source: benefit?.source || null,
     caps: Array.isArray(benefit?.caps) ? benefit.caps : [],
     otherDiscounts: benefit?.otherDiscounts || null,
     subscriptionIds: getBenefitSubscriptionIds(benefit)

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildBusinessBenefitSummary,
   getActiveBenefitsMatch,
   handleCategorySeoPage,
   handleGetBenefitById,
@@ -101,9 +102,37 @@ describe('merchant-first serverless helpers', () => {
     expect(result.merchantSnapshot.merchantId).toBe('merchant_1');
   });
 
+  it('buildBusinessBenefitSummary preserves MODO source metadata for non-MODO ids', () => {
+    const result = buildBusinessBenefitSummary({
+      id: 'confirmed-benefit-1',
+      merchantId: 'merchant_1',
+      sourceCollection: 'MODO_PROMOS_RAW',
+      rawBenefitCollection: 'MODO_PROMOS_RAW',
+      source: 'modo',
+      benefitTitle: '20% en Nutrican',
+      availableDays: ['viernes'],
+      discountPercentage: 20,
+      caps: [{ amount: 6000 }],
+      online: false,
+      validUntil: '2026-07-31',
+      eligibilities: [
+        {
+          providerName: 'Banco Ciudad',
+          cardType: 'visa-credit'
+        }
+      ]
+    }, new Map([['visa-credit', 'Visa crédito']]));
+
+    expect(result.id).toBe('confirmed-benefit-1');
+    expect(result.sourceCollection).toBe('MODO_PROMOS_RAW');
+    expect(result.rawBenefitCollection).toBe('MODO_PROMOS_RAW');
+    expect(result.source).toBe('modo');
+  });
+
   it('handleGetBusinesses paginates merchants before benefit hydration', async () => {
     const merchantQueries: unknown[] = [];
     const benefitQueries: unknown[] = [];
+    const benefitFindOptions: unknown[] = [];
 
     const merchants = [
       {
@@ -175,8 +204,9 @@ describe('merchant-first serverless helpers', () => {
 
         if (name === 'confirmed_benefits') {
           return {
-            find(query: unknown) {
+            find(query: unknown, options: unknown) {
               benefitQueries.push(query);
+              benefitFindOptions.push(options);
               return createCursor(benefits);
             }
           };
@@ -207,6 +237,11 @@ describe('merchant-first serverless helpers', () => {
     expect(payload.businesses[0].benefits).toHaveLength(1);
     expect((merchantQueries[0] as { categories: unknown }).categories).toEqual({ $in: ['shopping'] });
     expect(((benefitQueries[0] as { merchantId: { $in: unknown[] } }).merchantId).$in).toEqual(['merchant_1']);
+    expect((benefitFindOptions[0] as { projection: Record<string, number> }).projection).toMatchObject({
+      sourceCollection: 1,
+      rawBenefitCollection: 1,
+      source: 1
+    });
   });
 
   it('handleGetBusinesses supports exact merchantId lookups without fuzzy search filters', async () => {


### PR DESCRIPTION
### Motivation
- Summarized benefits currently drop `sourceCollection`, `rawBenefitCollection`, and `source`, which prevents reliable detection/deduplication of MODO-sourced promos once returned by summary endpoints.\
- The change ensures downstream display and dedupe logic can identify MODO-origin offers even when the serialized `id` is not MODO-prefixed.

### Description
- Add `sourceCollection`, `rawBenefitCollection`, and `source` to `BENEFIT_SUMMARY_PROJECTION` in `api/[...path].js`.\
- Propagate those fields through `buildBusinessBenefitSummary` so the summary object includes `sourceCollection`, `rawBenefitCollection`, and `source`.\
- Add a regression test in `src/services/__tests__/merchantFirstServerless.test.ts` that asserts `buildBusinessBenefitSummary` preserves MODO metadata for a non-`modo-promos-raw-` id and that the `confirmed_benefits` query projection includes the source fields.\
- Changes touch `api/[...path].js` and the merchant-first serverless test file to exercise the new projection and summary behavior.

### Testing
- Ran the targeted unit tests with `npm test -- src/services/__tests__/merchantFirstServerless.test.ts`, and the test file passed (`1 file, 20 tests` succeeded).\
- An earlier `npm test -- --run ...` invocation failed due to a duplicate `--run` flag in the npm script, which was a CLI usage issue and not a code failure.\
- Ran `npm run lint`, which reported pre-existing lint errors unrelated to this change (TypeScript `@typescript-eslint/no-explicit-any` issues) so linting did not pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a246fd458832ea0354c58a77c45bc)