### PR TITLE
[codex] Render descuentos landing pages for crawlers

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -24,6 +24,14 @@ import {
   renderCategorySeoHtml,
   resolveSeoCategory
 } from './category-seo.js';
+import {
+  getLandingSeoPath,
+  loadLandingSeoData,
+  renderLandingSeoHtml,
+  resolveLandingBank,
+  resolveLandingCategory,
+  resolveLandingCity
+} from './landing-seo.js';
 
 const DEFAULT_COLLECTION = 'confirmed_benefits';
 const ALLOWED_COLLECTIONS = new Set([
@@ -2618,6 +2626,54 @@ async function handleCategorySeoPage(req, res, url, db, categoryParam, pageParam
   return html(res, 200, renderedHtml);
 }
 
+async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam, cityParam, options = {}) {
+  const bank = resolveLandingBank(bankParam);
+  const category = resolveLandingCategory(categoryParam);
+  const city = cityParam ? resolveLandingCity(cityParam) : null;
+
+  if (!bank || !category || (cityParam && !city)) {
+    return json(res, 404, {
+      success: false,
+      error: 'Landing page not found',
+      bank: bankParam,
+      category: categoryParam,
+      ...(cityParam && { city: cityParam })
+    });
+  }
+
+  const canonicalPath = getLandingSeoPath(bank, category, city);
+  const requestedPath = cityParam
+    ? `/descuentos/${bankParam}/${categoryParam}/${cityParam}`
+    : `/descuentos/${bankParam}/${categoryParam}`;
+
+  if (requestedPath !== canonicalPath) {
+    setCacheControl(res, CC_CONTENT);
+    return redirect(res, 301, canonicalPath);
+  }
+
+  const data = await loadLandingSeoData({
+    db,
+    merchantCollectionName: MERCHANT_ASSETS_COLLECTION,
+    bank,
+    category,
+    city
+  });
+  const appShell = options.appShell || readViteAppShell();
+  const renderedHtml = renderLandingSeoHtml({
+    appShell,
+    bank,
+    category,
+    city,
+    merchants: data.merchants,
+    resultCount: data.resultCount,
+    path: canonicalPath,
+    siteUrl: options.siteUrl || getCanonicalSiteUrl(url)
+  });
+
+  setCacheControl(res, CC_CONTENT);
+  return html(res, 200, renderedHtml);
+}
+
 async function handlePlaceDetails(req, res) {
   const body = await readJsonBody(req);
   const placeId = body?.placeId;
@@ -2650,6 +2706,7 @@ export {
   handleGetBenefits,
   handleGetBusinesses,
   handleCategorySeoPage,
+  handleLandingSeoPage,
   handleLegacyBusinessRedirect,
   handleMerchantSeoPage,
   handleSearch,
@@ -2737,6 +2794,19 @@ export default async function handler(req, res) {
         );
       }
 
+      const landingSeoMatch = path.match(/^\/api\/descuentos\/([^/]+)\/([^/]+)(?:\/([^/]+))?$/);
+      if (landingSeoMatch) {
+        return await handleLandingSeoPage(
+          req,
+          res,
+          url,
+          db,
+          decodeURIComponent(landingSeoMatch[1]),
+          decodeURIComponent(landingSeoMatch[2]),
+          landingSeoMatch[3] ? decodeURIComponent(landingSeoMatch[3]) : undefined
+        );
+      }
+
       const merchantSeoMatch = path.match(/^\/api\/comercios\/([^/]+)$/);
       if (merchantSeoMatch) {
         return await handleMerchantSeoPage(req, res, url, db, decodeURIComponent(merchantSeoMatch[1]));
@@ -2820,6 +2890,8 @@ export default async function handler(req, res) {
         'GET /api/businesses',
         'GET /api/categorias/:category',
         'GET /api/categorias/:category/page/:page',
+        'GET /api/descuentos/:bank/:category',
+        'GET /api/descuentos/:bank/:category/:city',
         'GET /api/comercios/:slugId',
         'GET /api/business/:id',
         'GET /api/search',

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -29,8 +29,11 @@ import {
   loadLandingSeoData,
   renderLandingSeoHtml,
   resolveLandingBank,
+  resolveLandingBankFromMerchants,
   resolveLandingCategory,
-  resolveLandingCity
+  resolveLandingCategoryFromMerchants,
+  resolveLandingCity,
+  resolveLandingCityFromMerchants
 } from './landing-seo.js';
 
 const DEFAULT_COLLECTION = 'confirmed_benefits';
@@ -2627,11 +2630,11 @@ async function handleCategorySeoPage(req, res, url, db, categoryParam, pageParam
 }
 
 async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam, cityParam, options = {}) {
-  const bank = resolveLandingBank(bankParam);
-  const category = resolveLandingCategory(categoryParam);
-  const city = cityParam ? resolveLandingCity(cityParam) : null;
+  const requestedBank = resolveLandingBank(bankParam);
+  const requestedCategory = resolveLandingCategory(categoryParam);
+  const requestedCity = cityParam ? resolveLandingCity(cityParam) : null;
 
-  if (!bank || !category || (cityParam && !city)) {
+  if (!requestedBank || !requestedCategory || (cityParam && !requestedCity)) {
     return json(res, 404, {
       success: false,
       error: 'Landing page not found',
@@ -2641,6 +2644,29 @@ async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam,
     });
   }
 
+  const data = await loadLandingSeoData({
+    db,
+    merchantCollectionName: MERCHANT_ASSETS_COLLECTION,
+    bank: requestedBank,
+    category: requestedCategory,
+    city: requestedCity
+  });
+
+  if (data.resultCount <= 0) {
+    return json(res, 404, {
+      success: false,
+      error: 'Landing page not found',
+      bank: bankParam,
+      category: categoryParam,
+      ...(cityParam && { city: cityParam })
+    });
+  }
+
+  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants) || requestedBank;
+  const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants) || requestedCategory;
+  const city = cityParam
+    ? (resolveLandingCityFromMerchants(cityParam, data.merchants) || requestedCity)
+    : null;
   const canonicalPath = getLandingSeoPath(bank, category, city);
   const requestedPath = cityParam
     ? `/descuentos/${bankParam}/${categoryParam}/${cityParam}`
@@ -2651,13 +2677,6 @@ async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam,
     return redirect(res, 301, canonicalPath);
   }
 
-  const data = await loadLandingSeoData({
-    db,
-    merchantCollectionName: MERCHANT_ASSETS_COLLECTION,
-    bank,
-    category,
-    city
-  });
   const appShell = options.appShell || readViteAppShell();
   const renderedHtml = renderLandingSeoHtml({
     appShell,

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2662,11 +2662,22 @@ async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam,
     });
   }
 
-  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants) || requestedBank;
-  const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants) || requestedCategory;
+  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants);
+  const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants);
   const city = cityParam
-    ? (resolveLandingCityFromMerchants(cityParam, data.merchants) || requestedCity)
+    ? resolveLandingCityFromMerchants(cityParam, data.merchants)
     : null;
+
+  if (!bank || !category || (cityParam && !city)) {
+    return json(res, 404, {
+      success: false,
+      error: 'Landing page not found',
+      bank: bankParam,
+      category: categoryParam,
+      ...(cityParam && { city: cityParam })
+    });
+  }
+
   const canonicalPath = getLandingSeoPath(bank, category, city);
   const requestedPath = cityParam
     ? `/descuentos/${bankParam}/${categoryParam}/${cityParam}`

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -28,11 +28,11 @@ import {
   getLandingSeoPath,
   loadLandingSeoData,
   renderLandingSeoHtml,
-  resolveLandingBank,
+  resolveClientLandingBank,
+  resolveClientLandingCategory,
+  resolveClientLandingCity,
   resolveLandingBankFromMerchants,
-  resolveLandingCategory,
   resolveLandingCategoryFromMerchants,
-  resolveLandingCity,
   resolveLandingCityFromMerchants
 } from './landing-seo.js';
 
@@ -2630,9 +2630,9 @@ async function handleCategorySeoPage(req, res, url, db, categoryParam, pageParam
 }
 
 async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam, cityParam, options = {}) {
-  const requestedBank = resolveLandingBank(bankParam);
-  const requestedCategory = resolveLandingCategory(categoryParam);
-  const requestedCity = cityParam ? resolveLandingCity(cityParam) : null;
+  const requestedBank = resolveClientLandingBank(bankParam);
+  const requestedCategory = resolveClientLandingCategory(categoryParam);
+  const requestedCity = cityParam ? resolveClientLandingCity(cityParam) : null;
 
   if (!requestedBank || !requestedCategory || (cityParam && !requestedCity)) {
     return json(res, 404, {
@@ -2662,10 +2662,10 @@ async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam,
     });
   }
 
-  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants, { includeClientDefinitions: true });
-  const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants);
+  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants, { seedDefinitions: [requestedBank] });
+  const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants, { seedDefinitions: [requestedCategory] });
   const city = cityParam
-    ? resolveLandingCityFromMerchants(cityParam, data.merchants)
+    ? resolveLandingCityFromMerchants(cityParam, data.merchants, { seedDefinitions: [requestedCity] })
     : null;
 
   if (!bank || !category || (cityParam && !city)) {

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2662,7 +2662,7 @@ async function handleLandingSeoPage(req, res, url, db, bankParam, categoryParam,
     });
   }
 
-  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants);
+  const bank = resolveLandingBankFromMerchants(bankParam, data.merchants, { includeClientDefinitions: true });
   const category = resolveLandingCategoryFromMerchants(categoryParam, data.merchants);
   const city = cityParam
     ? resolveLandingCityFromMerchants(cityParam, data.merchants)

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -138,6 +138,12 @@ function mergeDefinition(map, definition) {
   });
 }
 
+function seedDefinitionMap(map, definitions) {
+  for (const definition of toArray(definitions)) {
+    mergeDefinition(map, definition);
+  }
+}
+
 export function buildLandingBankDefinition(value) {
   const name = formatLandingName(value);
   if (!name) return null;
@@ -176,6 +182,15 @@ export function buildLandingCityDefinition(value) {
     aliases: createAliases(value, name, slug),
   };
 }
+
+const CLIENT_LANDING_BANK_DEFINITIONS = [
+  { slug: 'galicia', name: 'Banco Galicia', aliases: createAliases('galicia', 'Banco Galicia') },
+  { slug: 'santander', name: 'Banco Santander', aliases: createAliases('santander', 'rio', 'Banco Santander', 'Banco Santander Rio', 'Banco Santander Río') },
+  { slug: 'bbva', name: 'BBVA', aliases: createAliases('bbva', 'frances', 'banco frances', 'Banco Francés') },
+  { slug: 'macro', name: 'Banco Macro', aliases: createAliases('macro', 'Banco Macro') },
+  { slug: 'nacion', name: 'Banco Nacion', aliases: createAliases('nacion', 'bna', 'banco nacion', 'Banco Nación') },
+  { slug: 'icbc', name: 'ICBC', aliases: createAliases('icbc', 'ICBC') },
+];
 
 export function resolveLandingBank(value, definitions = []) {
   return resolveExistingLandingDefinition(value, definitions) || buildLandingBankDefinition(value);
@@ -220,8 +235,9 @@ export function getLandingCityValuesFromMerchant(merchant) {
   return uniqueStrings(values);
 }
 
-export function buildLandingBankDefinitionsFromMerchants(merchants) {
+export function buildLandingBankDefinitionsFromMerchants(merchants, seedDefinitions = []) {
   const map = new Map();
+  seedDefinitionMap(map, seedDefinitions);
   for (const merchant of toArray(merchants)) {
     for (const value of getLandingBankValuesFromMerchant(merchant)) {
       mergeDefinition(map, buildLandingBankDefinition(value));
@@ -230,8 +246,9 @@ export function buildLandingBankDefinitionsFromMerchants(merchants) {
   return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
-export function buildLandingCategoryDefinitionsFromMerchants(merchants) {
+export function buildLandingCategoryDefinitionsFromMerchants(merchants, seedDefinitions = []) {
   const map = new Map();
+  seedDefinitionMap(map, seedDefinitions);
   for (const merchant of toArray(merchants)) {
     for (const value of getLandingCategoryValuesFromMerchant(merchant)) {
       mergeDefinition(map, buildLandingCategoryDefinition(value));
@@ -240,8 +257,9 @@ export function buildLandingCategoryDefinitionsFromMerchants(merchants) {
   return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
-export function buildLandingCityDefinitionsFromMerchants(merchants) {
+export function buildLandingCityDefinitionsFromMerchants(merchants, seedDefinitions = []) {
   const map = new Map();
+  seedDefinitionMap(map, seedDefinitions);
   for (const merchant of toArray(merchants)) {
     for (const value of getLandingCityValuesFromMerchant(merchant)) {
       mergeDefinition(map, buildLandingCityDefinition(value));
@@ -250,8 +268,9 @@ export function buildLandingCityDefinitionsFromMerchants(merchants) {
   return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
-export function resolveLandingBankFromMerchants(value, merchants) {
-  return resolveExistingLandingDefinition(value, buildLandingBankDefinitionsFromMerchants(merchants));
+export function resolveLandingBankFromMerchants(value, merchants, options = {}) {
+  const seedDefinitions = options.includeClientDefinitions ? CLIENT_LANDING_BANK_DEFINITIONS : options.seedDefinitions;
+  return resolveExistingLandingDefinition(value, buildLandingBankDefinitionsFromMerchants(merchants, seedDefinitions));
 }
 
 export function resolveLandingCategoryFromMerchants(value, merchants) {

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -387,11 +387,46 @@ function filterDefinitionsByAllowedSlugs(definitions, allowedSlugs) {
   return definitions.filter((definition) => allowedSlugs.has(definition.slug));
 }
 
+function parseIntegerOption(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? fallback), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function resolveClientDefinitionForLandingDefinition(definition, clientDefinitions) {
+  const candidates = uniqueStrings([
+    definition?.slug,
+    definition?.name,
+    definition?.category,
+    ...(definition?.aliases || []),
+  ]);
+
+  for (const candidate of candidates) {
+    const match = resolveExistingLandingDefinition(candidate, clientDefinitions);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+function filterDefinitionsByAllowedClientSlugs(definitions, allowedSlugs, clientDefinitions) {
+  if (!allowedSlugs) return definitions;
+
+  const map = new Map();
+  for (const definition of definitions) {
+    const canonicalDefinition =
+      resolveClientDefinitionForLandingDefinition(definition, clientDefinitions) || definition;
+    if (!allowedSlugs.has(canonicalDefinition.slug)) continue;
+    mergeDefinition(map, canonicalDefinition);
+  }
+
+  return Array.from(map.values());
+}
+
 export function buildLandingSeoRoutesFromMerchants(merchants, options = {}) {
-  const minMerchantCount = Math.max(1, Number.parseInt(String(options.minMerchantCount || 3), 10));
+  const minMerchantCount = Math.max(1, parseIntegerOption(options.minMerchantCount, 3));
   const maxCityRoutesPerCombination = Math.max(
     0,
-    Number.parseInt(String(options.maxCityRoutesPerCombination || 5), 10),
+    parseIntegerOption(options.maxCityRoutesPerCombination, 5),
   );
   const allowedBankSlugs = getAllowedSlugSet(options.allowedBankSlugs);
   const allowedCategorySlugs = getAllowedSlugSet(options.allowedCategorySlugs);
@@ -402,9 +437,17 @@ export function buildLandingSeoRoutesFromMerchants(merchants, options = {}) {
   for (const merchant of toArray(merchants)) {
     const merchantDefinitions = buildDefinitionsForMerchant(merchant);
     const definitions = {
-      banks: filterDefinitionsByAllowedSlugs(merchantDefinitions.banks, allowedBankSlugs),
+      banks: filterDefinitionsByAllowedClientSlugs(
+        merchantDefinitions.banks,
+        allowedBankSlugs,
+        CLIENT_LANDING_BANK_DEFINITIONS
+      ),
       categories: filterDefinitionsByAllowedSlugs(merchantDefinitions.categories, allowedCategorySlugs),
-      cities: filterDefinitionsByAllowedSlugs(merchantDefinitions.cities, allowedCitySlugs),
+      cities: filterDefinitionsByAllowedClientSlugs(
+        merchantDefinitions.cities,
+        allowedCitySlugs,
+        CLIENT_LANDING_CITY_DEFINITIONS
+      ),
     };
     if (definitions.banks.length === 0 || definitions.categories.length === 0) continue;
 

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -1,33 +1,17 @@
-export const LANDING_BANK_DEFINITIONS = [
-  { slug: 'galicia', name: 'Banco Galicia', aliases: ['galicia'] },
-  { slug: 'santander', name: 'Banco Santander', aliases: ['santander', 'rio'] },
-  { slug: 'bbva', name: 'BBVA', aliases: ['bbva', 'frances', 'banco frances'] },
-  { slug: 'macro', name: 'Banco Macro', aliases: ['macro'] },
-  { slug: 'nacion', name: 'Banco Nacion', aliases: ['nacion', 'bna', 'banco nacion'] },
-  { slug: 'icbc', name: 'ICBC', aliases: ['icbc'] },
-];
+const LANDING_STOP_WORDS = new Set(['de', 'del', 'la', 'las', 'el', 'los', 'y']);
+const EXCLUDED_CATEGORY_SLUGS = new Set(['all']);
 
-export const LANDING_CATEGORY_DEFINITIONS = [
-  { slug: 'gastronomia', category: 'gastronomia', name: 'Gastronomia' },
-  { slug: 'moda', category: 'moda', name: 'Moda' },
-  { slug: 'shopping', category: 'shopping', name: 'Supermercado y shopping' },
-  { slug: 'hogar', category: 'hogar', name: 'Hogar' },
-  { slug: 'deportes', category: 'deportes', name: 'Deportes' },
-  { slug: 'belleza', category: 'belleza', name: 'Belleza' },
-];
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  return [value];
+}
 
-export const LANDING_CITY_DEFINITIONS = [
-  { slug: 'buenos-aires', name: 'Buenos Aires', aliases: ['buenos aires', 'provincia de buenos aires'] },
-  { slug: 'caba', name: 'CABA', aliases: ['caba', 'ciudad autonoma de buenos aires', 'cdad autonoma de buenos aires', 'capital federal'] },
-  { slug: 'cordoba', name: 'Cordoba', aliases: ['cordoba', 'cordoba capital'] },
-  { slug: 'rosario', name: 'Rosario', aliases: ['rosario', 'santa fe'] },
-  { slug: 'mendoza', name: 'Mendoza', aliases: ['mendoza'] },
-  { slug: 'la-plata', name: 'La Plata', aliases: ['la plata'] },
-  { slug: 'mar-del-plata', name: 'Mar del Plata', aliases: ['mar del plata'] },
-  { slug: 'tucuman', name: 'Tucuman', aliases: ['tucuman', 'san miguel de tucuman'] },
-];
+function uniqueStrings(values) {
+  return Array.from(new Set(values.map((value) => String(value || '').trim()).filter(Boolean)));
+}
 
-function normalizeLandingValue(value) {
+export function normalizeLandingSearchText(value) {
   return String(value || '')
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
@@ -38,37 +22,253 @@ function normalizeLandingValue(value) {
     .trim();
 }
 
-export function resolveLandingBank(value) {
-  const normalized = normalizeLandingValue(value);
-  if (!normalized) return null;
-
-  return LANDING_BANK_DEFINITIONS.find((bank) => (
-    bank.slug === value ||
-    normalizeLandingValue(bank.slug) === normalized ||
-    bank.aliases.some((alias) => normalizeLandingValue(alias) === normalized)
-  )) || null;
+export function slugifyLandingValue(value) {
+  return normalizeLandingSearchText(value)
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
-export function resolveLandingCategory(value) {
-  const normalized = normalizeLandingValue(value);
-  if (!normalized) return null;
+function formatLandingName(value) {
+  const raw = String(value || '').replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
 
-  return LANDING_CATEGORY_DEFINITIONS.find((category) => (
-    category.slug === value ||
-    normalizeLandingValue(category.slug) === normalized ||
-    normalizeLandingValue(category.category) === normalized
-  )) || null;
+  return raw.split(' ').map((word, index) => {
+    if (/^[A-Z0-9]{2,}$/.test(word) || /[A-Z][a-z]+[A-Z]/.test(word)) {
+      return word;
+    }
+
+    const lower = word.toLowerCase();
+    if (index > 0 && LANDING_STOP_WORDS.has(lower)) {
+      return lower;
+    }
+
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+  }).join(' ');
 }
 
-export function resolveLandingCity(value) {
-  const normalized = normalizeLandingValue(value);
-  if (!normalized) return null;
+function getInitialsAlias(value) {
+  const initials = normalizeLandingSearchText(value)
+    .split(' ')
+    .filter((word) => word && !LANDING_STOP_WORDS.has(word))
+    .map((word) => word[0])
+    .join('');
 
-  return LANDING_CITY_DEFINITIONS.find((city) => (
-    city.slug === value ||
-    normalizeLandingValue(city.slug) === normalized ||
-    city.aliases.some((alias) => normalizeLandingValue(alias) === normalized)
-  )) || null;
+  return initials.length >= 3 && initials.length <= 6 ? initials : '';
+}
+
+export function compactLandingBankName(bankName) {
+  return String(bankName || '').replace(/^Banco\s+/i, '').trim();
+}
+
+function createAliases(...values) {
+  const aliases = new Set();
+
+  for (const value of values) {
+    const normalized = normalizeLandingSearchText(value);
+    if (normalized) aliases.add(normalized);
+
+    const slug = slugifyLandingValue(value);
+    if (slug) aliases.add(slug);
+
+    const initials = getInitialsAlias(value);
+    if (initials) aliases.add(initials);
+  }
+
+  return Array.from(aliases);
+}
+
+function definitionMatches(definition, value) {
+  const normalized = normalizeLandingSearchText(value);
+  const slug = slugifyLandingValue(value);
+  if (!normalized && !slug) return false;
+
+  const candidates = [
+    definition.slug,
+    definition.name,
+    definition.category,
+    ...(definition.aliases || []),
+  ];
+
+  return candidates.some((candidate) => (
+    normalizeLandingSearchText(candidate) === normalized ||
+    slugifyLandingValue(candidate) === slug
+  ));
+}
+
+function getDefinitionNameScore(name) {
+  const value = String(name || '');
+  let score = 0;
+  if (/^Banco\s/i.test(value)) score += 4;
+  if (/^[A-Z0-9]{2,}$/.test(value.replace(/\s+/g, ''))) score += 3;
+  if (/[A-Z]/.test(value) && /[a-z]/.test(value)) score += 2;
+  if (value.includes(' ')) score += 1;
+  return score;
+}
+
+function mergeDefinition(map, definition) {
+  if (!definition?.slug) return;
+
+  const existing = map.get(definition.slug);
+  if (!existing) {
+    map.set(definition.slug, {
+      ...definition,
+      aliases: uniqueStrings(definition.aliases || []),
+    });
+    return;
+  }
+
+  const existingScore = getDefinitionNameScore(existing.name);
+  const incomingScore = getDefinitionNameScore(definition.name);
+  const name = incomingScore > existingScore ? definition.name : existing.name;
+
+  map.set(definition.slug, {
+    ...existing,
+    name,
+    aliases: uniqueStrings([
+      ...(existing.aliases || []),
+      ...(definition.aliases || []),
+      definition.name,
+    ]),
+  });
+}
+
+export function buildLandingBankDefinition(value) {
+  const name = formatLandingName(value);
+  if (!name) return null;
+
+  const compactName = compactLandingBankName(name);
+  const slug = slugifyLandingValue(compactName || name);
+  if (!slug) return null;
+
+  return {
+    slug,
+    name,
+    aliases: createAliases(value, name, compactName, slug),
+  };
+}
+
+export function buildLandingCategoryDefinition(value) {
+  const category = slugifyLandingValue(value);
+  if (!category || EXCLUDED_CATEGORY_SLUGS.has(category)) return null;
+
+  return {
+    slug: category,
+    category,
+    name: formatLandingName(value),
+    aliases: createAliases(value, category),
+  };
+}
+
+export function buildLandingCityDefinition(value) {
+  const name = formatLandingName(value);
+  const slug = slugifyLandingValue(value);
+  if (!name || !slug) return null;
+
+  return {
+    slug,
+    name,
+    aliases: createAliases(value, name, slug),
+  };
+}
+
+export function resolveLandingBank(value, definitions = []) {
+  if (!normalizeLandingSearchText(value)) return null;
+  return definitions.find((bank) => definitionMatches(bank, value)) || buildLandingBankDefinition(value);
+}
+
+export function resolveLandingCategory(value, definitions = []) {
+  if (!normalizeLandingSearchText(value)) return null;
+  return definitions.find((category) => definitionMatches(category, value)) || buildLandingCategoryDefinition(value);
+}
+
+export function resolveLandingCity(value, definitions = []) {
+  if (!normalizeLandingSearchText(value)) return null;
+  return definitions.find((city) => definitionMatches(city, value)) || buildLandingCityDefinition(value);
+}
+
+function getSearchProfileBankNames(merchant) {
+  return toArray(merchant?.searchProfile?.benefits)
+    .flatMap((benefit) => String(benefit?.bankName || '').split(','))
+    .map((value) => value.trim());
+}
+
+export function getLandingBankValuesFromMerchant(merchant) {
+  return uniqueStrings([
+    ...getSearchProfileBankNames(merchant),
+    ...toArray(merchant?.banks),
+  ]);
+}
+
+export function getLandingCategoryValuesFromMerchant(merchant) {
+  return uniqueStrings(toArray(merchant?.categories))
+    .filter((category) => !EXCLUDED_CATEGORY_SLUGS.has(slugifyLandingValue(category)));
+}
+
+export function getLandingCityValuesFromMerchant(merchant) {
+  const values = [];
+
+  for (const location of toArray(merchant?.locations)) {
+    const components = location?.addressComponents || {};
+    values.push(
+      components.locality,
+      components.sublocality,
+      components.adminAreaLevel2,
+      components.adminAreaLevel1,
+    );
+  }
+
+  return uniqueStrings(values);
+}
+
+export function buildLandingBankDefinitionsFromMerchants(merchants) {
+  const map = new Map();
+  for (const merchant of toArray(merchants)) {
+    for (const value of getLandingBankValuesFromMerchant(merchant)) {
+      mergeDefinition(map, buildLandingBankDefinition(value));
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export function buildLandingCategoryDefinitionsFromMerchants(merchants) {
+  const map = new Map();
+  for (const merchant of toArray(merchants)) {
+    for (const value of getLandingCategoryValuesFromMerchant(merchant)) {
+      mergeDefinition(map, buildLandingCategoryDefinition(value));
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export function buildLandingCityDefinitionsFromMerchants(merchants) {
+  const map = new Map();
+  for (const merchant of toArray(merchants)) {
+    for (const value of getLandingCityValuesFromMerchant(merchant)) {
+      mergeDefinition(map, buildLandingCityDefinition(value));
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export function resolveLandingBankFromMerchants(value, merchants) {
+  return resolveLandingBank(value, buildLandingBankDefinitionsFromMerchants(merchants));
+}
+
+export function resolveLandingCategoryFromMerchants(value, merchants) {
+  return resolveLandingCategory(value, buildLandingCategoryDefinitionsFromMerchants(merchants));
+}
+
+export function resolveLandingCityFromMerchants(value, merchants) {
+  return resolveLandingCity(value, buildLandingCityDefinitionsFromMerchants(merchants));
+}
+
+export function getLandingCategoryMatchValues(category) {
+  return uniqueStrings([
+    category?.category,
+    category?.slug,
+    ...(category?.aliases || []),
+  ]).filter((value) => !EXCLUDED_CATEGORY_SLUGS.has(slugifyLandingValue(value)));
 }
 
 export function getLandingSeoPath(bank, category, city) {
@@ -76,10 +276,96 @@ export function getLandingSeoPath(bank, category, city) {
   return city ? `${basePath}/${city.slug}` : basePath;
 }
 
-export function compactLandingBankName(bankName) {
-  return String(bankName || '').replace(/^Banco\s+/i, '').trim();
+function addRouteCandidate(map, key, route) {
+  const existing = map.get(key);
+  if (existing) {
+    existing.count += 1;
+    return;
+  }
+
+  map.set(key, {
+    ...route,
+    count: 1,
+  });
 }
 
-export function normalizeLandingSearchText(value) {
-  return normalizeLandingValue(value);
+function buildDefinitionsForMerchant(merchant) {
+  const bankMap = new Map();
+  for (const value of getLandingBankValuesFromMerchant(merchant)) {
+    mergeDefinition(bankMap, buildLandingBankDefinition(value));
+  }
+
+  const categoryMap = new Map();
+  for (const value of getLandingCategoryValuesFromMerchant(merchant)) {
+    mergeDefinition(categoryMap, buildLandingCategoryDefinition(value));
+  }
+
+  const cityMap = new Map();
+  for (const value of getLandingCityValuesFromMerchant(merchant)) {
+    mergeDefinition(cityMap, buildLandingCityDefinition(value));
+  }
+
+  return {
+    banks: Array.from(bankMap.values()),
+    categories: Array.from(categoryMap.values()),
+    cities: Array.from(cityMap.values()),
+  };
+}
+
+function routeSort(a, b) {
+  if (b.count !== a.count) return b.count - a.count;
+  return a.path.localeCompare(b.path);
+}
+
+export function buildLandingSeoRoutesFromMerchants(merchants, options = {}) {
+  const minMerchantCount = Math.max(1, Number.parseInt(String(options.minMerchantCount || 3), 10));
+  const maxCityRoutesPerCombination = Math.max(
+    0,
+    Number.parseInt(String(options.maxCityRoutesPerCombination || 5), 10),
+  );
+  const nationalRoutes = new Map();
+  const cityRoutes = new Map();
+
+  for (const merchant of toArray(merchants)) {
+    const definitions = buildDefinitionsForMerchant(merchant);
+    if (definitions.banks.length === 0 || definitions.categories.length === 0) continue;
+
+    for (const bank of definitions.banks) {
+      for (const category of definitions.categories) {
+        const nationalKey = `${bank.slug}:${category.slug}`;
+        addRouteCandidate(nationalRoutes, nationalKey, {
+          path: getLandingSeoPath(bank, category),
+          changefreq: 'weekly',
+          priority: '0.8',
+        });
+
+        for (const city of definitions.cities) {
+          const cityKey = `${bank.slug}:${category.slug}:${city.slug}`;
+          addRouteCandidate(cityRoutes, cityKey, {
+            path: getLandingSeoPath(bank, category, city),
+            changefreq: 'weekly',
+            priority: '0.7',
+            parentKey: nationalKey,
+          });
+        }
+      }
+    }
+  }
+
+  const selectedCityRoutes = [];
+  const cityRoutesByParent = new Map();
+  for (const route of Array.from(cityRoutes.values()).filter((route) => route.count >= minMerchantCount).sort(routeSort)) {
+    const siblings = cityRoutesByParent.get(route.parentKey) || [];
+    if (siblings.length >= maxCityRoutesPerCombination) continue;
+    siblings.push(route);
+    cityRoutesByParent.set(route.parentKey, siblings);
+    selectedCityRoutes.push(route);
+  }
+
+  return [
+    ...Array.from(nationalRoutes.values()).filter((route) => route.count >= minMerchantCount),
+    ...selectedCityRoutes,
+  ]
+    .sort(routeSort)
+    .map(({ parentKey, count, ...route }) => route);
 }

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -96,6 +96,11 @@ function definitionMatches(definition, value) {
   ));
 }
 
+function resolveExistingLandingDefinition(value, definitions = []) {
+  if (!normalizeLandingSearchText(value)) return null;
+  return definitions.find((definition) => definitionMatches(definition, value)) || null;
+}
+
 function getDefinitionNameScore(name) {
   const value = String(name || '');
   let score = 0;
@@ -173,18 +178,15 @@ export function buildLandingCityDefinition(value) {
 }
 
 export function resolveLandingBank(value, definitions = []) {
-  if (!normalizeLandingSearchText(value)) return null;
-  return definitions.find((bank) => definitionMatches(bank, value)) || buildLandingBankDefinition(value);
+  return resolveExistingLandingDefinition(value, definitions) || buildLandingBankDefinition(value);
 }
 
 export function resolveLandingCategory(value, definitions = []) {
-  if (!normalizeLandingSearchText(value)) return null;
-  return definitions.find((category) => definitionMatches(category, value)) || buildLandingCategoryDefinition(value);
+  return resolveExistingLandingDefinition(value, definitions) || buildLandingCategoryDefinition(value);
 }
 
 export function resolveLandingCity(value, definitions = []) {
-  if (!normalizeLandingSearchText(value)) return null;
-  return definitions.find((city) => definitionMatches(city, value)) || buildLandingCityDefinition(value);
+  return resolveExistingLandingDefinition(value, definitions) || buildLandingCityDefinition(value);
 }
 
 function getSearchProfileBankNames(merchant) {
@@ -194,10 +196,7 @@ function getSearchProfileBankNames(merchant) {
 }
 
 export function getLandingBankValuesFromMerchant(merchant) {
-  return uniqueStrings([
-    ...getSearchProfileBankNames(merchant),
-    ...toArray(merchant?.banks),
-  ]);
+  return uniqueStrings(getSearchProfileBankNames(merchant));
 }
 
 export function getLandingCategoryValuesFromMerchant(merchant) {
@@ -252,15 +251,15 @@ export function buildLandingCityDefinitionsFromMerchants(merchants) {
 }
 
 export function resolveLandingBankFromMerchants(value, merchants) {
-  return resolveLandingBank(value, buildLandingBankDefinitionsFromMerchants(merchants));
+  return resolveExistingLandingDefinition(value, buildLandingBankDefinitionsFromMerchants(merchants));
 }
 
 export function resolveLandingCategoryFromMerchants(value, merchants) {
-  return resolveLandingCategory(value, buildLandingCategoryDefinitionsFromMerchants(merchants));
+  return resolveExistingLandingDefinition(value, buildLandingCategoryDefinitionsFromMerchants(merchants));
 }
 
 export function resolveLandingCityFromMerchants(value, merchants) {
-  return resolveLandingCity(value, buildLandingCityDefinitionsFromMerchants(merchants));
+  return resolveExistingLandingDefinition(value, buildLandingCityDefinitionsFromMerchants(merchants));
 }
 
 export function getLandingCategoryMatchValues(category) {
@@ -317,17 +316,36 @@ function routeSort(a, b) {
   return a.path.localeCompare(b.path);
 }
 
+function getAllowedSlugSet(values) {
+  if (!values) return null;
+  const slugs = toArray(values).map((value) => slugifyLandingValue(value)).filter(Boolean);
+  return slugs.length > 0 ? new Set(slugs) : null;
+}
+
+function filterDefinitionsByAllowedSlugs(definitions, allowedSlugs) {
+  if (!allowedSlugs) return definitions;
+  return definitions.filter((definition) => allowedSlugs.has(definition.slug));
+}
+
 export function buildLandingSeoRoutesFromMerchants(merchants, options = {}) {
   const minMerchantCount = Math.max(1, Number.parseInt(String(options.minMerchantCount || 3), 10));
   const maxCityRoutesPerCombination = Math.max(
     0,
     Number.parseInt(String(options.maxCityRoutesPerCombination || 5), 10),
   );
+  const allowedBankSlugs = getAllowedSlugSet(options.allowedBankSlugs);
+  const allowedCategorySlugs = getAllowedSlugSet(options.allowedCategorySlugs);
+  const allowedCitySlugs = getAllowedSlugSet(options.allowedCitySlugs);
   const nationalRoutes = new Map();
   const cityRoutes = new Map();
 
   for (const merchant of toArray(merchants)) {
-    const definitions = buildDefinitionsForMerchant(merchant);
+    const merchantDefinitions = buildDefinitionsForMerchant(merchant);
+    const definitions = {
+      banks: filterDefinitionsByAllowedSlugs(merchantDefinitions.banks, allowedBankSlugs),
+      categories: filterDefinitionsByAllowedSlugs(merchantDefinitions.categories, allowedCategorySlugs),
+      cities: filterDefinitionsByAllowedSlugs(merchantDefinitions.cities, allowedCitySlugs),
+    };
     if (definitions.banks.length === 0 || definitions.categories.length === 0) continue;
 
     for (const bank of definitions.banks) {

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -1,0 +1,85 @@
+export const LANDING_BANK_DEFINITIONS = [
+  { slug: 'galicia', name: 'Banco Galicia', aliases: ['galicia'] },
+  { slug: 'santander', name: 'Banco Santander', aliases: ['santander', 'rio'] },
+  { slug: 'bbva', name: 'BBVA', aliases: ['bbva', 'frances', 'banco frances'] },
+  { slug: 'macro', name: 'Banco Macro', aliases: ['macro'] },
+  { slug: 'nacion', name: 'Banco Nacion', aliases: ['nacion', 'bna', 'banco nacion'] },
+  { slug: 'icbc', name: 'ICBC', aliases: ['icbc'] },
+];
+
+export const LANDING_CATEGORY_DEFINITIONS = [
+  { slug: 'gastronomia', category: 'gastronomia', name: 'Gastronomia' },
+  { slug: 'moda', category: 'moda', name: 'Moda' },
+  { slug: 'shopping', category: 'shopping', name: 'Supermercado y shopping' },
+  { slug: 'hogar', category: 'hogar', name: 'Hogar' },
+  { slug: 'deportes', category: 'deportes', name: 'Deportes' },
+  { slug: 'belleza', category: 'belleza', name: 'Belleza' },
+];
+
+export const LANDING_CITY_DEFINITIONS = [
+  { slug: 'buenos-aires', name: 'Buenos Aires', aliases: ['buenos aires', 'provincia de buenos aires'] },
+  { slug: 'caba', name: 'CABA', aliases: ['caba', 'ciudad autonoma de buenos aires', 'cdad autonoma de buenos aires', 'capital federal'] },
+  { slug: 'cordoba', name: 'Cordoba', aliases: ['cordoba', 'cordoba capital'] },
+  { slug: 'rosario', name: 'Rosario', aliases: ['rosario', 'santa fe'] },
+  { slug: 'mendoza', name: 'Mendoza', aliases: ['mendoza'] },
+  { slug: 'la-plata', name: 'La Plata', aliases: ['la plata'] },
+  { slug: 'mar-del-plata', name: 'Mar del Plata', aliases: ['mar del plata'] },
+  { slug: 'tucuman', name: 'Tucuman', aliases: ['tucuman', 'san miguel de tucuman'] },
+];
+
+function normalizeLandingValue(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/-/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function resolveLandingBank(value) {
+  const normalized = normalizeLandingValue(value);
+  if (!normalized) return null;
+
+  return LANDING_BANK_DEFINITIONS.find((bank) => (
+    bank.slug === value ||
+    normalizeLandingValue(bank.slug) === normalized ||
+    bank.aliases.some((alias) => normalizeLandingValue(alias) === normalized)
+  )) || null;
+}
+
+export function resolveLandingCategory(value) {
+  const normalized = normalizeLandingValue(value);
+  if (!normalized) return null;
+
+  return LANDING_CATEGORY_DEFINITIONS.find((category) => (
+    category.slug === value ||
+    normalizeLandingValue(category.slug) === normalized ||
+    normalizeLandingValue(category.category) === normalized
+  )) || null;
+}
+
+export function resolveLandingCity(value) {
+  const normalized = normalizeLandingValue(value);
+  if (!normalized) return null;
+
+  return LANDING_CITY_DEFINITIONS.find((city) => (
+    city.slug === value ||
+    normalizeLandingValue(city.slug) === normalized ||
+    city.aliases.some((alias) => normalizeLandingValue(alias) === normalized)
+  )) || null;
+}
+
+export function getLandingSeoPath(bank, category, city) {
+  const basePath = `/descuentos/${bank.slug}/${category.slug}`;
+  return city ? `${basePath}/${city.slug}` : basePath;
+}
+
+export function compactLandingBankName(bankName) {
+  return String(bankName || '').replace(/^Banco\s+/i, '').trim();
+}
+
+export function normalizeLandingSearchText(value) {
+  return normalizeLandingValue(value);
+}

--- a/api/landing-seo-data.js
+++ b/api/landing-seo-data.js
@@ -192,6 +192,26 @@ const CLIENT_LANDING_BANK_DEFINITIONS = [
   { slug: 'icbc', name: 'ICBC', aliases: createAliases('icbc', 'ICBC') },
 ];
 
+const CLIENT_LANDING_CATEGORY_DEFINITIONS = [
+  { slug: 'gastronomia', category: 'gastronomia', name: 'Gastronomia', aliases: createAliases('gastronomia') },
+  { slug: 'moda', category: 'moda', name: 'Moda', aliases: createAliases('moda') },
+  { slug: 'shopping', category: 'shopping', name: 'Supermercado y shopping', aliases: createAliases('shopping') },
+  { slug: 'hogar', category: 'hogar', name: 'Hogar', aliases: createAliases('hogar') },
+  { slug: 'deportes', category: 'deportes', name: 'Deportes', aliases: createAliases('deportes') },
+  { slug: 'belleza', category: 'belleza', name: 'Belleza', aliases: createAliases('belleza') },
+];
+
+const CLIENT_LANDING_CITY_DEFINITIONS = [
+  { slug: 'buenos-aires', name: 'Buenos Aires', aliases: createAliases('buenos aires', 'provincia de buenos aires') },
+  { slug: 'caba', name: 'CABA', aliases: createAliases('caba', 'ciudad autonoma de buenos aires', 'cdad autonoma de buenos aires', 'capital federal') },
+  { slug: 'cordoba', name: 'Cordoba', aliases: createAliases('cordoba', 'cordoba capital') },
+  { slug: 'rosario', name: 'Rosario', aliases: createAliases('rosario', 'santa fe') },
+  { slug: 'mendoza', name: 'Mendoza', aliases: createAliases('mendoza') },
+  { slug: 'la-plata', name: 'La Plata', aliases: createAliases('la plata') },
+  { slug: 'mar-del-plata', name: 'Mar del Plata', aliases: createAliases('mar del plata') },
+  { slug: 'tucuman', name: 'Tucuman', aliases: createAliases('tucuman', 'san miguel de tucuman') },
+];
+
 export function resolveLandingBank(value, definitions = []) {
   return resolveExistingLandingDefinition(value, definitions) || buildLandingBankDefinition(value);
 }
@@ -202,6 +222,18 @@ export function resolveLandingCategory(value, definitions = []) {
 
 export function resolveLandingCity(value, definitions = []) {
   return resolveExistingLandingDefinition(value, definitions) || buildLandingCityDefinition(value);
+}
+
+export function resolveClientLandingBank(value) {
+  return resolveExistingLandingDefinition(value, CLIENT_LANDING_BANK_DEFINITIONS);
+}
+
+export function resolveClientLandingCategory(value) {
+  return resolveExistingLandingDefinition(value, CLIENT_LANDING_CATEGORY_DEFINITIONS);
+}
+
+export function resolveClientLandingCity(value) {
+  return resolveExistingLandingDefinition(value, CLIENT_LANDING_CITY_DEFINITIONS);
 }
 
 function getSearchProfileBankNames(merchant) {
@@ -225,11 +257,18 @@ export function getLandingCityValuesFromMerchant(merchant) {
   for (const location of toArray(merchant?.locations)) {
     const components = location?.addressComponents || {};
     values.push(
+      location?.formattedAddress,
+      location?.name,
+    );
+    values.push(
       components.locality,
       components.sublocality,
       components.adminAreaLevel2,
       components.adminAreaLevel1,
     );
+    if (typeof location?.raw === 'string') {
+      values.push(location.raw);
+    }
   }
 
   return uniqueStrings(values);
@@ -273,12 +312,14 @@ export function resolveLandingBankFromMerchants(value, merchants, options = {}) 
   return resolveExistingLandingDefinition(value, buildLandingBankDefinitionsFromMerchants(merchants, seedDefinitions));
 }
 
-export function resolveLandingCategoryFromMerchants(value, merchants) {
-  return resolveExistingLandingDefinition(value, buildLandingCategoryDefinitionsFromMerchants(merchants));
+export function resolveLandingCategoryFromMerchants(value, merchants, options = {}) {
+  const seedDefinitions = options.includeClientDefinitions ? CLIENT_LANDING_CATEGORY_DEFINITIONS : options.seedDefinitions;
+  return resolveExistingLandingDefinition(value, buildLandingCategoryDefinitionsFromMerchants(merchants, seedDefinitions));
 }
 
-export function resolveLandingCityFromMerchants(value, merchants) {
-  return resolveExistingLandingDefinition(value, buildLandingCityDefinitionsFromMerchants(merchants));
+export function resolveLandingCityFromMerchants(value, merchants, options = {}) {
+  const seedDefinitions = options.includeClientDefinitions ? CLIENT_LANDING_CITY_DEFINITIONS : options.seedDefinitions;
+  return resolveExistingLandingDefinition(value, buildLandingCityDefinitionsFromMerchants(merchants, seedDefinitions));
 }
 
 export function getLandingCategoryMatchValues(category) {

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -9,6 +9,9 @@ import {
   resolveLandingBank,
   resolveLandingCategory,
   resolveLandingCity,
+  resolveClientLandingBank,
+  resolveClientLandingCategory,
+  resolveClientLandingCity,
 } from './landing-seo-data.js';
 import {
   getMerchantSeoPathFromMerchant,
@@ -498,4 +501,7 @@ export {
   resolveLandingCategoryFromMerchants,
   resolveLandingCity,
   resolveLandingCityFromMerchants,
+  resolveClientLandingBank,
+  resolveClientLandingCategory,
+  resolveClientLandingCity,
 };

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -19,7 +19,7 @@ const DEFAULT_SITE_NAME = 'Blink';
 const DEFAULT_SITE_URL = 'https://www.blinkapp.com.ar';
 const DEFAULT_OG_IMAGE = '/pwa-512x512.png';
 const LANDING_PAGE_SIZE = 24;
-const LANDING_FETCH_LIMIT = 500;
+const LANDING_CITY_FETCH_BATCH_SIZE = 500;
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -319,7 +319,7 @@ function buildHeadHtml({ title, description, absoluteUrl, structuredData }) {
     `    <meta name="twitter:title" content="${escapedTitle}" />`,
     `    <meta name="twitter:description" content="${escapedDescription}" />`,
     `    <meta name="twitter:image" content="${escapedImage}" />`,
-    `    <script type="application/ld+json" data-blink-landing-seo="structured-data">${escapeJsonForHtml(structuredData)}</script>`,
+    `    <script type="application/ld+json" data-blink-landing-seo="structured-data" data-blink-seo-url="${escapedUrl}">${escapeJsonForHtml(structuredData)}</script>`,
     '    <style data-blink-landing-seo>',
     '      .blink-landing-shell{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;max-width:1040px;margin:0 auto;padding:32px 20px 56px;color:#111827;background:#fff}',
     '      .blink-landing-breadcrumb{display:flex;gap:8px;flex-wrap:wrap;font-size:14px;margin-bottom:32px;color:#4b5563}.blink-landing-breadcrumb a{color:#111827}',
@@ -339,7 +339,44 @@ function getBankPatterns(bank) {
       compactLandingBankName(bank.name),
       ...(bank.aliases || []),
     ].filter(Boolean))
-  ).map((value) => new RegExp(escapeRegex(value), 'i'));
+  )
+    .filter((value) => normalizeLandingSearchText(value).length >= 2)
+    .map((value) => {
+      const phrasePattern = escapeRegex(String(value).trim()).replace(/\s+/g, '\\s+');
+      return new RegExp(`(^|[^A-Za-z0-9])${phrasePattern}([^A-Za-z0-9]|$)`, 'i');
+    });
+}
+
+function getLandingSort() {
+  return { activeBenefitCount: -1, maxDiscountPercentage: -1, benefitCount: -1, merchantName: 1 };
+}
+
+async function loadCityLandingSeoData({ collection, merchantQuery, projection, city }) {
+  let resultCount = 0;
+  const merchants = [];
+
+  for (let skip = 0; ; skip += LANDING_CITY_FETCH_BATCH_SIZE) {
+    const batch = await collection
+      .find(merchantQuery, { projection })
+      .sort(getLandingSort())
+      .skip(skip)
+      .limit(LANDING_CITY_FETCH_BATCH_SIZE)
+      .toArray();
+
+    if (batch.length === 0) break;
+
+    for (const merchant of batch) {
+      if (!merchantMatchesCity(merchant, city)) continue;
+      resultCount += 1;
+      if (merchants.length < LANDING_PAGE_SIZE) {
+        merchants.push(merchant);
+      }
+    }
+
+    if (batch.length < LANDING_CITY_FETCH_BATCH_SIZE) break;
+  }
+
+  return { resultCount, merchants };
 }
 
 export async function loadLandingSeoData({ db, merchantCollectionName, bank, category, city }) {
@@ -347,9 +384,9 @@ export async function loadLandingSeoData({ db, merchantCollectionName, bank, cat
   const merchantQuery = {
     isActive: { $ne: false },
     merchantId: { $exists: true, $type: 'string' },
-    benefitCount: { $gt: 0 },
+    activeBenefitCount: { $gt: 0 },
     categories: { $in: categoryValues },
-    banks: { $in: getBankPatterns(bank) },
+    'searchProfile.benefits.bankName': { $in: getBankPatterns(bank) },
   };
   const projection = {
     _id: 0,
@@ -364,18 +401,28 @@ export async function loadLandingSeoData({ db, merchantCollectionName, bank, cat
     searchProfile: 1,
   };
   const collection = db.collection(merchantCollectionName);
-  const baseCountPromise = city ? null : collection.countDocuments(merchantQuery);
-  const merchants = await collection
-    .find(merchantQuery, { projection })
-    .sort({ activeBenefitCount: -1, maxDiscountPercentage: -1, benefitCount: -1, merchantName: 1 })
-    .limit(city ? LANDING_FETCH_LIMIT : LANDING_PAGE_SIZE)
-    .toArray();
-  const filteredMerchants = city ? merchants.filter((merchant) => merchantMatchesCity(merchant, city)) : merchants;
-  const resultCount = city ? filteredMerchants.length : await baseCountPromise;
+
+  if (city) {
+    return loadCityLandingSeoData({
+      collection,
+      merchantQuery,
+      projection,
+      city,
+    });
+  }
+
+  const [resultCount, merchants] = await Promise.all([
+    collection.countDocuments(merchantQuery),
+    collection
+      .find(merchantQuery, { projection })
+      .sort(getLandingSort())
+      .limit(LANDING_PAGE_SIZE)
+      .toArray(),
+  ]);
 
   return {
     resultCount,
-    merchants: filteredMerchants.slice(0, LANDING_PAGE_SIZE),
+    merchants,
   };
 }
 

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -1,0 +1,425 @@
+import {
+  compactLandingBankName,
+  getLandingSeoPath,
+  normalizeLandingSearchText,
+  resolveLandingBank,
+  resolveLandingCategory,
+  resolveLandingCity,
+} from './landing-seo-data.js';
+import {
+  getMerchantSeoPathFromMerchant,
+  readViteAppShell,
+} from './merchant-seo.js';
+
+const DEFAULT_SITE_NAME = 'Blink';
+const DEFAULT_SITE_URL = 'https://www.blinkapp.com.ar';
+const DEFAULT_OG_IMAGE = '/pwa-512x512.png';
+const LANDING_PAGE_SIZE = 24;
+const LANDING_FETCH_LIMIT = 500;
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeRegex(value) {
+  return String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeJsonForHtml(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function toAbsoluteUrl(siteUrl, pathOrUrl) {
+  if (/^https?:\/\//i.test(pathOrUrl)) {
+    return pathOrUrl;
+  }
+
+  const normalizedSiteUrl = String(siteUrl || DEFAULT_SITE_URL).replace(/\/$/, '');
+  const normalizedPath = String(pathOrUrl || '/').startsWith('/') ? pathOrUrl : `/${pathOrUrl}`;
+  return `${normalizedSiteUrl}${normalizedPath}`;
+}
+
+function stripDefaultSeo(shell) {
+  return shell
+    .replace(/<title>[\s\S]*?<\/title>\s*/i, '')
+    .replace(/<meta\s+(name|property)=["'](?:description|robots|keywords|og:[^"']+|twitter:[^"']+)["'][^>]*>\s*/gi, '')
+    .replace(/<link\s+rel=["']canonical["'][^>]*>\s*/gi, '')
+    .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>\s*/gi, '');
+}
+
+function injectHead(shell, headHtml) {
+  const strippedShell = stripDefaultSeo(shell);
+  if (strippedShell.includes('</head>')) {
+    return strippedShell.replace('</head>', `${headHtml}\n  </head>`);
+  }
+
+  return `${headHtml}\n${strippedShell}`;
+}
+
+function injectBody(shell, bodyHtml) {
+  const rootPattern = /<div\s+id=["']root["']\s*><\/div>/i;
+  if (rootPattern.test(shell)) {
+    return shell.replace(rootPattern, `<div id="root">${bodyHtml}</div>`);
+  }
+
+  if (shell.includes('<body>')) {
+    return shell.replace('<body>', `<body>\n<div id="root">${bodyHtml}</div>`);
+  }
+
+  return `${shell}\n<div id="root">${bodyHtml}</div>`;
+}
+
+function getMerchantBanks(merchant) {
+  const banks = Array.isArray(merchant?.banks) ? merchant.banks : [];
+  return banks.filter(Boolean).slice(0, 4).join(', ') || 'bancos participantes';
+}
+
+function getMerchantLocation(merchant) {
+  const locations = Array.isArray(merchant?.locations) ? merchant.locations : [];
+  const firstLocation = locations[0];
+  const components = firstLocation?.addressComponents || {};
+  return components.locality ||
+    components.sublocality ||
+    components.adminAreaLevel2 ||
+    components.adminAreaLevel1 ||
+    firstLocation?.formattedAddress ||
+    'Argentina';
+}
+
+function getMerchantDiscountText(merchant) {
+  const discount = Number(merchant?.maxDiscountPercentage || 0);
+  if (Number.isFinite(discount) && discount > 0) {
+    return `hasta ${discount}% OFF`;
+  }
+
+  const count = Number(merchant?.activeBenefitCount || merchant?.benefitCount || 0);
+  return count === 1 ? '1 beneficio' : `${count} beneficios`;
+}
+
+function collectLocationText(merchant) {
+  const parts = [];
+  for (const location of Array.isArray(merchant?.locations) ? merchant.locations : []) {
+    if (location?.formattedAddress) parts.push(location.formattedAddress);
+    if (location?.name) parts.push(location.name);
+    if (location?.addressComponents?.locality) parts.push(location.addressComponents.locality);
+    if (location?.addressComponents?.adminAreaLevel1) parts.push(location.addressComponents.adminAreaLevel1);
+    if (location?.addressComponents?.adminAreaLevel2) parts.push(location.addressComponents.adminAreaLevel2);
+    if (typeof location?.raw === 'string') parts.push(location.raw);
+    if (location?.raw && typeof location.raw === 'object') parts.push(JSON.stringify(location.raw));
+  }
+
+  return parts.map((part) => normalizeLandingSearchText(part));
+}
+
+function merchantMatchesCity(merchant, city) {
+  if (!city) return true;
+  const locationText = collectLocationText(merchant);
+  return locationText.some((text) => (
+    city.aliases.some((alias) => text.includes(normalizeLandingSearchText(alias)))
+  ));
+}
+
+function buildDescription({ bank, category, city, resultCount }) {
+  const locationText = city ? ` en ${city.name}` : ' en Argentina';
+  const countPrefix = resultCount > 0 ? `${resultCount} comercios con ` : '';
+  return `Descubri ${countPrefix}descuentos y beneficios de ${bank.name} en ${category.name}${locationText}. Compara bancos, topes y promociones activas en Blink.`;
+}
+
+function buildTitle({ bank, category, city }) {
+  return `Descuentos ${bank.name} en ${category.name}${city ? ` en ${city.name}` : ''} | ${DEFAULT_SITE_NAME}`;
+}
+
+function buildFaqItems({ bank, category, city }) {
+  const locationText = city ? ` en ${city.name}` : '';
+  return [
+    {
+      question: `Como encontrar descuentos de ${bank.name} en ${category.name}${locationText}?`,
+      answer: `Filtra por ${bank.name} y ${category.name}${locationText} para ver comercios adheridos, condiciones y beneficios vigentes.`,
+    },
+    {
+      question: 'Como saber si un beneficio aplica hoy?',
+      answer: 'Revisa la vigencia, los dias de aplicacion y el tope de reintegro en cada beneficio.',
+    },
+    {
+      question: 'Blink sirve para todo Argentina?',
+      answer: 'Si. Puedes explorar beneficios por ciudad o a nivel nacional en toda Argentina.',
+    },
+  ];
+}
+
+function buildRelatedLinks({ bank, category, city }) {
+  const links = [
+    {
+      href: `/search?bank=${encodeURIComponent(bank.slug)}&category=${encodeURIComponent(category.slug)}`,
+      label: `Ver filtros de ${compactLandingBankName(bank.name)} y ${category.name}`,
+    },
+  ];
+
+  if (city) {
+    links.push({
+      href: getLandingSeoPath(bank, category),
+      label: `${compactLandingBankName(bank.name)} en ${category.name} a nivel nacional`,
+    });
+  }
+
+  return links;
+}
+
+function buildStructuredData({ bank, category, city, merchants, absoluteUrl, description, faqItems }) {
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: buildTitle({ bank, category, city }),
+      description,
+      url: absoluteUrl,
+      inLanguage: 'es-AR',
+      isPartOf: {
+        '@type': 'WebSite',
+        name: DEFAULT_SITE_NAME,
+        url: new URL('/', absoluteUrl).toString(),
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: DEFAULT_SITE_NAME,
+          item: new URL('/', absoluteUrl).toString(),
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Descuentos',
+          item: new URL('/search', absoluteUrl).toString(),
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: `${bank.name} en ${category.name}`,
+          item: absoluteUrl,
+        },
+      ],
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqItems.map((item) => ({
+        '@type': 'Question',
+        name: item.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: item.answer,
+        },
+      })),
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: `${bank.name} en ${category.name}${city ? ` en ${city.name}` : ''}`,
+      numberOfItems: merchants.length,
+      itemListElement: merchants.map((merchant, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: merchant.merchantName,
+        url: new URL(getMerchantSeoPathFromMerchant(merchant), absoluteUrl).toString(),
+      })),
+    },
+  ];
+}
+
+function renderMerchantLinks(merchants) {
+  if (merchants.length === 0) {
+    return '<p class="blink-landing-empty">Todavia no hay comercios publicados para esta combinacion.</p>';
+  }
+
+  return [
+    '<ol class="blink-landing-list">',
+    ...merchants.map((merchant) => {
+      const href = getMerchantSeoPathFromMerchant(merchant);
+      return [
+        '<li class="blink-landing-card">',
+        `  <a href="${escapeHtml(href)}">`,
+        `    <strong>${escapeHtml(merchant.merchantName || 'Comercio')}</strong>`,
+        `    <span>${escapeHtml(getMerchantDiscountText(merchant))}</span>`,
+        `    <small>${escapeHtml(getMerchantBanks(merchant))} · ${escapeHtml(getMerchantLocation(merchant))}</small>`,
+        '  </a>',
+        '</li>',
+      ].join('\n');
+    }),
+    '</ol>',
+  ].join('\n');
+}
+
+function renderRelatedLinks(links) {
+  if (links.length === 0) return '';
+
+  return [
+    '<nav class="blink-landing-related" aria-label="Enlaces relacionados">',
+    ...links.map((link) => `<a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`),
+    '</nav>',
+  ].join('\n');
+}
+
+function buildBodyHtml({ bank, category, city, merchants, resultCount, description, relatedLinks }) {
+  return [
+    '<main class="blink-landing-shell" data-blink-landing-seo>',
+    '  <nav class="blink-landing-breadcrumb" aria-label="Breadcrumb"><a href="/">Blink</a><span>/</span><a href="/search">Descuentos</a><span>/</span><span>' + escapeHtml(bank.name) + '</span><span>/</span><span>' + escapeHtml(category.name) + '</span></nav>',
+    '  <section class="blink-landing-hero">',
+    '    <p class="blink-landing-kicker">Descuentos</p>',
+    `    <h1>Descuentos ${escapeHtml(bank.name)} en ${escapeHtml(category.name)}${city ? ` en ${escapeHtml(city.name)}` : ''}</h1>`,
+    `    <p>${escapeHtml(description)}</p>`,
+    `    <a class="blink-landing-search" href="/search?bank=${escapeHtml(encodeURIComponent(bank.slug))}&category=${escapeHtml(encodeURIComponent(category.slug))}">Ver en buscador</a>`,
+    '  </section>',
+    '  <section class="blink-landing-section">',
+    `    <h2>${escapeHtml(resultCount.toLocaleString('es-AR'))} comercios encontrados</h2>`,
+    renderMerchantLinks(merchants),
+    renderRelatedLinks(relatedLinks),
+    '  </section>',
+    '</main>',
+  ].join('\n');
+}
+
+function buildHeadHtml({ title, description, absoluteUrl, structuredData }) {
+  const escapedTitle = escapeHtml(title);
+  const escapedDescription = escapeHtml(description);
+  const escapedUrl = escapeHtml(absoluteUrl);
+  const escapedImage = escapeHtml(toAbsoluteUrl(new URL(absoluteUrl).origin, DEFAULT_OG_IMAGE));
+
+  return [
+    `    <title>${escapedTitle}</title>`,
+    `    <meta name="description" content="${escapedDescription}" />`,
+    '    <meta name="robots" content="index, follow" />',
+    `    <link rel="canonical" href="${escapedUrl}" />`,
+    '    <meta property="og:site_name" content="Blink" />',
+    '    <meta property="og:locale" content="es_AR" />',
+    '    <meta property="og:type" content="website" />',
+    `    <meta property="og:title" content="${escapedTitle}" />`,
+    `    <meta property="og:description" content="${escapedDescription}" />`,
+    `    <meta property="og:url" content="${escapedUrl}" />`,
+    `    <meta property="og:image" content="${escapedImage}" />`,
+    '    <meta name="twitter:card" content="summary_large_image" />',
+    `    <meta name="twitter:title" content="${escapedTitle}" />`,
+    `    <meta name="twitter:description" content="${escapedDescription}" />`,
+    `    <meta name="twitter:image" content="${escapedImage}" />`,
+    `    <script type="application/ld+json" data-blink-landing-seo="structured-data">${escapeJsonForHtml(structuredData)}</script>`,
+    '    <style data-blink-landing-seo>',
+    '      .blink-landing-shell{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;max-width:1040px;margin:0 auto;padding:32px 20px 56px;color:#111827;background:#fff}',
+    '      .blink-landing-breadcrumb{display:flex;gap:8px;flex-wrap:wrap;font-size:14px;margin-bottom:32px;color:#4b5563}.blink-landing-breadcrumb a{color:#111827}',
+    '      .blink-landing-kicker{text-transform:uppercase;font-size:12px;letter-spacing:.08em;font-weight:700;color:#4f46e5}.blink-landing-hero h1{font-size:40px;line-height:1.05;margin:8px 0 12px}.blink-landing-hero p{font-size:18px;line-height:1.55;color:#374151}.blink-landing-search{display:inline-flex;margin-top:12px;color:#4f46e5;font-weight:700}',
+    '      .blink-landing-section{margin-top:36px}.blink-landing-section h2{font-size:24px;margin:0 0 14px}.blink-landing-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;list-style:none;margin:0;padding:0}.blink-landing-card a{display:block;border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fafafa;color:#111827;text-decoration:none}.blink-landing-card strong{display:block;font-size:18px}.blink-landing-card span,.blink-landing-card small{display:block;margin-top:5px;color:#4b5563}.blink-landing-card small{font-size:12px}.blink-landing-empty{color:#6b7280}',
+    '      .blink-landing-related{display:flex;flex-wrap:wrap;gap:12px;margin-top:28px}.blink-landing-related a{font-weight:700;color:#4f46e5}',
+    '      @media (max-width:640px){.blink-landing-shell{padding:24px 16px 48px}.blink-landing-hero h1{font-size:32px}}',
+    '    </style>',
+  ].join('\n');
+}
+
+function getBankPatterns(bank) {
+  return Array.from(
+    new Set([
+      bank.slug,
+      bank.name,
+      compactLandingBankName(bank.name),
+      ...(bank.aliases || []),
+    ].filter(Boolean))
+  ).map((value) => new RegExp(escapeRegex(value), 'i'));
+}
+
+export async function loadLandingSeoData({ db, merchantCollectionName, bank, category, city }) {
+  const merchantQuery = {
+    isActive: { $ne: false },
+    merchantId: { $exists: true, $type: 'string' },
+    benefitCount: { $gt: 0 },
+    categories: { $in: [category.category || category.slug] },
+    banks: { $in: getBankPatterns(bank) },
+  };
+  const projection = {
+    _id: 0,
+    merchantId: 1,
+    merchantName: 1,
+    categories: 1,
+    banks: 1,
+    locations: 1,
+    benefitCount: 1,
+    activeBenefitCount: 1,
+    maxDiscountPercentage: 1,
+  };
+  const collection = db.collection(merchantCollectionName);
+  const baseCountPromise = city ? null : collection.countDocuments(merchantQuery);
+  const merchants = await collection
+    .find(merchantQuery, { projection })
+    .sort({ activeBenefitCount: -1, maxDiscountPercentage: -1, benefitCount: -1, merchantName: 1 })
+    .limit(city ? LANDING_FETCH_LIMIT : LANDING_PAGE_SIZE)
+    .toArray();
+  const filteredMerchants = city ? merchants.filter((merchant) => merchantMatchesCity(merchant, city)) : merchants;
+  const resultCount = city ? filteredMerchants.length : await baseCountPromise;
+
+  return {
+    resultCount,
+    merchants: filteredMerchants.slice(0, LANDING_PAGE_SIZE),
+  };
+}
+
+export function renderLandingSeoHtml({
+  appShell,
+  bank,
+  category,
+  city,
+  merchants,
+  resultCount,
+  path,
+  siteUrl,
+}) {
+  const absoluteUrl = toAbsoluteUrl(siteUrl, path);
+  const title = buildTitle({ bank, category, city });
+  const description = buildDescription({ bank, category, city, resultCount });
+  const faqItems = buildFaqItems({ bank, category, city });
+  const relatedLinks = buildRelatedLinks({ bank, category, city });
+  const structuredData = buildStructuredData({
+    bank,
+    category,
+    city,
+    merchants,
+    absoluteUrl,
+    description,
+    faqItems,
+  });
+  const headHtml = buildHeadHtml({
+    title,
+    description,
+    absoluteUrl,
+    structuredData,
+  });
+  const bodyHtml = buildBodyHtml({
+    bank,
+    category,
+    city,
+    merchants,
+    resultCount,
+    description,
+    relatedLinks,
+  });
+
+  return injectBody(injectHead(appShell, headHtml), bodyHtml);
+}
+
+export {
+  getLandingSeoPath,
+  readViteAppShell,
+  resolveLandingBank,
+  resolveLandingCategory,
+  resolveLandingCity,
+};

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -342,9 +342,29 @@ function getBankPatterns(bank) {
   )
     .filter((value) => normalizeLandingSearchText(value).length >= 2)
     .map((value) => {
-      const phrasePattern = escapeRegex(String(value).trim()).replace(/\s+/g, '\\s+');
+      const phrasePattern = buildAccentInsensitiveRegexSource(value);
       return new RegExp(`(^|[^A-Za-z0-9])${phrasePattern}([^A-Za-z0-9]|$)`, 'i');
     });
+}
+
+function buildAccentInsensitiveRegexSource(value) {
+  const accentClasses = {
+    a: '[aAáÁàÀäÄâÂãÃ]',
+    e: '[eEéÉèÈëËêÊ]',
+    i: '[iIíÍìÌïÏîÎ]',
+    o: '[oOóÓòÒöÖôÔõÕ]',
+    u: '[uUúÚùÙüÜûÛ]',
+    n: '[nNñÑ]',
+    c: '[cCçÇ]',
+  };
+
+  return normalizeLandingSearchText(value)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => Array.from(word)
+      .map((char) => accentClasses[char] || escapeRegex(char))
+      .join(''))
+    .join('\\s+');
 }
 
 function getLandingSort() {

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -1,7 +1,11 @@
 import {
   compactLandingBankName,
+  getLandingCategoryMatchValues,
   getLandingSeoPath,
   normalizeLandingSearchText,
+  resolveLandingBankFromMerchants,
+  resolveLandingCategoryFromMerchants,
+  resolveLandingCityFromMerchants,
   resolveLandingBank,
   resolveLandingCategory,
   resolveLandingCity,
@@ -339,11 +343,12 @@ function getBankPatterns(bank) {
 }
 
 export async function loadLandingSeoData({ db, merchantCollectionName, bank, category, city }) {
+  const categoryValues = getLandingCategoryMatchValues(category);
   const merchantQuery = {
     isActive: { $ne: false },
     merchantId: { $exists: true, $type: 'string' },
     benefitCount: { $gt: 0 },
-    categories: { $in: [category.category || category.slug] },
+    categories: { $in: categoryValues },
     banks: { $in: getBankPatterns(bank) },
   };
   const projection = {
@@ -356,6 +361,7 @@ export async function loadLandingSeoData({ db, merchantCollectionName, bank, cat
     benefitCount: 1,
     activeBenefitCount: 1,
     maxDiscountPercentage: 1,
+    searchProfile: 1,
   };
   const collection = db.collection(merchantCollectionName);
   const baseCountPromise = city ? null : collection.countDocuments(merchantQuery);
@@ -420,6 +426,9 @@ export {
   getLandingSeoPath,
   readViteAppShell,
   resolveLandingBank,
+  resolveLandingBankFromMerchants,
   resolveLandingCategory,
+  resolveLandingCategoryFromMerchants,
   resolveLandingCity,
+  resolveLandingCityFromMerchants,
 };

--- a/api/landing-seo.js
+++ b/api/landing-seo.js
@@ -86,8 +86,25 @@ function injectBody(shell, bodyHtml) {
   return `${shell}\n<div id="root">${bodyHtml}</div>`;
 }
 
+function getMerchantDisplayBankNames(merchant) {
+  const benefits = Array.isArray(merchant?.searchProfile?.benefits)
+    ? merchant.searchProfile.benefits
+    : [];
+
+  return Array.from(new Set(
+    benefits
+      .flatMap((benefit) => String(benefit?.bankName || '').split(','))
+      .map((bankName) => bankName.trim())
+      .filter(Boolean)
+  ));
+}
+
 function getMerchantBanks(merchant) {
-  const banks = Array.isArray(merchant?.banks) ? merchant.banks : [];
+  const banks = getMerchantDisplayBankNames(merchant);
+  if (banks.length === 0 && Array.isArray(merchant?.banks)) {
+    banks.push(...merchant.banks);
+  }
+
   return banks.filter(Boolean).slice(0, 4).join(', ') || 'bancos participantes';
 }
 

--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -3,6 +3,12 @@ import path from 'node:path';
 import { MongoClient } from 'mongodb';
 import { DEFAULT_CANONICAL_SITE_URL, resolveCanonicalSiteUrl } from '../api/canonical-site.js';
 import { SEO_CATEGORY_DEFINITIONS } from '../api/category-seo-data.js';
+import {
+  LANDING_BANK_DEFINITIONS,
+  LANDING_CATEGORY_DEFINITIONS,
+  LANDING_CITY_DEFINITIONS,
+  getLandingSeoPath,
+} from '../api/landing-seo-data.js';
 import { slugify } from '../api/search/normalize.js';
 
 const DEFAULT_SITE_URL = DEFAULT_CANONICAL_SITE_URL;
@@ -55,9 +61,9 @@ const mongoUri = process.env.MONGODB_URI_READ_ONLY || '';
 const databaseName = process.env.DATABASE_NAME || DEFAULT_DATABASE_NAME;
 
 const today = new Date().toISOString().split('T')[0];
-const banks = ['galicia', 'santander', 'bbva', 'macro', 'nacion', 'icbc'];
-const categories = ['gastronomia', 'moda', 'shopping', 'hogar', 'deportes', 'belleza'];
-const cities = ['buenos-aires', 'caba', 'cordoba', 'rosario', 'mendoza'];
+const banks = LANDING_BANK_DEFINITIONS;
+const categories = LANDING_CATEGORY_DEFINITIONS;
+const cities = LANDING_CITY_DEFINITIONS.slice(0, 5);
 
 const baseRoutes = [
   { path: '/', changefreq: 'daily', priority: '1.0' },
@@ -130,14 +136,14 @@ const landingRoutes = [];
 for (const bank of banks) {
   for (const category of categories) {
     landingRoutes.push({
-      path: `/descuentos/${bank}/${category}`,
+      path: getLandingSeoPath(bank, category),
       changefreq: 'weekly',
       priority: '0.8',
     });
 
     for (const city of cities) {
       landingRoutes.push({
-        path: `/descuentos/${bank}/${category}/${city}`,
+        path: getLandingSeoPath(bank, category, city),
         changefreq: 'weekly',
         priority: '0.7',
       });

--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { MongoClient } from 'mongodb';
+import ts from 'typescript';
 import { DEFAULT_CANONICAL_SITE_URL, resolveCanonicalSiteUrl } from '../api/canonical-site.js';
 import { SEO_CATEGORY_DEFINITIONS } from '../api/category-seo-data.js';
 import { buildLandingSeoRoutesFromMerchants } from '../api/landing-seo-data.js';
@@ -74,6 +75,52 @@ const categorySeoRoutes = SEO_CATEGORY_DEFINITIONS.map((category) => ({
   priority: '0.8',
 }));
 
+function extractExportedSlugArray(sourceFile, exportName) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if (!statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) continue;
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== exportName) continue;
+      if (!declaration.initializer || !ts.isArrayLiteralExpression(declaration.initializer)) return [];
+
+      return declaration.initializer.elements.flatMap((element) => {
+        if (!ts.isObjectLiteralExpression(element)) return [];
+        const slugProperty = element.properties.find((property) => {
+          return ts.isPropertyAssignment(property) &&
+            ts.isIdentifier(property.name) &&
+            property.name.text === 'slug';
+        });
+        if (!slugProperty || !ts.isPropertyAssignment(slugProperty)) return [];
+        return (
+          ts.isStringLiteral(slugProperty.initializer) ||
+          ts.isNoSubstitutionTemplateLiteral(slugProperty.initializer)
+        ) ? [slugProperty.initializer.text] : [];
+      });
+    }
+  }
+
+  return [];
+}
+
+function readClientLandingRouteAllowlist() {
+  const landingDataPath = path.resolve(process.cwd(), 'src/seo/landingData.ts');
+  const sourceText = fs.readFileSync(landingDataPath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    landingDataPath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  return {
+    allowedBankSlugs: extractExportedSlugArray(sourceFile, 'LANDING_BANKS'),
+    allowedCategorySlugs: extractExportedSlugArray(sourceFile, 'LANDING_CATEGORIES'),
+    allowedCitySlugs: extractExportedSlugArray(sourceFile, 'LANDING_CITIES'),
+  };
+}
+
 function escapeXml(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -104,7 +151,7 @@ async function loadMerchantSeoDocuments() {
         {
           isActive: { $ne: false },
           merchantId: { $exists: true, $type: 'string' },
-          benefitCount: { $gt: 0 },
+          activeBenefitCount: { $gt: 0 },
         },
         {
           projection: {
@@ -114,6 +161,8 @@ async function loadMerchantSeoDocuments() {
             categories: 1,
             banks: 1,
             locations: 1,
+            activeBenefitCount: 1,
+            'searchProfile.benefits.bankName': 1,
           },
         },
       )
@@ -142,6 +191,7 @@ const landingRoutes = buildLandingSeoRoutesFromMerchants(merchantDocuments, {
   maxCityRoutesPerCombination: Number.isFinite(landingMaxCityRoutesPerCombination)
     ? landingMaxCityRoutesPerCombination
     : 5,
+  ...readClientLandingRouteAllowlist(),
 });
 const routes = [...baseRoutes, ...categorySeoRoutes, ...landingRoutes, ...merchantRoutes];
 const uniqueRoutes = Array.from(new Map(routes.map((route) => [route.path, route])).values());

--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -151,7 +151,7 @@ async function loadMerchantSeoDocuments() {
         {
           isActive: { $ne: false },
           merchantId: { $exists: true, $type: 'string' },
-          activeBenefitCount: { $gt: 0 },
+          benefitCount: { $gt: 0 },
         },
         {
           projection: {
@@ -161,6 +161,7 @@ async function loadMerchantSeoDocuments() {
             categories: 1,
             banks: 1,
             locations: 1,
+            benefitCount: 1,
             activeBenefitCount: 1,
             'searchProfile.benefits.bankName': 1,
           },
@@ -186,7 +187,10 @@ function buildMerchantRoutes(merchants) {
 
 const merchantDocuments = await loadMerchantSeoDocuments();
 const merchantRoutes = buildMerchantRoutes(merchantDocuments);
-const landingRoutes = buildLandingSeoRoutesFromMerchants(merchantDocuments, {
+const landingMerchantDocuments = merchantDocuments.filter((merchant) => {
+  return Number(merchant?.activeBenefitCount || 0) > 0;
+});
+const landingRoutes = buildLandingSeoRoutesFromMerchants(landingMerchantDocuments, {
   minMerchantCount: Number.isFinite(landingMinMerchantCount) ? landingMinMerchantCount : 3,
   maxCityRoutesPerCombination: Number.isFinite(landingMaxCityRoutesPerCombination)
     ? landingMaxCityRoutesPerCombination

--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -3,12 +3,7 @@ import path from 'node:path';
 import { MongoClient } from 'mongodb';
 import { DEFAULT_CANONICAL_SITE_URL, resolveCanonicalSiteUrl } from '../api/canonical-site.js';
 import { SEO_CATEGORY_DEFINITIONS } from '../api/category-seo-data.js';
-import {
-  LANDING_BANK_DEFINITIONS,
-  LANDING_CATEGORY_DEFINITIONS,
-  LANDING_CITY_DEFINITIONS,
-  getLandingSeoPath,
-} from '../api/landing-seo-data.js';
+import { buildLandingSeoRoutesFromMerchants } from '../api/landing-seo-data.js';
 import { slugify } from '../api/search/normalize.js';
 
 const DEFAULT_SITE_URL = DEFAULT_CANONICAL_SITE_URL;
@@ -59,11 +54,13 @@ const hasConfiguredSiteUrl = siteUrlCandidates.some((value) => String(value || '
 const siteUrl = resolveCanonicalSiteUrl(...siteUrlCandidates);
 const mongoUri = process.env.MONGODB_URI_READ_ONLY || '';
 const databaseName = process.env.DATABASE_NAME || DEFAULT_DATABASE_NAME;
+const landingMinMerchantCount = Number.parseInt(process.env.SITEMAP_LANDING_MIN_MERCHANTS || '3', 10);
+const landingMaxCityRoutesPerCombination = Number.parseInt(
+  process.env.SITEMAP_LANDING_MAX_CITY_ROUTES_PER_COMBO || '5',
+  10,
+);
 
 const today = new Date().toISOString().split('T')[0];
-const banks = LANDING_BANK_DEFINITIONS;
-const categories = LANDING_CATEGORY_DEFINITIONS;
-const cities = LANDING_CITY_DEFINITIONS.slice(0, 5);
 
 const baseRoutes = [
   { path: '/', changefreq: 'daily', priority: '1.0' },
@@ -92,9 +89,9 @@ function getMerchantSeoPath(merchant) {
   return `/comercios/${merchantSlug}--${encodeURIComponent(merchantId)}`;
 }
 
-async function loadMerchantRoutes() {
+async function loadMerchantSeoDocuments() {
   if (!mongoUri) {
-    console.warn('[seo] MONGODB_URI_READ_ONLY is not set. Skipping merchant sitemap URLs.');
+    console.warn('[seo] MONGODB_URI_READ_ONLY is not set. Skipping dynamic merchant and landing sitemap URLs.');
     return [];
   }
 
@@ -114,44 +111,38 @@ async function loadMerchantRoutes() {
             _id: 0,
             merchantId: 1,
             merchantName: 1,
+            categories: 1,
+            banks: 1,
+            locations: 1,
           },
         },
       )
       .sort({ merchantName: 1 })
       .toArray();
-
-    return merchants
-      .filter((merchant) => String(merchant.merchantId || '').trim())
-      .map((merchant) => ({
-        path: getMerchantSeoPath(merchant),
-        changefreq: 'weekly',
-        priority: '0.8',
-      }));
+    return merchants;
   } finally {
     await client.close();
   }
 }
 
-const landingRoutes = [];
-for (const bank of banks) {
-  for (const category of categories) {
-    landingRoutes.push({
-      path: getLandingSeoPath(bank, category),
+function buildMerchantRoutes(merchants) {
+  return merchants
+    .filter((merchant) => String(merchant.merchantId || '').trim())
+    .map((merchant) => ({
+      path: getMerchantSeoPath(merchant),
       changefreq: 'weekly',
       priority: '0.8',
-    });
-
-    for (const city of cities) {
-      landingRoutes.push({
-        path: getLandingSeoPath(bank, category, city),
-        changefreq: 'weekly',
-        priority: '0.7',
-      });
-    }
-  }
+    }));
 }
 
-const merchantRoutes = await loadMerchantRoutes();
+const merchantDocuments = await loadMerchantSeoDocuments();
+const merchantRoutes = buildMerchantRoutes(merchantDocuments);
+const landingRoutes = buildLandingSeoRoutesFromMerchants(merchantDocuments, {
+  minMerchantCount: Number.isFinite(landingMinMerchantCount) ? landingMinMerchantCount : 3,
+  maxCityRoutesPerCombination: Number.isFinite(landingMaxCityRoutesPerCombination)
+    ? landingMaxCityRoutesPerCombination
+    : 5,
+});
 const routes = [...baseRoutes, ...categorySeoRoutes, ...landingRoutes, ...merchantRoutes];
 const uniqueRoutes = Array.from(new Map(routes.map((route) => [route.path, route])).values());
 
@@ -241,5 +232,5 @@ fs.writeFileSync(path.join(publicDir, 'robots.txt'), robotsContent, 'utf8');
 if (!hasConfiguredSiteUrl) {
   console.warn(`[seo] CANONICAL_SITE_URL/VITE_SITE_URL/SITE_URL is not set. Using ${DEFAULT_SITE_URL} in sitemap and robots.txt.`);
 } else {
-  console.log(`[seo] Generated sitemap.xml and robots.txt for ${siteUrl} (${uniqueRoutes.length} URLs, ${categorySeoRoutes.length} category URLs, ${merchantRoutes.length} merchant URLs)`);
+  console.log(`[seo] Generated sitemap.xml and robots.txt for ${siteUrl} (${uniqueRoutes.length} URLs, ${categorySeoRoutes.length} category URLs, ${landingRoutes.length} landing URLs, ${merchantRoutes.length} merchant URLs)`);
 }

--- a/src/services/__tests__/landingSeoData.test.ts
+++ b/src/services/__tests__/landingSeoData.test.ts
@@ -29,6 +29,17 @@ describe('landing SEO data helpers', () => {
     expect(resolveLandingBankFromMerchants('a', [merchant])).toBeNull();
   });
 
+  it('can seed client aliases when validating bank names from merchant data', () => {
+    const merchant = {
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Santander Río' }]
+      }
+    };
+
+    expect(resolveLandingBankFromMerchants('santander', [merchant], { includeClientDefinitions: true })?.slug).toBe('santander');
+    expect(resolveLandingBankFromMerchants('rio', [merchant], { includeClientDefinitions: true })?.slug).toBe('santander');
+  });
+
   it('filters generated sitemap landing routes to client-supported slugs', () => {
     const merchants = [
       {

--- a/src/services/__tests__/landingSeoData.test.ts
+++ b/src/services/__tests__/landingSeoData.test.ts
@@ -95,4 +95,51 @@ describe('landing SEO data helpers', () => {
     ]));
     expect(routes).toHaveLength(2);
   });
+
+  it('maps merchant aliases to client slugs when allowlisting generated landing routes', () => {
+    const merchants = [
+      {
+        categories: ['shopping'],
+        locations: [{ formattedAddress: 'Ciudad Autónoma de Buenos Aires' }],
+        searchProfile: {
+          benefits: [{ bankName: 'Banco Santander Río' }]
+        }
+      }
+    ];
+
+    const routes = buildLandingSeoRoutesFromMerchants(merchants, {
+      minMerchantCount: 1,
+      allowedBankSlugs: ['santander'],
+      allowedCategorySlugs: ['shopping'],
+      allowedCitySlugs: ['caba'],
+    });
+
+    expect(routes.map((route) => route.path)).toEqual(expect.arrayContaining([
+      '/descuentos/santander/shopping',
+      '/descuentos/santander/shopping/caba',
+    ]));
+    expect(routes).toHaveLength(2);
+  });
+
+  it('honors an explicit zero city route limit when generating landing routes', () => {
+    const merchants = [
+      {
+        categories: ['shopping'],
+        locations: [{ addressComponents: { locality: 'CABA' } }],
+        searchProfile: {
+          benefits: [{ bankName: 'Banco Galicia' }]
+        }
+      }
+    ];
+
+    const routes = buildLandingSeoRoutesFromMerchants(merchants, {
+      minMerchantCount: 1,
+      maxCityRoutesPerCombination: 0,
+      allowedBankSlugs: ['galicia'],
+      allowedCategorySlugs: ['shopping'],
+      allowedCitySlugs: ['caba'],
+    });
+
+    expect(routes.map((route) => route.path)).toEqual(['/descuentos/galicia/shopping']);
+  });
 });

--- a/src/services/__tests__/landingSeoData.test.ts
+++ b/src/services/__tests__/landingSeoData.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLandingSeoRoutesFromMerchants,
+  getLandingBankValuesFromMerchant,
+  resolveLandingBankFromMerchants,
+} from '../../../api/landing-seo-data.js';
+
+describe('landing SEO data helpers', () => {
+  it('uses canonical search profile bank names instead of tokenized bank fields', () => {
+    const merchant = {
+      banks: ['provincia', 'buenos', 'aires'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Provincia' }]
+      }
+    };
+
+    expect(getLandingBankValuesFromMerchant(merchant)).toEqual(['Banco Provincia']);
+  });
+
+  it('does not resolve arbitrary bank tokens from merchant bank search fields', () => {
+    const merchant = {
+      banks: ['a', 'provincia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      }
+    };
+
+    expect(resolveLandingBankFromMerchants('galicia', [merchant])?.slug).toBe('galicia');
+    expect(resolveLandingBankFromMerchants('a', [merchant])).toBeNull();
+  });
+
+  it('filters generated sitemap landing routes to client-supported slugs', () => {
+    const merchants = [
+      {
+        categories: ['shopping'],
+        locations: [{ addressComponents: { locality: 'CABA' } }],
+        searchProfile: {
+          benefits: [{ bankName: 'Banco Galicia' }]
+        }
+      },
+      {
+        categories: ['combustible'],
+        locations: [{ addressComponents: { locality: 'San Miguel de Tucuman' } }],
+        searchProfile: {
+          benefits: [{ bankName: 'NaranjaX' }]
+        }
+      }
+    ];
+
+    const routes = buildLandingSeoRoutesFromMerchants(merchants, {
+      minMerchantCount: 1,
+      allowedBankSlugs: ['galicia'],
+      allowedCategorySlugs: ['shopping'],
+      allowedCitySlugs: ['caba'],
+    });
+
+    expect(routes.map((route) => route.path)).toEqual(expect.arrayContaining([
+      '/descuentos/galicia/shopping',
+      '/descuentos/galicia/shopping/caba',
+    ]));
+    expect(routes).toHaveLength(2);
+  });
+});

--- a/src/services/__tests__/landingSeoData.test.ts
+++ b/src/services/__tests__/landingSeoData.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildLandingSeoRoutesFromMerchants,
+  getLandingCityValuesFromMerchant,
   getLandingBankValuesFromMerchant,
+  resolveClientLandingBank,
+  resolveClientLandingCategory,
+  resolveClientLandingCity,
   resolveLandingBankFromMerchants,
 } from '../../../api/landing-seo-data.js';
 
@@ -38,6 +42,26 @@ describe('landing SEO data helpers', () => {
 
     expect(resolveLandingBankFromMerchants('santander', [merchant], { includeClientDefinitions: true })?.slug).toBe('santander');
     expect(resolveLandingBankFromMerchants('rio', [merchant], { includeClientDefinitions: true })?.slug).toBe('santander');
+  });
+
+  it('resolves only client-supported landing routes for live pages', () => {
+    expect(resolveClientLandingBank('frances')?.slug).toBe('bbva');
+    expect(resolveClientLandingBank('naranjax')).toBeNull();
+    expect(resolveClientLandingCategory('shopping')?.name).toBe('Supermercado y shopping');
+    expect(resolveClientLandingCategory('combustible')).toBeNull();
+    expect(resolveClientLandingCity('capital-federal')?.slug).toBe('caba');
+    expect(resolveClientLandingCity('san-miguel-de-tucuman')?.slug).toBe('tucuman');
+  });
+
+  it('uses formatted location text when deriving landing city definitions', () => {
+    const merchant = {
+      locations: [{ formattedAddress: 'Mar del Plata', name: 'Sucursal Centro' }]
+    };
+
+    expect(getLandingCityValuesFromMerchant(merchant)).toEqual([
+      'Mar del Plata',
+      'Sucursal Centro',
+    ]);
   });
 
   it('filters generated sitemap landing routes to client-supported slugs', () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -6,6 +6,7 @@ import {
   handleGetBenefits,
   handleGetBusinesses,
   handleLegacyBusinessRedirect,
+  handleLandingSeoPage,
   handleMerchantSeoPage,
   resolveRequestPath,
   rehydrateBenefitDoc
@@ -74,6 +75,8 @@ describe('merchant-first serverless helpers', () => {
     expect(resolveRequestPath(new URL('https://example.com/business/merchant_1?path=business/merchant_1'))).toBe('/api/business/merchant_1');
     expect(resolveRequestPath(new URL('https://example.com/categorias/moda?path=categorias/moda'))).toBe('/api/categorias/moda');
     expect(resolveRequestPath(new URL('https://example.com/categorias/moda/page/2?path=categorias/moda/page/2'))).toBe('/api/categorias/moda/page/2');
+    expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia?path=descuentos/galicia/gastronomia'))).toBe('/api/descuentos/galicia/gastronomia');
+    expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia/caba?path=descuentos/galicia/gastronomia/caba'))).toBe('/api/descuentos/galicia/gastronomia/caba');
   });
 
   it('rehydrateBenefitDoc prefers merchant-owned fields', () => {
@@ -710,6 +713,109 @@ describe('merchant-first serverless helpers', () => {
       error: 'Category page not found',
       category: 'moda',
       page: 3
+    });
+  });
+
+  it('handleLandingSeoPage returns crawlable HTML with merchant links', async () => {
+    const merchantQueries: unknown[] = [];
+    const merchant = {
+      merchantId: 'merchant_1',
+      merchantName: 'Coto',
+      categories: ['shopping'],
+      banks: ['Banco Galicia'],
+      activeBenefitCount: 2,
+      benefitCount: 4,
+      maxDiscountPercentage: 25,
+      locations: [
+        {
+          addressComponents: {
+            locality: 'Buenos Aires'
+          }
+        }
+      ]
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments(query: unknown) {
+              merchantQueries.push(query);
+              return 1;
+            },
+            find(query: unknown) {
+              merchantQueries.push(query);
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/galicia/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'galicia', 'shopping', undefined, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.body).toContain('<title>Descuentos Banco Galicia en Supermercado y shopping | Blink</title>');
+    expect(res.body).toContain('<h1>Descuentos Banco Galicia en Supermercado y shopping</h1>');
+    expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/galicia/shopping"');
+    expect(res.body).toContain('href="/comercios/coto--merchant_1"');
+    expect(res.body).toContain('Banco Galicia');
+    expect(res.body).toContain('src="/assets/index-test.js"');
+    expect(res.body).toContain('https://schema.org');
+    expect(merchantQueries[0]).toEqual({
+      isActive: { $ne: false },
+      merchantId: { $exists: true, $type: 'string' },
+      benefitCount: { $gt: 0 },
+      categories: { $in: ['shopping'] },
+      banks: { $in: expect.arrayContaining([expect.any(RegExp)]) }
+    });
+  });
+
+  it('handleLandingSeoPage redirects aliases to canonical landing paths', async () => {
+    const db = {
+      collection() {
+        throw new Error('Landing alias redirects should not query MongoDB');
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/descuentos/frances/moda');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'frances', 'moda');
+
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.Location).toBe('/descuentos/bbva/moda');
+  });
+
+  it('handleLandingSeoPage returns 404 for invalid landing combinations', async () => {
+    const db = {
+      collection() {
+        throw new Error('Invalid landing pages should not query MongoDB');
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/descuentos/nope/moda');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'nope', 'moda');
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body || '{}')).toEqual({
+      success: false,
+      error: 'Landing page not found',
+      bank: 'nope',
+      category: 'moda'
     });
   });
 

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -764,8 +764,8 @@ describe('merchant-first serverless helpers', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
-    expect(res.body).toContain('<title>Descuentos Banco Galicia en Supermercado y shopping | Blink</title>');
-    expect(res.body).toContain('<h1>Descuentos Banco Galicia en Supermercado y shopping</h1>');
+    expect(res.body).toContain('<title>Descuentos Banco Galicia en Shopping | Blink</title>');
+    expect(res.body).toContain('<h1>Descuentos Banco Galicia en Shopping</h1>');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/galicia/shopping"');
     expect(res.body).toContain('href="/comercios/coto--merchant_1"');
     expect(res.body).toContain('Banco Galicia');
@@ -780,27 +780,118 @@ describe('merchant-first serverless helpers', () => {
     });
   });
 
-  it('handleLandingSeoPage redirects aliases to canonical landing paths', async () => {
+  it('handleLandingSeoPage renders landing pages from merchant data outside the seed list', async () => {
+    const merchant = {
+      merchantId: 'merchant_2',
+      merchantName: 'YPF',
+      categories: ['combustible'],
+      banks: ['naranjax'],
+      searchProfile: {
+        benefits: [{ bankName: 'NaranjaX' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 15,
+      locations: [
+        {
+          addressComponents: {
+            locality: 'San Miguel de Tucuman',
+            adminAreaLevel1: 'Tucuman'
+          }
+        }
+      ]
+    };
     const db = {
-      collection() {
-        throw new Error('Landing alias redirects should not query MongoDB');
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
       }
     };
 
     const req = {};
     const res = createResponseCapture();
-    const url = new URL('https://example.com/api/descuentos/frances/moda');
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/naranjax/combustible/san-miguel-de-tucuman');
 
-    await handleLandingSeoPage(req as never, res as never, url, db as never, 'frances', 'moda');
+    await handleLandingSeoPage(
+      req as never,
+      res as never,
+      url,
+      db as never,
+      'naranjax',
+      'combustible',
+      'san-miguel-de-tucuman',
+      {
+        appShell: merchantSeoAppShell,
+        siteUrl: 'https://www.blinkapp.com.ar'
+      }
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<title>Descuentos NaranjaX en Combustible en San Miguel de Tucuman | Blink</title>');
+    expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/naranjax/combustible/san-miguel-de-tucuman"');
+    expect(res.body).toContain('href="/comercios/ypf--merchant_2"');
+  });
+
+  it('handleLandingSeoPage redirects dynamic aliases to canonical landing paths', async () => {
+    const merchant = {
+      merchantId: 'merchant_1',
+      merchantName: 'Coto',
+      categories: ['shopping'],
+      banks: ['Galicia'],
+      activeBenefitCount: 2,
+      benefitCount: 4,
+      maxDiscountPercentage: 25,
+      locations: []
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return 1;
+            },
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/descuentos/banco-galicia/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'banco-galicia', 'shopping');
 
     expect(res.statusCode).toBe(301);
-    expect(res.headers.Location).toBe('/descuentos/bbva/moda');
+    expect(res.headers.Location).toBe('/descuentos/galicia/shopping');
   });
 
   it('handleLandingSeoPage returns 404 for invalid landing combinations', async () => {
     const db = {
-      collection() {
-        throw new Error('Invalid landing pages should not query MongoDB');
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return 0;
+            },
+            find() {
+              return createCursor([]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
       }
     };
 

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -792,8 +792,8 @@ describe('merchant-first serverless helpers', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
-    expect(res.body).toContain('<title>Descuentos Banco Galicia en Shopping | Blink</title>');
-    expect(res.body).toContain('<h1>Descuentos Banco Galicia en Shopping</h1>');
+    expect(res.body).toContain('<title>Descuentos Banco Galicia en Supermercado y shopping | Blink</title>');
+    expect(res.body).toContain('<h1>Descuentos Banco Galicia en Supermercado y shopping</h1>');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/galicia/shopping"');
     expect(res.body).toContain('href="/comercios/coto--merchant_1"');
     expect(res.body).toContain('Banco Galicia');
@@ -854,7 +854,7 @@ describe('merchant-first serverless helpers', () => {
     const bankPatterns = (merchantQueries[0] as Record<string, { $in: RegExp[] }>)['searchProfile.benefits.bankName'].$in;
     expect(bankPatterns.some((pattern) => pattern.test('Banco Nación'))).toBe(true);
     expect(res.statusCode).toBe(200);
-    expect(res.body).toContain('<title>Descuentos Banco Nacion en Shopping | Blink</title>');
+    expect(res.body).toContain('<title>Descuentos Banco Nacion en Supermercado y shopping | Blink</title>');
   });
 
   it('handleLandingSeoPage preserves client bank aliases for Santander Rio merchant data', async () => {
@@ -898,11 +898,108 @@ describe('merchant-first serverless helpers', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toContain('<title>Descuentos Banco Santander en Shopping | Blink</title>');
+    expect(res.body).toContain('<title>Descuentos Banco Santander en Supermercado y shopping | Blink</title>');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/santander/shopping"');
   });
 
-  it('handleLandingSeoPage renders landing pages from merchant data outside the seed list', async () => {
+  it('handleLandingSeoPage seeds client bank aliases before loading landing data', async () => {
+    const merchantQueries: unknown[] = [];
+    const merchant = {
+      merchantId: 'merchant_frances',
+      merchantName: 'Super Frances',
+      categories: ['shopping'],
+      banks: ['Banco Francés'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Francés' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 20,
+      locations: []
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments(query: unknown) {
+              merchantQueries.push(query);
+              return 1;
+            },
+            find(query: unknown) {
+              merchantQueries.push(query);
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/bbva/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'bbva', 'shopping', undefined, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    const bankPatterns = (merchantQueries[0] as Record<string, { $in: RegExp[] }>)['searchProfile.benefits.bankName'].$in;
+    expect(bankPatterns.some((pattern) => pattern.test('Banco Francés'))).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<title>Descuentos BBVA en Supermercado y shopping | Blink</title>');
+  });
+
+  it('handleLandingSeoPage seeds client city aliases before loading landing data', async () => {
+    const merchant = {
+      merchantId: 'merchant_caba',
+      merchantName: 'Coto CABA',
+      categories: ['shopping'],
+      banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 20,
+      locations: [
+        {
+          formattedAddress: 'Ciudad Autónoma de Buenos Aires'
+        }
+      ]
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              throw new Error('City landing pages should count by scanning all matching merchants');
+            },
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/galicia/shopping/capital-federal');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'galicia', 'shopping', 'capital-federal', {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.Location).toBe('/descuentos/galicia/shopping/caba');
+  });
+
+  it('handleLandingSeoPage rejects landing pages outside the client route set', async () => {
     const merchant = {
       merchantId: 'merchant_2',
       merchantName: 'YPF',
@@ -955,10 +1052,14 @@ describe('merchant-first serverless helpers', () => {
       }
     );
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toContain('<title>Descuentos NaranjaX en Combustible en San Miguel de Tucuman | Blink</title>');
-    expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/naranjax/combustible/san-miguel-de-tucuman"');
-    expect(res.body).toContain('href="/comercios/ypf--merchant_2"');
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body || '{}')).toEqual({
+      success: false,
+      error: 'Landing page not found',
+      bank: 'naranjax',
+      category: 'combustible',
+      city: 'san-miguel-de-tucuman'
+    });
   });
 
   it('handleLandingSeoPage scans city matches beyond the first merchant fetch window', async () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -808,6 +808,57 @@ describe('merchant-first serverless helpers', () => {
     });
   });
 
+  it('handleLandingSeoPage renders display bank names instead of search bank tokens', async () => {
+    const merchant = {
+      merchantId: 'merchant_1',
+      merchantName: 'Coto',
+      categories: ['shopping'],
+      banks: ['banco galicia', 'galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
+      activeBenefitCount: 2,
+      benefitCount: 4,
+      maxDiscountPercentage: 25,
+      locations: [
+        {
+          addressComponents: {
+            locality: 'Buenos Aires'
+          }
+        }
+      ]
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return 1;
+            },
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/galicia/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'galicia', 'shopping', undefined, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<small>Banco Galicia · Buenos Aires</small>');
+    expect(res.body).not.toContain('banco galicia, galicia');
+  });
+
   it('handleLandingSeoPage matches accented bank names with unaccented slugs', async () => {
     const merchantQueries: unknown[] = [];
     const merchant = {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -808,6 +808,100 @@ describe('merchant-first serverless helpers', () => {
     });
   });
 
+  it('handleLandingSeoPage matches accented bank names with unaccented slugs', async () => {
+    const merchantQueries: unknown[] = [];
+    const merchant = {
+      merchantId: 'merchant_nacion',
+      merchantName: 'Farmacia',
+      categories: ['shopping'],
+      banks: ['Banco Nación'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Nación' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 20,
+      locations: []
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments(query: unknown) {
+              merchantQueries.push(query);
+              return 1;
+            },
+            find(query: unknown) {
+              merchantQueries.push(query);
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/nacion/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'nacion', 'shopping', undefined, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    const bankPatterns = (merchantQueries[0] as Record<string, { $in: RegExp[] }>)['searchProfile.benefits.bankName'].$in;
+    expect(bankPatterns.some((pattern) => pattern.test('Banco Nación'))).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<title>Descuentos Banco Nacion en Shopping | Blink</title>');
+  });
+
+  it('handleLandingSeoPage preserves client bank aliases for Santander Rio merchant data', async () => {
+    const merchant = {
+      merchantId: 'merchant_santander',
+      merchantName: 'Restaurante',
+      categories: ['shopping'],
+      banks: ['Banco Santander Río'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Santander Río' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 30,
+      locations: []
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return 1;
+            },
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/santander/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'santander', 'shopping', undefined, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('<title>Descuentos Banco Santander en Shopping | Blink</title>');
+    expect(res.body).toContain('href="https://www.blinkapp.com.ar/descuentos/santander/shopping"');
+  });
+
   it('handleLandingSeoPage renders landing pages from merchant data outside the seed list', async () => {
     const merchant = {
       merchantId: 'merchant_2',

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -57,6 +57,28 @@ function createCursor<T>(data: T[]) {
   return cursor;
 }
 
+function createPaginatedCursor<T>(data: T[]) {
+  let offset = 0;
+  let count = data.length;
+  const cursor = {
+    sort() {
+      return cursor;
+    },
+    skip(value: number) {
+      offset = value;
+      return cursor;
+    },
+    limit(value: number) {
+      count = value;
+      return cursor;
+    },
+    async toArray() {
+      return data.slice(offset, offset + count);
+    }
+  };
+  return cursor;
+}
+
 function createAggregateCursor<T>(data: T[]) {
   return {
     async toArray() {
@@ -572,6 +594,9 @@ describe('merchant-first serverless helpers', () => {
       merchantName: 'Coto',
       categories: ['shopping'],
       banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
       activeBenefitCount: 2,
       benefitCount: 4,
       maxDiscountPercentage: 25,
@@ -723,6 +748,9 @@ describe('merchant-first serverless helpers', () => {
       merchantName: 'Coto',
       categories: ['shopping'],
       banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
       activeBenefitCount: 2,
       benefitCount: 4,
       maxDiscountPercentage: 25,
@@ -774,9 +802,9 @@ describe('merchant-first serverless helpers', () => {
     expect(merchantQueries[0]).toEqual({
       isActive: { $ne: false },
       merchantId: { $exists: true, $type: 'string' },
-      benefitCount: { $gt: 0 },
+      activeBenefitCount: { $gt: 0 },
       categories: { $in: ['shopping'] },
-      banks: { $in: expect.arrayContaining([expect.any(RegExp)]) }
+      'searchProfile.benefits.bankName': { $in: expect.arrayContaining([expect.any(RegExp)]) }
     });
   });
 
@@ -839,12 +867,86 @@ describe('merchant-first serverless helpers', () => {
     expect(res.body).toContain('href="/comercios/ypf--merchant_2"');
   });
 
+  it('handleLandingSeoPage scans city matches beyond the first merchant fetch window', async () => {
+    const nonMatchingMerchants = Array.from({ length: 500 }, (_, index) => ({
+      merchantId: `merchant_other_${index}`,
+      merchantName: `Other ${index}`,
+      categories: ['shopping'],
+      banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
+      activeBenefitCount: 1,
+      benefitCount: 1,
+      maxDiscountPercentage: 10,
+      locations: [
+        {
+          addressComponents: {
+            locality: 'Cordoba'
+          }
+        }
+      ]
+    }));
+    const matchingMerchant = {
+      merchantId: 'merchant_match',
+      merchantName: 'Coto Buenos Aires',
+      categories: ['shopping'],
+      banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
+      activeBenefitCount: 2,
+      benefitCount: 2,
+      maxDiscountPercentage: 25,
+      locations: [
+        {
+          addressComponents: {
+            locality: 'Buenos Aires'
+          }
+        }
+      ]
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              throw new Error('City landing pages should count by scanning all matching merchants');
+            },
+            find() {
+              return createPaginatedCursor([...nonMatchingMerchants, matchingMerchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/api/descuentos/galicia/shopping/buenos-aires');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'galicia', 'shopping', 'buenos-aires', {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('1 comercios encontrados');
+    expect(res.body).toContain('Coto Buenos Aires');
+    expect(res.body).not.toContain('Other 0');
+  });
+
   it('handleLandingSeoPage redirects dynamic aliases to canonical landing paths', async () => {
     const merchant = {
       merchantId: 'merchant_1',
       merchantName: 'Coto',
       categories: ['shopping'],
       banks: ['Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
       activeBenefitCount: 2,
       benefitCount: 4,
       maxDiscountPercentage: 25,
@@ -875,6 +977,52 @@ describe('merchant-first serverless helpers', () => {
 
     expect(res.statusCode).toBe(301);
     expect(res.headers.Location).toBe('/descuentos/galicia/shopping');
+  });
+
+  it('handleLandingSeoPage rejects unknown bank slugs not backed by canonical merchant banks', async () => {
+    const merchant = {
+      merchantId: 'merchant_1',
+      merchantName: 'Coto',
+      categories: ['shopping'],
+      banks: ['Banco Galicia'],
+      searchProfile: {
+        benefits: [{ bankName: 'Banco Galicia' }]
+      },
+      activeBenefitCount: 2,
+      benefitCount: 4,
+      maxDiscountPercentage: 25,
+      locations: []
+    };
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return 1;
+            },
+            find() {
+              return createCursor([merchant]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/descuentos/a/shopping');
+
+    await handleLandingSeoPage(req as never, res as never, url, db as never, 'a', 'shopping');
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body || '{}')).toEqual({
+      success: false,
+      error: 'Landing page not found',
+      bank: 'a',
+      category: 'shopping'
+    });
   });
 
   it('handleLandingSeoPage returns 404 for invalid landing combinations', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,14 @@
       "dest": "/api/[...path]?path=categorias/$1"
     },
     {
+      "src": "/descuentos/([^/]+)/([^/]+)/([^/]+)",
+      "dest": "/api/[...path]?path=descuentos/$1/$2/$3"
+    },
+    {
+      "src": "/descuentos/([^/]+)/([^/]+)",
+      "dest": "/api/[...path]?path=descuentos/$1/$2"
+    },
+    {
       "src": "/comercios/([^/]+)",
       "dest": "/api/[...path]?path=comercios/$1"
     },


### PR DESCRIPTION
## Summary
- Adds server-rendered SEO HTML for `/descuentos/:bank/:category/:city?` routes.
- Routes descuentos URLs through the serverless API before the Vite fallback.
- Reuses shared landing definitions for sitemap generation so sitemap URLs match canonical renderer paths.

## Why
These landing URLs are listed in the sitemap, but the initial HTML previously returned the generic app shell with the home canonical. Crawlers now receive route-specific title, canonical, visible content, merchant links, and JSON-LD in the first response.

## Validation
- `npm test -- src/services/__tests__/merchantFirstServerless.test.ts`
- `MONGODB_URI_READ_ONLY= npm run build`

Note: the full pre-push test suite currently fails on an existing date-sensitive `BusinessDetailPage` expectation for a `2026-05-31` benefit now that the current date is `2026-06-01`; this branch does not touch that component.