### PR TITLE
Noindex map route for SEO

### DIFF
--- a/api/spa-shell.js
+++ b/api/spa-shell.js
@@ -221,6 +221,15 @@ function sendHtml(res, statusCode, payload, extraHeaders = {}) {
   res.send(payload);
 }
 
+function getKnownSpaRouteHeaders(pathname) {
+  const normalizedPath = (String(pathname || '/').replace(/\/+$/, '') || '/').toLowerCase();
+  if (normalizedPath === '/map') {
+    return { 'X-Robots-Tag': 'noindex, follow' };
+  }
+
+  return {};
+}
+
 export default async function handler(req, res) {
   const url = getParsedUrl(req);
   const pathname = getRequestedPath(url);
@@ -248,5 +257,5 @@ export default async function handler(req, res) {
     );
   }
 
-  return sendHtml(res, 200, readAppShell());
+  return sendHtml(res, 200, readAppShell(), getKnownSpaRouteHeaders(pathname));
 }

--- a/scripts/generate-seo-files.mjs
+++ b/scripts/generate-seo-files.mjs
@@ -66,7 +66,6 @@ const today = new Date().toISOString().split('T')[0];
 const baseRoutes = [
   { path: '/', changefreq: 'daily', priority: '1.0' },
   { path: '/search', changefreq: 'daily', priority: '0.9' },
-  { path: '/map', changefreq: 'daily', priority: '0.8' },
 ];
 
 const categorySeoRoutes = SEO_CATEGORY_DEFINITIONS.map((category) => ({

--- a/src/components/seo/RouteSEO.tsx
+++ b/src/components/seo/RouteSEO.tsx
@@ -73,11 +73,12 @@ function RouteSEO() {
         inLanguage: 'es-AR',
       },
     };
-  } else if (location.pathname === '/map') {
+  } else if (normalizedPathname === '/map') {
     seoConfig = {
       title: `Mapa de descuentos bancarios cercanos | ${SITE_NAME}`,
       description: 'Explora descuentos bancarios cercanos en el mapa y encuentra beneficios por ubicacion.',
       path: '/map',
+      robots: 'noindex, follow',
     };
   } else if (location.pathname.startsWith('/descuentos/')) {
     seoConfig = {

--- a/src/components/seo/__tests__/RouteSEO.test.tsx
+++ b/src/components/seo/__tests__/RouteSEO.test.tsx
@@ -31,4 +31,15 @@ describe('RouteSEO', () => {
       })
     );
   });
+
+  it.each(['/map', '/map/'])('marks map route %s as noindex follow', (pathname) => {
+    renderRouteSEO(pathname);
+
+    expect(vi.mocked(useSEO)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/map',
+        robots: 'noindex, follow',
+      })
+    );
+  });
 });

--- a/src/services/__tests__/canonicalSite.test.ts
+++ b/src/services/__tests__/canonicalSite.test.ts
@@ -62,7 +62,7 @@ describe('Vercel host redirect config', () => {
     );
   });
 
-  it('sends noindex headers for private app routes', () => {
+  it('sends noindex headers for private and low-value SEO app routes', () => {
     const vercelConfig = JSON.parse(
       fs.readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8')
     );
@@ -102,6 +102,24 @@ describe('Vercel host redirect config', () => {
             {
               key: 'X-Robots-Tag',
               value: 'noindex, nofollow',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          source: '/map',
+          headers: expect.arrayContaining([
+            {
+              key: 'X-Robots-Tag',
+              value: 'noindex, follow',
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          source: '/map/',
+          headers: expect.arrayContaining([
+            {
+              key: 'X-Robots-Tag',
+              value: 'noindex, follow',
             },
           ]),
         }),

--- a/src/services/__tests__/spaShell.test.ts
+++ b/src/services/__tests__/spaShell.test.ts
@@ -72,6 +72,25 @@ describe('SPA shell route guard', () => {
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/no-such-path"');
   });
 
+  it('returns the SPA shell with noindex follow headers for the map route', async () => {
+    const req = {
+      method: 'GET',
+      url: '/api/spa-shell?path=map',
+      headers: {
+        host: 'www.blinkapp.com.ar',
+        'x-forwarded-proto': 'https',
+      },
+    };
+    const res = createResponseCapture();
+
+    await handler(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.headers['X-Robots-Tag']).toBe('noindex, follow');
+    expect(res.body).toContain('<div id="root"></div>');
+  });
+
   it('falls back when a site env value is malformed by literal quotes', async () => {
     vi.stubEnv('CANONICAL_SITE_URL', '');
     vi.stubEnv('VITE_CANONICAL_SITE_URL', '');

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,24 @@
           "value": "noindex, nofollow"
         }
       ]
+    },
+    {
+      "source": "/map",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, follow"
+        }
+      ]
+    },
+    {
+      "source": "/map/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, follow"
+        }
+      ]
     }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- remove `/map` from generated sitemap base routes
- set client SEO robots to `noindex, follow` for `/map` and `/map/`
- emit `X-Robots-Tag: noindex, follow` from the SPA shell and Vercel headers

## Validation
- `npm run test -- src/components/seo/__tests__/RouteSEO.test.tsx src/services/__tests__/spaShell.test.ts src/services/__tests__/canonicalSite.test.ts`

## SEO intent
This keeps the interactive map available to users but stops it from absorbing impressions as a weak search landing page.