### PR TITLE
fix(banks): keep bank filter tokens server-searchable, map logo key separately

### DIFF
--- a/src/components/BankLogos/BankLogo.tsx
+++ b/src/components/BankLogos/BankLogo.tsx
@@ -30,7 +30,7 @@ const lookupManifestEntry = (bankName: string) => {
   }
 
   const descriptor = toBankDescriptor(bankName);
-  return bankLogosManifest[descriptor.token] ?? null;
+  return bankLogosManifest[descriptor.logoKey] ?? null;
 };
 
 const BankLogo: React.FC<BankLogoProps> = ({ bankName, size = 28, className = '' }) => {

--- a/src/components/neo/BankFilterSheet.tsx
+++ b/src/components/neo/BankFilterSheet.tsx
@@ -5,9 +5,10 @@ export interface BankFilterOption {
   token: string;
   code: string;
   label: string;
+  logoKey: string;
 }
 
-// Brand colors keyed by token
+// Brand colors keyed by logoKey (matches the bank logo manifest keys)
 const BANK_BRAND: Record<string, { bg: string; color: string }> = {
   galicia:    { bg: '#FFF0F0', color: '#E31837' },
   santander:  { bg: '#FFF0F0', color: '#EC0000' },
@@ -28,8 +29,8 @@ const BANK_BRAND: Record<string, { bg: string; color: string }> = {
   personalpay: { bg: '#F3E8FF', color: '#7C3AED' },
 };
 
-const getBrand = (token: string) =>
-  BANK_BRAND[token] ?? { bg: '#F7F6F4', color: '#374151' };
+const getBrand = (logoKey: string) =>
+  BANK_BRAND[logoKey] ?? { bg: '#F7F6F4', color: '#374151' };
 
 interface BankFilterSheetProps {
   isOpen: boolean;
@@ -154,7 +155,7 @@ const BankFilterSheet = ({
           <div className="grid grid-cols-3 gap-2.5">
             {filteredOptions.map((option) => {
               const isSelected = draftTokens.includes(option.token);
-              const brand = getBrand(option.token);
+              const brand = getBrand(option.logoKey);
               return (
                 <button
                   key={option.token}
@@ -169,7 +170,7 @@ const BankFilterSheet = ({
                     border: `1px solid ${brand.color}25`,
                   }}
                 >
-                  <BankLogo bankName={option.token} size={40} />
+                  <BankLogo bankName={option.logoKey} size={40} />
                   <span
                     className="text-[10px] font-medium mt-1.5 text-center leading-tight"
                     style={{ color: isSelected ? brand.color : `${brand.color}CC` }}

--- a/src/utils/banks.ts
+++ b/src/utils/banks.ts
@@ -1,27 +1,35 @@
 export interface BankDescriptor {
+  // Searchable value sent to the API in `bank=`. The server matches it against
+  // stored bank text with `new RegExp(escapeRegex(token), 'i')` and does NOT
+  // strip whitespace, so the token must stay a space-free substring of the
+  // stored display name (e.g. `naranja` matches `Naranja X`, `personal` matches
+  // `Personal Pay`). The visual logo/brand key is tracked separately in `logoKey`.
   token: string;
   code: string;
   label: string;
+  // Key into the bank logo manifest / brand color maps. Differs from `token`
+  // when the brand's display name contains a space (e.g. Naranja X, Personal Pay).
+  logoKey: string;
 }
 
 export const KNOWN_BANKS: BankDescriptor[] = [
-  { token: 'galicia', code: 'GAL', label: 'GALICIA' },
-  { token: 'santander', code: 'SAN', label: 'SANTANDER' },
-  { token: 'bbva', code: 'BBVA', label: 'BBVA' },
-  { token: 'macro', code: 'MAC', label: 'MACRO' },
-  { token: 'modo', code: 'MODO', label: 'MODO' },
-  { token: 'icbc', code: 'ICBC', label: 'ICBC' },
-  { token: 'hsbc', code: 'HSBC', label: 'HSBC' },
-  { token: 'amex', code: 'AMEX', label: 'AMEX' },
-  { token: 'naranjax', code: 'NX', label: 'NARANJA X' },
-  { token: 'nacion', code: 'BNA', label: 'NACION' },
-  { token: 'ciudad', code: 'CIUD', label: 'CIUDAD' },
-  { token: 'patagonia', code: 'PAT', label: 'PATAGONIA' },
-  { token: 'visa', code: 'VISA', label: 'VISA' },
-  { token: 'mastercard', code: 'MC', label: 'MASTERCARD' },
-  { token: 'lagaceta', code: 'LAGA', label: 'LA GACETA' },
-  { token: 'buepp', code: 'BUEPP', label: 'BUEPP' },
-  { token: 'personalpay', code: 'PP', label: 'PERSONAL PAY' },
+  { token: 'galicia', code: 'GAL', label: 'GALICIA', logoKey: 'galicia' },
+  { token: 'santander', code: 'SAN', label: 'SANTANDER', logoKey: 'santander' },
+  { token: 'bbva', code: 'BBVA', label: 'BBVA', logoKey: 'bbva' },
+  { token: 'macro', code: 'MAC', label: 'MACRO', logoKey: 'macro' },
+  { token: 'modo', code: 'MODO', label: 'MODO', logoKey: 'modo' },
+  { token: 'icbc', code: 'ICBC', label: 'ICBC', logoKey: 'icbc' },
+  { token: 'hsbc', code: 'HSBC', label: 'HSBC', logoKey: 'hsbc' },
+  { token: 'amex', code: 'AMEX', label: 'AMEX', logoKey: 'amex' },
+  { token: 'naranja', code: 'NX', label: 'NARANJA X', logoKey: 'naranjax' },
+  { token: 'nacion', code: 'BNA', label: 'NACION', logoKey: 'nacion' },
+  { token: 'ciudad', code: 'CIUD', label: 'CIUDAD', logoKey: 'ciudad' },
+  { token: 'patagonia', code: 'PAT', label: 'PATAGONIA', logoKey: 'patagonia' },
+  { token: 'visa', code: 'VISA', label: 'VISA', logoKey: 'visa' },
+  { token: 'mastercard', code: 'MC', label: 'MASTERCARD', logoKey: 'mastercard' },
+  { token: 'lagaceta', code: 'LAGA', label: 'LA GACETA', logoKey: 'lagaceta' },
+  { token: 'buepp', code: 'BUEPP', label: 'BUEPP', logoKey: 'buepp' },
+  { token: 'personal', code: 'PP', label: 'PERSONAL PAY', logoKey: 'personalpay' },
 ];
 
 const asBankText = (value: unknown): string => {
@@ -87,6 +95,7 @@ export const toBankDescriptor = (bankValue: unknown): BankDescriptor => {
       token: 'bank',
       code: 'BANK',
       label: 'BANCO',
+      logoKey: 'bank',
     };
   }
 
@@ -102,6 +111,7 @@ export const toBankDescriptor = (bankValue: unknown): BankDescriptor => {
     token,
     code,
     label: sanitized.toUpperCase().slice(0, 18),
+    logoKey: token,
   };
 };
 


### PR DESCRIPTION
Fixes the P2 review comment on PR #142 (Naranja X / Personal Pay bank tokens).

## Problem

`toBankDescriptor` was emitting `naranjax`/`personalpay` as the `token`, which Search/Home pass verbatim in `?bank=`. The server filters `merchantQuery.banks` and `eligibilities.bank` with `new RegExp(escapeRegex(value), 'i')` ([api/[...path].js:2258-2259](https://github.com/blink-ar/Blink-v2/blob/development/api/%5B...path%5D.js#L2258-L2259) and [:1350-1351](https://github.com/blink-ar/Blink-v2/blob/development/api/%5B...path%5D.js#L1350-L1351)) — no whitespace stripping — so records storing `Naranja X` / `Personal Pay` no longer matched, making the selected bank appear empty.

## Fix

- Restore the space-free, substring-matching `token` (`naranja`, `personal`) so server-side regex still matches stored bank text.
- Add a new `logoKey` field on `BankDescriptor` (`naranjax`, `personalpay`) used only for the logo manifest + brand color lookups.
- `BankLogo` and `BankFilterSheet` now resolve logos/colors via `logoKey`; `token` continues to drive selection state and the `?bank=` query.

## Test plan

- [x] `pnpm test` (all 563 tests pass)
- [x] `tsc --noEmit` clean
- [x] ESLint clean on changed files
- [ ] Manual: open Search, select Naranja X, confirm results render (vs. the previous empty state).
- [ ] Manual: open Search, select Personal Pay, confirm results render.
- [ ] Manual: confirm Naranja X / Personal Pay logos still display in the bank filter sheet.

https://claude.ai/code/session_017zo243zfNfmo8khS4e2rjf

---
_Generated by [Claude Code](https://claude.ai/code/session_017zo243zfNfmo8khS4e2rjf)_