### PR TITLE
Fix Naranja X and Personal Pay logos missing in bancos dropdown

### DIFF
--- a/src/components/neo/BankFilterSheet.tsx
+++ b/src/components/neo/BankFilterSheet.tsx
@@ -17,13 +17,15 @@ const BANK_BRAND: Record<string, { bg: string; color: string }> = {
   icbc:       { bg: '#FFF0F0', color: '#C8102E' },
   hsbc:       { bg: '#FFF0F0', color: '#DB0011' },
   amex:       { bg: '#EBF4FF', color: '#007BC1' },
-  naranja:    { bg: '#FFF3E8', color: '#EA580C' },
-  nacion:     { bg: '#EBF4FF', color: '#1A5E96' },
-  ciudad:     { bg: '#EBF4FF', color: '#0070B9' },
-  patagonia:  { bg: '#FFF8E8', color: '#D97706' },
-  visa:       { bg: '#EBF4FF', color: '#1A1F71' },
-  mastercard: { bg: '#FFF3E8', color: '#EB001B' },
-  lagaceta:   { bg: '#EBF4FF', color: '#0E5FA0' },
+  naranjax:    { bg: '#FFF3E8', color: '#EA580C' },
+  nacion:      { bg: '#EBF4FF', color: '#1A5E96' },
+  ciudad:      { bg: '#EBF4FF', color: '#0070B9' },
+  patagonia:   { bg: '#FFF8E8', color: '#D97706' },
+  visa:        { bg: '#EBF4FF', color: '#1A1F71' },
+  mastercard:  { bg: '#FFF3E8', color: '#EB001B' },
+  lagaceta:    { bg: '#EBF4FF', color: '#0E5FA0' },
+  buepp:       { bg: '#FEF9C3', color: '#A16207' },
+  personalpay: { bg: '#F3E8FF', color: '#7C3AED' },
 };
 
 const getBrand = (token: string) =>

--- a/src/utils/banks.ts
+++ b/src/utils/banks.ts
@@ -76,7 +76,7 @@ const getKnownDescriptor = (normalized: string): BankDescriptor | null => {
   if (normalized.includes('master')) return KNOWN_BANKS[13];
   if (normalized.includes('gaceta')) return KNOWN_BANKS[14];
   if (normalized.includes('buepp')) return KNOWN_BANKS[15];
-  if (normalized.includes('personal pay') || normalized.includes('personalpay')) return KNOWN_BANKS[16];
+  if (normalized.includes('personal')) return KNOWN_BANKS[16];
   return null;
 };
 

--- a/src/utils/banks.ts
+++ b/src/utils/banks.ts
@@ -13,7 +13,7 @@ export const KNOWN_BANKS: BankDescriptor[] = [
   { token: 'icbc', code: 'ICBC', label: 'ICBC' },
   { token: 'hsbc', code: 'HSBC', label: 'HSBC' },
   { token: 'amex', code: 'AMEX', label: 'AMEX' },
-  { token: 'naranja', code: 'NX', label: 'NARANJA X' },
+  { token: 'naranjax', code: 'NX', label: 'NARANJA X' },
   { token: 'nacion', code: 'BNA', label: 'NACION' },
   { token: 'ciudad', code: 'CIUD', label: 'CIUDAD' },
   { token: 'patagonia', code: 'PAT', label: 'PATAGONIA' },
@@ -68,7 +68,7 @@ const getKnownDescriptor = (normalized: string): BankDescriptor | null => {
   if (normalized.includes('icbc')) return KNOWN_BANKS[5];
   if (normalized.includes('hsbc')) return KNOWN_BANKS[6];
   if (normalized.includes('amex') || normalized.includes('american express')) return KNOWN_BANKS[7];
-  if (normalized.includes('naranja x') || normalized.includes('naranjax') || normalized === 'nx') return KNOWN_BANKS[8];
+  if (normalized.includes('naranja') || normalized === 'nx') return KNOWN_BANKS[8];
   if (normalized.includes('nacion')) return KNOWN_BANKS[9];
   if (normalized.includes('ciudad')) return KNOWN_BANKS[10];
   if (normalized.includes('patagonia')) return KNOWN_BANKS[11];


### PR DESCRIPTION
The bancos dropdown passes each bank's token to <BankLogo>, but the
Naranja X token was 'naranja' while its logo manifest key and asset are
'naranjax', so lookup fell back to the 'NX' text badge. Align the token
with the manifest key (matching the convention used by every other bank)
and broaden the descriptor matcher accordingly.

Also add the missing 'personalpay' (and 'buepp') entries to the dropdown
brand color map so their tiles use brand colors instead of the gray
fallback.