### PR TITLE
Use active offer details in merchant SEO meta

### DIFF
--- a/api/merchant-seo.js
+++ b/api/merchant-seo.js
@@ -218,11 +218,13 @@ function buildMerchantTitle(merchant, activeBenefits) {
   const benefitValue = formatBenefitValue(topActiveBenefit);
   const bankName = getBenefitBankName(topActiveBenefit);
 
-  if (benefitValue && bankName) {
+  if (benefitValue && bankName && normalizeText(bankName) !== 'proveedor') {
     return `${name}: ${benefitValue} con ${bankName} | ${DEFAULT_SITE_NAME}`;
   }
 
-  return `${name}: promociones activas | ${DEFAULT_SITE_NAME}`;
+  return benefitValue
+    ? `${name}: ${benefitValue} | ${DEFAULT_SITE_NAME}`
+    : `${name}: promociones activas | ${DEFAULT_SITE_NAME}`;
 }
 
 function buildMerchantDescription(merchant, benefits, activeBenefits = benefits) {
@@ -242,10 +244,14 @@ function buildMerchantDescription(merchant, benefits, activeBenefits = benefits)
 
   if (activeBenefits.length > 0) {
     const topActiveBenefit = activeBenefits[0];
+    const topProvider = getBenefitBankName(topActiveBenefit);
+    const topProviderText = normalizeText(topProvider) === 'proveedor'
+      ? ''
+      : ` con ${topProvider}`;
     const activeText = activeBenefits.length === 1
       ? '1 promo activa'
       : `${activeBenefits.length} promos activas`;
-    return `${name}: ${activeText} ${locationText} en ${category}. Destacado: ${formatBenefitValue(topActiveBenefit)} con ${getBenefitBankName(topActiveBenefit)}. Consulta dias, tope, tarjetas y vigencia en Blink.`;
+    return `${name}: ${activeText} ${locationText} en ${category}. Destacado: ${formatBenefitValue(topActiveBenefit)}${topProviderText}. Consulta dias, tope, tarjetas y vigencia en Blink.`;
   }
 
   return `${name}: descuentos y promociones ${locationText} en ${category} con ${bankText}. Consulta ${discountText}, beneficios activos y promociones anteriores en Blink.`;

--- a/api/merchant-seo.js
+++ b/api/merchant-seo.js
@@ -207,7 +207,25 @@ function formatBenefitValue(benefit) {
   return String(benefit?.rewardRate || benefit?.valor || getBenefitTitle(benefit)).trim();
 }
 
-function buildMerchantDescription(merchant, benefits) {
+function buildMerchantTitle(merchant, activeBenefits) {
+  const name = getMerchantName(merchant);
+  const topActiveBenefit = activeBenefits[0];
+
+  if (!topActiveBenefit) {
+    return `${name} descuentos y promociones | ${DEFAULT_SITE_NAME}`;
+  }
+
+  const benefitValue = formatBenefitValue(topActiveBenefit);
+  const bankName = getBenefitBankName(topActiveBenefit);
+
+  if (benefitValue && bankName) {
+    return `${name}: ${benefitValue} con ${bankName} | ${DEFAULT_SITE_NAME}`;
+  }
+
+  return `${name}: promociones activas | ${DEFAULT_SITE_NAME}`;
+}
+
+function buildMerchantDescription(merchant, benefits, activeBenefits = benefits) {
   const name = getMerchantName(merchant);
   const category = getPrimaryCategory(merchant);
   const city = getPrimaryCity(merchant);
@@ -221,6 +239,14 @@ function buildMerchantDescription(merchant, benefits) {
   const discountText = maxDiscount
     ? `hasta ${maxDiscount}% OFF`
     : 'promociones bancarias';
+
+  if (activeBenefits.length > 0) {
+    const topActiveBenefit = activeBenefits[0];
+    const activeText = activeBenefits.length === 1
+      ? '1 promo activa'
+      : `${activeBenefits.length} promos activas`;
+    return `${name}: ${activeText} ${locationText} en ${category}. Destacado: ${formatBenefitValue(topActiveBenefit)} con ${getBenefitBankName(topActiveBenefit)}. Consulta dias, tope, tarjetas y vigencia en Blink.`;
+  }
 
   return `${name}: descuentos y promociones ${locationText} en ${category} con ${bankText}. Consulta ${discountText}, beneficios activos y promociones anteriores en Blink.`;
 }
@@ -317,7 +343,7 @@ function buildStructuredData({ merchant, activeBenefits, pastBenefits, faqItems,
     name,
     image: toAbsoluteUrl(new URL(absoluteUrl).origin, image),
     url: absoluteUrl,
-    description: buildMerchantDescription(merchant, [...activeBenefits, ...pastBenefits]),
+    description: buildMerchantDescription(merchant, [...activeBenefits, ...pastBenefits], activeBenefits),
     address: buildAddressSchema(merchant)
   };
 
@@ -611,8 +637,8 @@ export function renderMerchantSeoHtml({
   const absoluteUrl = toAbsoluteUrl(siteUrl, canonicalPath);
   const allBenefits = sortBenefitsForSeo(benefits);
   const { activeBenefits, pastBenefits } = splitMerchantSeoBenefits(allBenefits, now);
-  const title = `${getMerchantName(merchant)} descuentos y promociones | ${DEFAULT_SITE_NAME}`;
-  const description = buildMerchantDescription(merchant, allBenefits);
+  const title = buildMerchantTitle(merchant, activeBenefits);
+  const description = buildMerchantDescription(merchant, allBenefits, activeBenefits);
   const faqItems = buildFaqItems(merchant, activeBenefits, pastBenefits, description);
   const imageUrl = toAbsoluteUrl(siteUrl, getMerchantImage(merchant));
   const structuredData = buildStructuredData({

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -453,7 +453,8 @@ describe('merchant-first serverless helpers', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
-    expect(res.body).toContain('<title>Coto descuentos y promociones | Blink</title>');
+    expect(res.body).toContain('<title>Coto: 25% OFF | Blink</title>');
+    expect(res.body).toContain('Destacado: 25% OFF.');
     expect(res.body).toContain('<h1>Coto descuentos y promociones</h1>');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/comercios/coto--merchant_1"');
     expect(res.body).toContain('src="/assets/index-test.js"');

--- a/src/services/__tests__/merchantSeoRenderer.test.ts
+++ b/src/services/__tests__/merchantSeoRenderer.test.ts
@@ -66,7 +66,8 @@ describe('merchant SEO renderer', () => {
       ],
     });
 
-    expect(html).toContain('<title>Coto &lt;Especial&gt; descuentos y promociones | Blink</title>');
+    expect(html).toContain('<title>Coto &lt;Especial&gt;: 35% OFF con Banco Galicia | Blink</title>');
+    expect(html).toContain('Destacado: 35% OFF con Banco Galicia');
     expect(html).toContain('<h1>Coto &lt;Especial&gt; descuentos y promociones</h1>');
     expect(html).toContain('Banco Galicia y BBVA');
     expect(html).toContain('Buenos Aires');


### PR DESCRIPTION
## Summary
- build merchant SEO titles from the top active benefit when present
- make merchant descriptions highlight active promo count, top discount, provider, and practical details
- keep the previous generic merchant title/description fallback when there are no active benefits

## Validation
- `npm run test -- src/services/__tests__/merchantSeoRenderer.test.ts`

## SEO intent
This makes active merchant pages more specific in search snippets and better aligned with offer-driven queries.