### PR TITLE
Improve inactive merchant SEO pages

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -14,6 +14,7 @@ import {
 } from './search/normalize.js';
 import {
   getMerchantSeoPathFromMerchant,
+  isMerchantBenefitActive,
   parseMerchantSeoSlugId,
   readViteAppShell,
   renderMerchantSeoHtml
@@ -2556,18 +2557,98 @@ async function handleMerchantSeoPage(req, res, url, db, slugId, options = {}) {
     .toArray();
   const cardNameLookup = await resolveCardNameLookup(db, rawBenefits);
   const benefits = rawBenefits.map((benefit) => buildBusinessBenefitSummary(benefit, cardNameLookup));
+  const now = options.now || new Date();
+  const hasActiveBenefits = benefits.some((benefit) => isMerchantBenefitActive(benefit, now));
+  const relatedActiveMerchants = hasActiveBenefits
+    ? []
+    : await loadRelatedActiveMerchantAlternatives(db, merchant);
   const appShell = options.appShell || readViteAppShell();
   const renderedHtml = renderMerchantSeoHtml({
     appShell,
     merchant,
     benefits,
+    relatedActiveMerchants,
     path: canonicalPath,
     siteUrl: options.siteUrl || getCanonicalSiteUrl(url),
-    now: options.now || new Date()
+    now
   });
 
   setCacheControl(res, CC_CONTENT);
   return html(res, 200, renderedHtml);
+}
+
+function getMerchantAlternativeCategories(merchant) {
+  return Array.isArray(merchant?.categories)
+    ? merchant.categories.map((category) => String(category || '').trim()).filter(Boolean)
+    : [];
+}
+
+function getMerchantAlternativeBanks(merchant) {
+  return Array.isArray(merchant?.banks)
+    ? merchant.banks.map((bank) => String(bank || '').trim()).filter(Boolean)
+    : [];
+}
+
+function getMerchantAlternativeCity(merchant) {
+  const location = Array.isArray(merchant?.locations) ? merchant.locations.find(Boolean) : null;
+  const components = location?.addressComponents || {};
+  return (
+    components.locality ||
+    components.sublocality ||
+    components.adminAreaLevel2 ||
+    components.adminAreaLevel1 ||
+    ''
+  );
+}
+
+function serializeRelatedActiveMerchant(merchant) {
+  return {
+    merchantId: merchant?.merchantId,
+    merchantName: merchant?.merchantName,
+    path: getMerchantSeoPathFromMerchant(merchant),
+    category: getMerchantAlternativeCategories(merchant)[0] || '',
+    city: getMerchantAlternativeCity(merchant),
+    banks: getMerchantAlternativeBanks(merchant),
+    activeBenefitCount: Number(merchant?.activeBenefitCount || 0),
+    maxDiscountPercentage: Number(merchant?.maxDiscountPercentage || 0)
+  };
+}
+
+async function loadRelatedActiveMerchantAlternatives(db, merchant) {
+  const merchantId = String(merchant?.merchantId || '').trim();
+  const categories = getMerchantAlternativeCategories(merchant);
+  const banks = getMerchantAlternativeBanks(merchant);
+  const relatedClauses = [];
+
+  if (categories.length > 0) {
+    relatedClauses.push({ categories: { $in: categories } });
+  }
+
+  if (banks.length > 0) {
+    relatedClauses.push({ banks: { $in: banks } });
+  }
+
+  if (!merchantId || relatedClauses.length === 0) {
+    return [];
+  }
+
+  const alternatives = await db.collection(MERCHANT_ASSETS_COLLECTION)
+    .find(
+      {
+        isActive: { $ne: false },
+        merchantId: { $exists: true, $type: 'string', $ne: merchantId },
+        activeBenefitCount: { $gt: 0 },
+        $or: relatedClauses
+      },
+      {
+        projection: MERCHANT_SEO_PROJECTION
+      }
+    )
+    .sort({ activeBenefitCount: -1, maxDiscountPercentage: -1, merchantName: 1 })
+    .limit(4)
+    .toArray();
+
+  return alternatives.map(serializeRelatedActiveMerchant);
 }
 
 async function handleLegacyBusinessRedirect(req, res, url, db, merchantId) {

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2632,7 +2632,12 @@ async function loadRelatedActiveMerchantAlternatives(db, merchant) {
     return [];
   }
 
-  const alternatives = await db.collection(MERCHANT_ASSETS_COLLECTION)
+  const merchantCollection = db.collection(MERCHANT_ASSETS_COLLECTION);
+  if (typeof merchantCollection?.find !== 'function') {
+    return [];
+  }
+
+  const alternatives = await merchantCollection
     .find(
       {
         isActive: { $ne: false },

--- a/api/merchant-seo.js
+++ b/api/merchant-seo.js
@@ -8,6 +8,7 @@ const DEFAULT_SITE_NAME = 'Blink';
 const DEFAULT_SITE_URL = 'https://www.blinkapp.com.ar';
 const DEFAULT_OG_IMAGE = '/pwa-512x512.png';
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const RECENT_PAST_BENEFIT_WINDOW_DAYS = 180;
 
 let cachedAppShell = null;
 
@@ -242,7 +243,7 @@ function buildFaqItems(merchant, activeBenefits, pastBenefits, description) {
       question: `Que descuentos hay en ${name}?`,
       answer: activeBenefits.length > 0
         ? `${description}`
-        : `${name} no tiene descuentos activos publicados ahora, pero puedes revisar promociones anteriores.`
+        : `${name} no tiene promos activas publicadas ahora, pero puedes revisar promos recientes anteriores y alternativas activas.`
     },
     {
       question: `Que bancos tienen promociones en ${name}?`,
@@ -398,6 +399,82 @@ function renderBenefitList(benefits, emptyText, isPast = false) {
   return `<ul class="blink-seo-benefits">${items}</ul>`;
 }
 
+function getBenefitValidUntilTime(benefit) {
+  const validUntil = String(benefit?.validUntil || '').trim();
+  if (!validUntil) return null;
+
+  const parsedTime = DATE_ONLY_PATTERN.test(validUntil)
+    ? Date.parse(`${validUntil}T23:59:59.999Z`)
+    : Date.parse(validUntil);
+
+  return Number.isFinite(parsedTime) ? parsedTime : null;
+}
+
+function getRecentPastBenefits(pastBenefits, now) {
+  const nowTime = now.getTime();
+  const earliestRecentTime = nowTime - RECENT_PAST_BENEFIT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+  return pastBenefits.filter((benefit) => {
+    const validUntilTime = getBenefitValidUntilTime(benefit);
+    if (validUntilTime === null) return true;
+    return validUntilTime < nowTime && validUntilTime >= earliestRecentTime;
+  });
+}
+
+function getRelatedMerchantPath(merchant) {
+  const path = String(merchant?.path || '').trim();
+  if (path) return path;
+  if (!merchant?.merchantId) return '';
+  return getMerchantSeoPathFromMerchant(merchant);
+}
+
+function getRelatedMerchantOfferText(merchant) {
+  if (Number.isFinite(Number(merchant?.maxDiscountPercentage)) && Number(merchant.maxDiscountPercentage) > 0) {
+    return `Hasta ${Number(merchant.maxDiscountPercentage)}% OFF`;
+  }
+
+  if (Number.isFinite(Number(merchant?.activeBenefitCount)) && Number(merchant.activeBenefitCount) > 0) {
+    return `${Number(merchant.activeBenefitCount)} promos activas`;
+  }
+
+  return 'Promos activas';
+}
+
+function renderRelatedActiveAlternatives(relatedActiveMerchants) {
+  const alternatives = (relatedActiveMerchants || [])
+    .map((merchant) => ({
+      name: getMerchantName(merchant),
+      path: getRelatedMerchantPath(merchant),
+      category: merchant?.category || getPrimaryCategory(merchant),
+      city: merchant?.city || getPrimaryCity(merchant),
+      offerText: getRelatedMerchantOfferText(merchant)
+    }))
+    .filter((merchant) => merchant.name && merchant.path)
+    .slice(0, 4);
+
+  if (alternatives.length === 0) return '';
+
+  const items = alternatives.map((merchant) => {
+    const detail = formatList([merchant.category, merchant.city].filter(Boolean), 'Comercio relacionado');
+    return [
+      '<li class="blink-seo-related-item">',
+      `  <a href="${escapeHtml(merchant.path)}">`,
+      `    <strong>${escapeHtml(merchant.name)}</strong>`,
+      `    <span>${escapeHtml(merchant.offerText)}</span>`,
+      `    <small>${escapeHtml(detail)}</small>`,
+      '  </a>',
+      '</li>'
+    ].join('');
+  }).join('');
+
+  return [
+    '  <section class="blink-seo-section">',
+    '    <h2>Alternativas con promos activas</h2>',
+    `    <ul class="blink-seo-related-list">${items}</ul>`,
+    '  </section>'
+  ].join('\n');
+}
+
 function renderFaq(faqItems) {
   return faqItems.map((item) => [
     '<article class="blink-seo-faq-item">',
@@ -407,10 +484,18 @@ function renderFaq(faqItems) {
   ].join('')).join('');
 }
 
-function buildBodyHtml({ merchant, activeBenefits, pastBenefits, description, faqItems }) {
+function buildBodyHtml({
+  merchant,
+  activeBenefits,
+  pastBenefits,
+  relatedActiveMerchants,
+  description,
+  faqItems
+}) {
   const name = getMerchantName(merchant);
   const category = getPrimaryCategory(merchant);
   const city = getPrimaryCity(merchant) || 'Argentina';
+  const hasActiveBenefits = activeBenefits.length > 0;
   const banks = formatList(
     uniqueDisplayStrings([
       ...(Array.isArray(merchant?.banks) ? merchant.banks : []),
@@ -438,12 +523,17 @@ function buildBodyHtml({ merchant, activeBenefits, pastBenefits, description, fa
     '  </section>',
     '  <section class="blink-seo-section">',
     '    <h2>Beneficios activos</h2>',
-    renderBenefitList(activeBenefits, 'No hay descuentos activos ahora.'),
+    renderBenefitList(activeBenefits, 'No hay promos activas :('),
     '  </section>',
     '  <section class="blink-seo-section">',
-    '    <h2>Beneficios anteriores</h2>',
-    renderBenefitList(pastBenefits, 'No hay beneficios anteriores publicados.', true),
+    `    <h2>${hasActiveBenefits ? 'Beneficios anteriores' : 'Promos recientes anteriores'}</h2>`,
+    renderBenefitList(
+      pastBenefits,
+      hasActiveBenefits ? 'No hay beneficios anteriores publicados.' : 'No hay promos recientes publicadas.',
+      true
+    ),
     '  </section>',
+    hasActiveBenefits ? '' : renderRelatedActiveAlternatives(relatedActiveMerchants),
     '  <section class="blink-seo-section blink-seo-faq">',
     '    <h2>Preguntas frecuentes</h2>',
     renderFaq(faqItems),
@@ -481,6 +571,7 @@ function buildHeadHtml({ title, description, absoluteUrl, imageUrl, structuredDa
     '      .blink-seo-kicker{text-transform:uppercase;font-size:12px;letter-spacing:.08em;font-weight:700;color:#4f46e5}.blink-seo-hero h1{font-size:40px;line-height:1.05;margin:8px 0 12px}.blink-seo-hero p{font-size:18px;line-height:1.55;color:#374151}',
     '      .blink-seo-facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:24px 0;padding:0}.blink-seo-facts div,.blink-seo-benefit,.blink-seo-faq-item{border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fafafa}.blink-seo-facts dt{font-size:12px;text-transform:uppercase;color:#6b7280}.blink-seo-facts dd{margin:4px 0 0;font-weight:700}',
     '      .blink-seo-section{margin-top:36px}.blink-seo-section h2{font-size:24px;margin:0 0 14px}.blink-seo-benefits{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;list-style:none;margin:0;padding:0}.blink-seo-benefit strong{display:block;font-size:20px}.blink-seo-benefit span{display:block;color:#4b5563;margin-top:4px}.blink-seo-benefit p{margin:8px 0;color:#111827}.blink-seo-benefit small{color:#6b7280}.blink-seo-empty{color:#6b7280}',
+    '      .blink-seo-related-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;list-style:none;margin:0;padding:0}.blink-seo-related-item a{display:block;border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fff;color:#111827;text-decoration:none}.blink-seo-related-item strong,.blink-seo-related-item span,.blink-seo-related-item small{display:block}.blink-seo-related-item span{margin-top:6px;font-weight:700}.blink-seo-related-item small{margin-top:6px;color:#6b7280}',
     '      .blink-seo-faq{display:grid;gap:12px}.blink-seo-faq h2{grid-column:1/-1}.blink-seo-faq-item h3{font-size:18px;margin:0 0 8px}.blink-seo-faq-item p{margin:0;color:#374151;line-height:1.5}',
     '      @media (max-width:640px){.blink-seo-shell{padding:24px 16px 48px}.blink-seo-hero h1{font-size:32px}}',
     '    </style>'
@@ -603,6 +694,7 @@ export function renderMerchantSeoHtml({
   appShell,
   merchant,
   benefits = [],
+  relatedActiveMerchants = [],
   path: merchantPath,
   siteUrl,
   now = new Date()
@@ -611,14 +703,17 @@ export function renderMerchantSeoHtml({
   const absoluteUrl = toAbsoluteUrl(siteUrl, canonicalPath);
   const allBenefits = sortBenefitsForSeo(benefits);
   const { activeBenefits, pastBenefits } = splitMerchantSeoBenefits(allBenefits, now);
+  const displayPastBenefits = activeBenefits.length > 0
+    ? pastBenefits
+    : getRecentPastBenefits(pastBenefits, now);
   const title = `${getMerchantName(merchant)} descuentos y promociones | ${DEFAULT_SITE_NAME}`;
-  const description = buildMerchantDescription(merchant, allBenefits);
-  const faqItems = buildFaqItems(merchant, activeBenefits, pastBenefits, description);
+  const description = buildMerchantDescription(merchant, [...activeBenefits, ...displayPastBenefits]);
+  const faqItems = buildFaqItems(merchant, activeBenefits, displayPastBenefits, description);
   const imageUrl = toAbsoluteUrl(siteUrl, getMerchantImage(merchant));
   const structuredData = buildStructuredData({
     merchant,
     activeBenefits,
-    pastBenefits,
+    pastBenefits: displayPastBenefits,
     faqItems,
     absoluteUrl
   });
@@ -632,7 +727,8 @@ export function renderMerchantSeoHtml({
   const bodyHtml = buildBodyHtml({
     merchant,
     activeBenefits,
-    pastBenefits,
+    pastBenefits: displayPastBenefits,
+    relatedActiveMerchants,
     description,
     faqItems
   });

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -40,6 +40,7 @@ const DAY_SHORT_LABEL: Record<string, string> = {
   D: 'Dom',
 };
 const DAY_TEXT_MAX_LENGTH = 24;
+const RECENT_PAST_BENEFIT_WINDOW_DAYS = 180;
 
 const isAllDays = (cuando?: string): boolean => {
   if (!cuando) return true;
@@ -75,6 +76,26 @@ const isBenefitAvailableToday = (b: BankBenefit): boolean =>
 const hasPercentDiscount = (benefit: BankBenefit): boolean => {
   const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
   return !!(discount && parseInt(discount) > 0);
+};
+
+const getBenefitValidUntilTime = (benefit: BankBenefit): number | null => {
+  const validUntil = String(benefit.validUntil || '').trim();
+  if (!validUntil) return null;
+
+  const parsedTime = /^\d{4}-\d{2}-\d{2}$/.test(validUntil)
+    ? Date.parse(`${validUntil}T23:59:59.999Z`)
+    : Date.parse(validUntil);
+
+  return Number.isFinite(parsedTime) ? parsedTime : null;
+};
+
+const isRecentPastBenefit = (benefit: BankBenefit, now: Date): boolean => {
+  const validUntilTime = getBenefitValidUntilTime(benefit);
+  if (validUntilTime === null) return true;
+
+  const nowTime = now.getTime();
+  const earliestRecentTime = nowTime - RECENT_PAST_BENEFIT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  return validUntilTime < nowTime && validUntilTime >= earliestRecentTime;
 };
 
 const normalizeValidityDate = (validUntil?: string | null): string => {
@@ -174,7 +195,11 @@ function BusinessDetailPage() {
   }, [sortedBenefits]);
 
   const activeBenefitCount = activeBenefits.length;
-  const pastBenefitCount = pastBenefits.length;
+  const displayPastBenefits = useMemo(() => {
+    if (activeBenefitCount > 0) return pastBenefits;
+    const now = new Date();
+    return pastBenefits.filter((benefit) => isRecentPastBenefit(benefit, now));
+  }, [activeBenefitCount, pastBenefits]);
 
   const topInstallmentGroupsByBank = useMemo(() => {
     const byBank = new Map<string, BankBenefit[]>();
@@ -812,22 +837,24 @@ function BusinessDetailPage() {
           </div>
         )}
 
-        {viewMode !== 'sucursal' && activeBenefitCount === 0 && pastBenefitCount > 0 && (
+        {viewMode !== 'sucursal' && activeBenefitCount === 0 && displayPastBenefits.length > 0 && (
           <section
             className="mx-4 mt-3 bg-white rounded-2xl p-4"
             style={{ border: '1px solid #E8E6E1', boxShadow: '0 1px 4px rgba(0,0,0,0.04)' }}
           >
-            <p className="text-sm font-semibold text-blink-ink">No hay descuentos activos ahora</p>
+            <p className="text-sm font-semibold text-blink-ink">No hay promos activas :(</p>
             <p className="text-xs text-blink-muted mt-1">
-              Igual puedes revisar promociones anteriores de {business.name}.
+              Igual puedes revisar promos recientes anteriores de {business.name}.
             </p>
           </section>
         )}
 
-        {viewMode !== 'sucursal' && pastBenefits.length > 0 && (
+        {viewMode !== 'sucursal' && displayPastBenefits.length > 0 && (
           <section className="space-y-2 pt-3 px-4">
-            <h2 className="font-semibold text-base text-gray-400">Beneficios anteriores</h2>
-            {pastBenefits.map((benefit, idx) => {
+            <h2 className="font-semibold text-base text-gray-400">
+              {activeBenefitCount > 0 ? 'Beneficios anteriores' : 'Promos recientes anteriores'}
+            </h2>
+            {displayPastBenefits.map((benefit, idx) => {
               const discount = benefit.rewardRate.match(/(\d+)%/)?.[1];
               const hasDiscount = !!(discount && parseInt(discount) > 0);
               const hasInstallments = !hasDiscount && (benefit.installments ?? 0) > 0;

--- a/src/pages/__tests__/BusinessDetailPage.test.tsx
+++ b/src/pages/__tests__/BusinessDetailPage.test.tsx
@@ -6,7 +6,8 @@ import { fetchBusinessById } from '../../services/api';
 import { useSEO } from '../../hooks/useSEO';
 
 const TEST_SYSTEM_TIME = new Date('2026-05-15T12:00:00.000Z');
-const EXPIRED_VALID_UNTIL = '2020-01-01';
+const RECENT_EXPIRED_VALID_UNTIL = '2026-04-01';
+const STALE_EXPIRED_VALID_UNTIL = '2020-01-01';
 const ACTIVE_VALID_UNTIL = '2026-06-30';
 const EARLIER_ACTIVE_VALID_UNTIL = '2026-05-31';
 
@@ -167,7 +168,13 @@ describe('BusinessDetailPage', () => {
       benefits: [
         {
           ...mockBusiness.benefits[0],
-          validUntil: EXPIRED_VALID_UNTIL,
+          benefit: '20% OFF reciente',
+          validUntil: RECENT_EXPIRED_VALID_UNTIL,
+        },
+        {
+          ...mockBusiness.benefits[0],
+          benefit: '20% OFF viejo',
+          validUntil: STALE_EXPIRED_VALID_UNTIL,
         },
       ],
     });
@@ -181,9 +188,11 @@ describe('BusinessDetailPage', () => {
 
     render(<BusinessDetailPage />);
 
-    expect(await screen.findByText('No hay descuentos activos ahora')).toBeInTheDocument();
-    expect(screen.getByText('Beneficios anteriores')).toBeInTheDocument();
-    expect(screen.getByText(`Venció: ${EXPIRED_VALID_UNTIL}`)).toBeInTheDocument();
+    expect(await screen.findByText('No hay promos activas :(')).toBeInTheDocument();
+    expect(screen.getByText('Promos recientes anteriores')).toBeInTheDocument();
+    expect(screen.getByText('20% OFF reciente')).toBeInTheDocument();
+    expect(screen.getByText(`Venció: ${RECENT_EXPIRED_VALID_UNTIL}`)).toBeInTheDocument();
+    expect(screen.queryByText('20% OFF viejo')).not.toBeInTheDocument();
   });
 
   it('shows lower-installment rows from the same bank when validity differs', async () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -559,7 +559,7 @@ describe('merchant-first serverless helpers', () => {
                   bank: 'BBVA',
                   benefitTitle: '20% OFF',
                   discountPercentage: 20,
-                  validUntil: '2020-01-01'
+                  validUntil: '2026-04-01'
                 }
               ]);
             }
@@ -581,8 +581,8 @@ describe('merchant-first serverless helpers', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toContain('No hay descuentos activos ahora');
-    expect(res.body).toContain('Beneficios anteriores');
+    expect(res.body).toContain('No hay promos activas :(');
+    expect(res.body).toContain('Promos recientes anteriores');
     expect(res.body).toContain('20% OFF');
     expect(res.body).toContain('https://schema.org/Discontinued');
   });

--- a/src/services/__tests__/merchantSeoRenderer.test.ts
+++ b/src/services/__tests__/merchantSeoRenderer.test.ts
@@ -107,6 +107,58 @@ describe('merchant SEO renderer', () => {
     expect(html).toContain('promociones bancarias');
   });
 
+  it('keeps inactive merchant pages useful with recent promos and active alternatives', () => {
+    const html = renderMerchantSeoHtml({
+      appShell,
+      siteUrl: 'https://www.blinkapp.com.ar',
+      path: '/comercios/tienda-inactiva--merchant_2',
+      now: new Date('2026-05-11T12:00:00.000Z'),
+      merchant: {
+        merchantId: 'merchant_2',
+        merchantName: 'Tienda Inactiva',
+        categories: ['indumentaria'],
+        banks: ['Banco Galicia'],
+      },
+      benefits: [
+        {
+          bankName: 'Banco Galicia',
+          cardName: 'Visa',
+          benefit: '25% OFF',
+          rewardRate: '25%',
+          validUntil: '2026-04-15',
+        },
+        {
+          bankName: 'BBVA',
+          cardName: 'Mastercard',
+          benefit: '10% OFF antiguo',
+          rewardRate: '10%',
+          validUntil: '2025-01-01',
+        },
+      ],
+      relatedActiveMerchants: [
+        {
+          merchantId: 'merchant_3',
+          merchantName: 'Tienda Activa',
+          path: '/comercios/tienda-activa--merchant_3',
+          category: 'indumentaria',
+          city: 'Buenos Aires',
+          activeBenefitCount: 2,
+          maxDiscountPercentage: 40,
+        },
+      ],
+    });
+
+    expect(html).toContain('No hay promos activas :(');
+    expect(html).toContain('Promos recientes anteriores');
+    expect(html).toContain('25% OFF');
+    expect(html).not.toContain('10% OFF antiguo');
+    expect(html).toContain('Alternativas con promos activas');
+    expect(html).toContain('Tienda Activa');
+    expect(html).toContain('href="/comercios/tienda-activa--merchant_3"');
+    expect(html).toContain('Hasta 40% OFF');
+    expect(html).toContain('<meta name="robots" content="index, follow" />');
+  });
+
   it('renders multi-bank MODO benefits with compact provider text', () => {
     const longBankName = 'Banco Nación, Galicia, NaranjaX';
     const html = renderMerchantSeoHtml({


### PR DESCRIPTION
## Summary
- keep inactive `/comercios` merchant SEO pages indexable
- show `No hay promos activas :(` when no active benefit is available
- limit historical inactive-page offers to recent past promos
- add related active alternatives matched by category or bank

## Validation
- `npm run test -- src/services/__tests__/merchantSeoRenderer.test.ts`

## SEO intent
This turns inactive merchant pages from thin empty states into useful historical/alternative pages, especially for important merchant URLs that still have brand demand.