### PR TITLE
Add related active merchant offers to SEO pages

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2556,11 +2556,13 @@ async function handleMerchantSeoPage(req, res, url, db, slugId, options = {}) {
     .toArray();
   const cardNameLookup = await resolveCardNameLookup(db, rawBenefits);
   const benefits = rawBenefits.map((benefit) => buildBusinessBenefitSummary(benefit, cardNameLookup));
+  const relatedActiveMerchants = await loadRelatedActiveMerchants(db, merchant);
   const appShell = options.appShell || readViteAppShell();
   const renderedHtml = renderMerchantSeoHtml({
     appShell,
     merchant,
     benefits,
+    relatedActiveMerchants,
     path: canonicalPath,
     siteUrl: options.siteUrl || getCanonicalSiteUrl(url),
     now: options.now || new Date()
@@ -2568,6 +2570,80 @@ async function handleMerchantSeoPage(req, res, url, db, slugId, options = {}) {
 
   setCacheControl(res, CC_CONTENT);
   return html(res, 200, renderedHtml);
+}
+
+function getRelatedMerchantCategories(merchant) {
+  return Array.isArray(merchant?.categories)
+    ? merchant.categories.map((category) => String(category || '').trim()).filter(Boolean)
+    : [];
+}
+
+function getRelatedMerchantBanks(merchant) {
+  return Array.isArray(merchant?.banks)
+    ? merchant.banks.map((bank) => String(bank || '').trim()).filter(Boolean)
+    : [];
+}
+
+function getRelatedMerchantCity(merchant) {
+  const location = Array.isArray(merchant?.locations) ? merchant.locations.find(Boolean) : null;
+  const components = location?.addressComponents || {};
+  return (
+    components.locality ||
+    components.sublocality ||
+    components.adminAreaLevel2 ||
+    components.adminAreaLevel1 ||
+    ''
+  );
+}
+
+function serializeRelatedActiveMerchant(merchant) {
+  return {
+    merchantId: merchant?.merchantId,
+    merchantName: merchant?.merchantName,
+    path: getMerchantSeoPathFromMerchant(merchant),
+    category: getRelatedMerchantCategories(merchant)[0] || '',
+    city: getRelatedMerchantCity(merchant),
+    banks: getRelatedMerchantBanks(merchant),
+    activeBenefitCount: Number(merchant?.activeBenefitCount || 0),
+    maxDiscountPercentage: Number(merchant?.maxDiscountPercentage || 0)
+  };
+}
+
+async function loadRelatedActiveMerchants(db, merchant) {
+  const merchantId = String(merchant?.merchantId || '').trim();
+  const categories = getRelatedMerchantCategories(merchant);
+  const banks = getRelatedMerchantBanks(merchant);
+  const relatedClauses = [];
+
+  if (categories.length > 0) {
+    relatedClauses.push({ categories: { $in: categories } });
+  }
+
+  if (banks.length > 0) {
+    relatedClauses.push({ banks: { $in: banks } });
+  }
+
+  if (!merchantId || relatedClauses.length === 0) {
+    return [];
+  }
+
+  const relatedMerchants = await db.collection(MERCHANT_ASSETS_COLLECTION)
+    .find(
+      {
+        isActive: { $ne: false },
+        merchantId: { $exists: true, $type: 'string', $ne: merchantId },
+        activeBenefitCount: { $gt: 0 },
+        $or: relatedClauses
+      },
+      {
+        projection: MERCHANT_SEO_PROJECTION
+      }
+    )
+    .sort({ activeBenefitCount: -1, maxDiscountPercentage: -1, merchantName: 1 })
+    .limit(4)
+    .toArray();
+
+  return relatedMerchants.map(serializeRelatedActiveMerchant);
 }
 
 async function handleLegacyBusinessRedirect(req, res, url, db, merchantId) {

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2627,7 +2627,12 @@ async function loadRelatedActiveMerchants(db, merchant) {
     return [];
   }
 
-  const relatedMerchants = await db.collection(MERCHANT_ASSETS_COLLECTION)
+  const merchantCollection = db.collection(MERCHANT_ASSETS_COLLECTION);
+  if (typeof merchantCollection?.find !== 'function') {
+    return [];
+  }
+
+  const relatedMerchants = await merchantCollection
     .find(
       {
         isActive: { $ne: false },

--- a/api/merchant-seo.js
+++ b/api/merchant-seo.js
@@ -398,6 +398,60 @@ function renderBenefitList(benefits, emptyText, isPast = false) {
   return `<ul class="blink-seo-benefits">${items}</ul>`;
 }
 
+function getRelatedMerchantPath(merchant) {
+  const path = String(merchant?.path || '').trim();
+  if (path) return path;
+  if (!merchant?.merchantId) return '';
+  return getMerchantSeoPathFromMerchant(merchant);
+}
+
+function getRelatedMerchantOfferText(merchant) {
+  if (Number.isFinite(Number(merchant?.maxDiscountPercentage)) && Number(merchant.maxDiscountPercentage) > 0) {
+    return `Hasta ${Number(merchant.maxDiscountPercentage)}% OFF`;
+  }
+
+  if (Number.isFinite(Number(merchant?.activeBenefitCount)) && Number(merchant.activeBenefitCount) > 0) {
+    return `${Number(merchant.activeBenefitCount)} promos activas`;
+  }
+
+  return 'Promos activas';
+}
+
+function renderRelatedActiveMerchants(relatedActiveMerchants) {
+  const relatedMerchants = (relatedActiveMerchants || [])
+    .map((merchant) => ({
+      name: getMerchantName(merchant),
+      path: getRelatedMerchantPath(merchant),
+      category: merchant?.category || getPrimaryCategory(merchant),
+      city: merchant?.city || getPrimaryCity(merchant),
+      offerText: getRelatedMerchantOfferText(merchant)
+    }))
+    .filter((merchant) => merchant.name && merchant.path)
+    .slice(0, 4);
+
+  if (relatedMerchants.length === 0) return '';
+
+  const items = relatedMerchants.map((merchant) => {
+    const detail = formatList([merchant.category, merchant.city].filter(Boolean), 'Comercio relacionado');
+    return [
+      '<li class="blink-seo-related-item">',
+      `  <a href="${escapeHtml(merchant.path)}">`,
+      `    <strong>${escapeHtml(merchant.name)}</strong>`,
+      `    <span>${escapeHtml(merchant.offerText)}</span>`,
+      `    <small>${escapeHtml(detail)}</small>`,
+      '  </a>',
+      '</li>'
+    ].join('');
+  }).join('');
+
+  return [
+    '  <section class="blink-seo-section">',
+    '    <h2>Comercios relacionados con promos activas</h2>',
+    `    <ul class="blink-seo-related-list">${items}</ul>`,
+    '  </section>'
+  ].join('\n');
+}
+
 function renderFaq(faqItems) {
   return faqItems.map((item) => [
     '<article class="blink-seo-faq-item">',
@@ -407,7 +461,7 @@ function renderFaq(faqItems) {
   ].join('')).join('');
 }
 
-function buildBodyHtml({ merchant, activeBenefits, pastBenefits, description, faqItems }) {
+function buildBodyHtml({ merchant, activeBenefits, pastBenefits, relatedActiveMerchants, description, faqItems }) {
   const name = getMerchantName(merchant);
   const category = getPrimaryCategory(merchant);
   const city = getPrimaryCity(merchant) || 'Argentina';
@@ -444,6 +498,7 @@ function buildBodyHtml({ merchant, activeBenefits, pastBenefits, description, fa
     '    <h2>Beneficios anteriores</h2>',
     renderBenefitList(pastBenefits, 'No hay beneficios anteriores publicados.', true),
     '  </section>',
+    renderRelatedActiveMerchants(relatedActiveMerchants),
     '  <section class="blink-seo-section blink-seo-faq">',
     '    <h2>Preguntas frecuentes</h2>',
     renderFaq(faqItems),
@@ -481,6 +536,7 @@ function buildHeadHtml({ title, description, absoluteUrl, imageUrl, structuredDa
     '      .blink-seo-kicker{text-transform:uppercase;font-size:12px;letter-spacing:.08em;font-weight:700;color:#4f46e5}.blink-seo-hero h1{font-size:40px;line-height:1.05;margin:8px 0 12px}.blink-seo-hero p{font-size:18px;line-height:1.55;color:#374151}',
     '      .blink-seo-facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:24px 0;padding:0}.blink-seo-facts div,.blink-seo-benefit,.blink-seo-faq-item{border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fafafa}.blink-seo-facts dt{font-size:12px;text-transform:uppercase;color:#6b7280}.blink-seo-facts dd{margin:4px 0 0;font-weight:700}',
     '      .blink-seo-section{margin-top:36px}.blink-seo-section h2{font-size:24px;margin:0 0 14px}.blink-seo-benefits{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;list-style:none;margin:0;padding:0}.blink-seo-benefit strong{display:block;font-size:20px}.blink-seo-benefit span{display:block;color:#4b5563;margin-top:4px}.blink-seo-benefit p{margin:8px 0;color:#111827}.blink-seo-benefit small{color:#6b7280}.blink-seo-empty{color:#6b7280}',
+    '      .blink-seo-related-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;list-style:none;margin:0;padding:0}.blink-seo-related-item a{display:block;border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fff;color:#111827;text-decoration:none}.blink-seo-related-item strong,.blink-seo-related-item span,.blink-seo-related-item small{display:block}.blink-seo-related-item span{margin-top:6px;font-weight:700}.blink-seo-related-item small{margin-top:6px;color:#6b7280}',
     '      .blink-seo-faq{display:grid;gap:12px}.blink-seo-faq h2{grid-column:1/-1}.blink-seo-faq-item h3{font-size:18px;margin:0 0 8px}.blink-seo-faq-item p{margin:0;color:#374151;line-height:1.5}',
     '      @media (max-width:640px){.blink-seo-shell{padding:24px 16px 48px}.blink-seo-hero h1{font-size:32px}}',
     '    </style>'
@@ -603,6 +659,7 @@ export function renderMerchantSeoHtml({
   appShell,
   merchant,
   benefits = [],
+  relatedActiveMerchants = [],
   path: merchantPath,
   siteUrl,
   now = new Date()
@@ -633,6 +690,7 @@ export function renderMerchantSeoHtml({
     merchant,
     activeBenefits,
     pastBenefits,
+    relatedActiveMerchants,
     description,
     faqItems
   });

--- a/src/services/__tests__/merchantSeoRenderer.test.ts
+++ b/src/services/__tests__/merchantSeoRenderer.test.ts
@@ -107,6 +107,46 @@ describe('merchant SEO renderer', () => {
     expect(html).toContain('promociones bancarias');
   });
 
+  it('renders related active merchant links when provided', () => {
+    const html = renderMerchantSeoHtml({
+      appShell,
+      siteUrl: 'https://www.blinkapp.com.ar',
+      path: '/comercios/coto--merchant_1',
+      now: new Date('2026-05-11T12:00:00.000Z'),
+      merchant: {
+        merchantId: 'merchant_1',
+        merchantName: 'Coto',
+        categories: ['supermercados'],
+        banks: ['Banco Galicia'],
+      },
+      benefits: [
+        {
+          bankName: 'Banco Galicia',
+          cardName: 'Visa',
+          benefit: '35% OFF',
+          rewardRate: '35%',
+          validUntil: '2099-12-31',
+        },
+      ],
+      relatedActiveMerchants: [
+        {
+          merchantId: 'merchant_2',
+          merchantName: 'Jumbo',
+          path: '/comercios/jumbo--merchant_2',
+          category: 'supermercados',
+          city: 'Buenos Aires',
+          activeBenefitCount: 3,
+          maxDiscountPercentage: 30,
+        },
+      ],
+    });
+
+    expect(html).toContain('Comercios relacionados con promos activas');
+    expect(html).toContain('href="/comercios/jumbo--merchant_2"');
+    expect(html).toContain('Jumbo');
+    expect(html).toContain('Hasta 30% OFF');
+  });
+
   it('renders multi-bank MODO benefits with compact provider text', () => {
     const longBankName = 'Banco Nación, Galicia, NaranjaX';
     const html = renderMerchantSeoHtml({


### PR DESCRIPTION
## Summary
- add a related active merchants section to merchant SEO pages when related alternatives are available
- load alternatives from `merchant_assets`, matched by shared category or bank
- sort alternatives toward stronger active benefit count and discount depth

## Validation
- `npm run test -- src/services/__tests__/merchantSeoRenderer.test.ts`

## SEO intent
This improves internal linking between merchant pages and gives users a useful next step when they are comparing active offers.