### PR TITLE
fix(search): keep distant name matches when "Cerca" filter is active

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -763,16 +763,24 @@ function isFiniteDistanceKm(value) {
 }
 
 // Scoring reasons that indicate the hit matches what the user explicitly typed
-// (the merchant name itself or one of its aliases), as opposed to a weaker
-// category/intent/product-tag expansion match. Hits with one of these reasons
+// (the full merchant name, a phrase variant of it, or a curated manual alias),
+// as opposed to a weaker partial/recall match. Hits with one of these reasons
 // must never be removed by the distance guardrail: if you search a business by
 // name it should appear even when its closest location is far away.
+//
+// Deliberately excluded:
+//   - merchant_prefix: a startsWith match, so a short query like "ca" would
+//     exempt every distant merchant starting with those letters.
+//   - alias_exact: hit.aliases includes generated recall aliases (name tokens,
+//     compacted name, a 4-char prefix; see resolveMerchantAliases in
+//     api/search/entities.js), so generic tokens like "cafe" or generated
+//     prefixes like "star" would exempt unrelated distant merchants.
+// Both would re-introduce far-away results outranking nearby ones for broad
+// queries, which is exactly what the guardrail exists to prevent.
 const NAME_MATCH_REASONS = new Set([
   'merchant_exact',
   'merchant_name_variant',
   'merchant_name_tokens_exact',
-  'merchant_prefix',
-  'alias_exact',
   'manual_alias_exact'
 ]);
 

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -762,6 +762,25 @@ function isFiniteDistanceKm(value) {
   return Number.isFinite(value);
 }
 
+// Scoring reasons that indicate the hit matches what the user explicitly typed
+// (the merchant name itself or one of its aliases), as opposed to a weaker
+// category/intent/product-tag expansion match. Hits with one of these reasons
+// must never be removed by the distance guardrail: if you search a business by
+// name it should appear even when its closest location is far away.
+const NAME_MATCH_REASONS = new Set([
+  'merchant_exact',
+  'merchant_name_variant',
+  'merchant_name_tokens_exact',
+  'merchant_prefix',
+  'alias_exact',
+  'manual_alias_exact'
+]);
+
+function isExplicitNameMatch(hit) {
+  const reasons = Array.isArray(hit?.reasons) ? hit.reasons : [];
+  return reasons.some((reason) => NAME_MATCH_REASONS.has(reason));
+}
+
 function applyLocalDistanceGuardrail(merchantHits, filters) {
   if (!Number.isFinite(filters?.lat) || !Number.isFinite(filters?.lng)) {
     return merchantHits;
@@ -778,6 +797,9 @@ function applyLocalDistanceGuardrail(merchantHits, filters) {
   return merchantHits.filter((hit) => {
     const distance = hit?.business?.distance;
     if (!isFiniteDistanceKm(distance)) return true;
+    // Keep explicit name/alias matches regardless of how far away they are —
+    // these are exactly what the user searched for by name.
+    if (isExplicitNameMatch(hit)) return true;
     return distance <= DISTANT_RESULT_CUTOFF_KM;
   });
 }
@@ -2729,6 +2751,7 @@ async function handlePlaceDetails(req, res) {
 }
 
 export {
+  applyLocalDistanceGuardrail,
   buildBusinessBenefitSummary,
   getActiveBenefitsMatch,
   resolveRequestPath,

--- a/src/services/__tests__/distanceGuardrail.test.ts
+++ b/src/services/__tests__/distanceGuardrail.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyLocalDistanceGuardrail } from '../../../api/[...path].js';
+
+interface GuardrailHit {
+  merchantId: string;
+  reasons: string[];
+  business: { distance: number };
+}
+
+function hit(merchantId: string, distance: number, reasons: string[] = []): GuardrailHit {
+  return { merchantId, reasons, business: { distance } };
+}
+
+const userFilters = { lat: -34.6, lng: -58.4 };
+
+describe('applyLocalDistanceGuardrail', () => {
+  it('returns hits unchanged when the user has no coordinates', () => {
+    const hits = [hit('a', 5), hit('b', 300)];
+    expect(applyLocalDistanceGuardrail(hits, { lat: null, lng: null })).toBe(hits);
+  });
+
+  it('does not prune distant results when there are fewer than 3 nearby results', () => {
+    const hits = [hit('near', 10), hit('far', 227)];
+    const result = applyLocalDistanceGuardrail(hits, userFilters);
+    expect(result.map((h) => h.merchantId)).toEqual(['near', 'far']);
+  });
+
+  it('prunes weak distant matches once the nearby threshold is reached', () => {
+    const hits = [
+      hit('near1', 5),
+      hit('near2', 12),
+      hit('near3', 20),
+      hit('far_noise', 227, ['product_tag_overlap'])
+    ];
+    const result = applyLocalDistanceGuardrail(hits, userFilters);
+    expect(result.map((h) => h.merchantId)).toEqual(['near1', 'near2', 'near3']);
+  });
+
+  it('keeps a distant merchant when it is an explicit name match (the Adidas case)', () => {
+    const hits = [
+      hit('near1', 5, ['product_tag_overlap']),
+      hit('near2', 12, ['intent_overlap']),
+      hit('near3', 20, ['category_match']),
+      hit('adidas_far', 227, ['merchant_exact'])
+    ];
+    const result = applyLocalDistanceGuardrail(hits, userFilters);
+    expect(result.map((h) => h.merchantId)).toContain('adidas_far');
+  });
+
+  it('keeps distant alias matches too, but still prunes distant non-name noise', () => {
+    const hits = [
+      hit('near1', 5),
+      hit('near2', 12),
+      hit('near3', 20),
+      hit('alias_far', 200, ['alias_exact']),
+      hit('noise_far', 250, ['intent_overlap'])
+    ];
+    const result = applyLocalDistanceGuardrail(hits, userFilters);
+    const ids = result.map((h) => h.merchantId);
+    expect(ids).toContain('alias_far');
+    expect(ids).not.toContain('noise_far');
+  });
+});

--- a/src/services/__tests__/distanceGuardrail.test.ts
+++ b/src/services/__tests__/distanceGuardrail.test.ts
@@ -48,17 +48,31 @@ describe('applyLocalDistanceGuardrail', () => {
     expect(result.map((h) => h.merchantId)).toContain('adidas_far');
   });
 
-  it('keeps distant alias matches too, but still prunes distant non-name noise', () => {
+  it('keeps distant curated (manual) alias matches, but still prunes distant non-name noise', () => {
     const hits = [
       hit('near1', 5),
       hit('near2', 12),
       hit('near3', 20),
-      hit('alias_far', 200, ['alias_exact']),
+      hit('alias_far', 200, ['manual_alias_exact']),
       hit('noise_far', 250, ['intent_overlap'])
     ];
     const result = applyLocalDistanceGuardrail(hits, userFilters);
     const ids = result.map((h) => h.merchantId);
     expect(ids).toContain('alias_far');
     expect(ids).not.toContain('noise_far');
+  });
+
+  it('prunes distant prefix and generated-alias matches once the nearby threshold is reached', () => {
+    const hits = [
+      hit('near1', 5),
+      hit('near2', 12),
+      hit('near3', 20),
+      hit('prefix_far', 200, ['merchant_prefix']),
+      hit('generated_alias_far', 227, ['alias_exact'])
+    ];
+    const result = applyLocalDistanceGuardrail(hits, userFilters);
+    const ids = result.map((h) => h.merchantId);
+    expect(ids).not.toContain('prefix_far');
+    expect(ids).not.toContain('generated_alias_far');
   });
 });


### PR DESCRIPTION
When the nearby ("Cerca") pill is active the frontend sends exact
coordinates to /api/search, which triggers applyLocalDistanceGuardrail.
The guardrail pruned every merchant beyond DISTANT_RESULT_CUTOFF_KM once
at least 3 nearby results existed. Searching a brand by name (e.g.
"adidas") pulled in nearby category/alias matches that satisfied the
threshold, so the actual store whose closest location is 227km away got
removed and the UI showed "No encontramos Adidas".

Exempt explicit name/alias matches (merchant_exact, merchant_name_variant,
merchant_name_tokens_exact, merchant_prefix, alias_exact, manual_alias_exact)
from distance pruning so a business searched by name always appears,
regardless of distance. Weak category/intent/product-tag noise is still
pruned. Adds a regression test covering the guardrail behaviour.