### PR TITLE
Use active merchants in SEO sitemap

### DIFF
--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -151,7 +151,7 @@ async function loadMerchantSeoDocuments() {
         {
           isActive: { $ne: false },
           merchantId: { $exists: true, $type: 'string' },
-          benefitCount: { $gt: 0 },
+          activeBenefitCount: { $gt: 0 },
         },
         {
           projection: {
@@ -187,10 +187,7 @@ function buildMerchantRoutes(merchants) {
 
 const merchantDocuments = await loadMerchantSeoDocuments();
 const merchantRoutes = buildMerchantRoutes(merchantDocuments);
-const landingMerchantDocuments = merchantDocuments.filter((merchant) => {
-  return Number(merchant?.activeBenefitCount || 0) > 0;
-});
-const landingRoutes = buildLandingSeoRoutesFromMerchants(landingMerchantDocuments, {
+const landingRoutes = buildLandingSeoRoutesFromMerchants(merchantDocuments, {
   minMerchantCount: Number.isFinite(landingMinMerchantCount) ? landingMinMerchantCount : 3,
   maxCityRoutesPerCombination: Number.isFinite(landingMaxCityRoutesPerCombination)
     ? landingMaxCityRoutesPerCombination


### PR DESCRIPTION
## Summary
- limit generated merchant sitemap URLs to merchants with active benefits
- reuse the active merchant set for generated landing SEO routes
- avoid committing generated sitemap output in this PR

## Validation
- `npm run test -- src/services/__tests__/landingSeoData.test.ts`

## SEO intent
This keeps stale historical-only merchant pages out of the sitemap so crawl budget is pointed at pages with currently useful offers.