### PR TITLE
Hierarchical back navigation for deep-linked benefit/business pages

### DIFF
--- a/src/pages/BenefitDetailPage.tsx
+++ b/src/pages/BenefitDetailPage.tsx
@@ -36,6 +36,8 @@ import {
   isModoSourcedBenefit,
 } from '../utils/benefitDisplay';
 import { getOptimizedImageUrl } from '../utils/images';
+import { hasInAppHistory } from '../utils/navigation';
+import { getMerchantSeoPath } from '../seo/merchantUrls';
 
 const BENEFIT_DAYS = [
   { key: 'monday' as const, abbr: 'L' },
@@ -346,6 +348,21 @@ function BenefitDetailPage() {
     }
   };
 
+  const handleBack = () => {
+    if (hasInAppHistory()) {
+      navigate(-1);
+      return;
+    }
+    // Direct/deep link: go up to the merchant's business page instead of
+    // leaving the app. Replace keeps history idx at 0 so the business page
+    // back arrow continues up to /search.
+    if (business) {
+      navigate(getMerchantSeoPath({ id: business.id, name: business.name }), { replace: true, state: { business } });
+    } else {
+      navigate('/search', { replace: true });
+    }
+  };
+
   const handleOpenMap = () => {
     if (!business) return;
     trackStartNavigation({ source: 'benefit_detail_page', destinationBusinessId: business.id, provider: 'in_app_map' });
@@ -388,7 +405,7 @@ function BenefitDetailPage() {
           <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 32 }}>search_off</span>
         </div>
         <p className="font-semibold text-blink-ink">{error || 'No encontrado'}</p>
-        <button onClick={() => navigate(-1)} className="text-primary font-medium text-sm">← Volver</button>
+        <button onClick={handleBack} className="text-primary font-medium text-sm">← Volver</button>
       </div>
     );
   }
@@ -468,7 +485,7 @@ function BenefitDetailPage() {
           {/* Floating nav */}
           <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-4 pt-6 z-20">
             <button
-              onClick={() => navigate(-1)}
+              onClick={handleBack}
               className="w-10 h-10 rounded-full flex items-center justify-center active:scale-95 transition-transform"
               style={{ background: 'rgba(0,0,0,0.07)', border: `1px solid ${bankAccent.border}` }}
             >

--- a/src/pages/BusinessDetailPage.tsx
+++ b/src/pages/BusinessDetailPage.tsx
@@ -14,6 +14,7 @@ import { buildBenefitPath } from '../utils/benefitIdentity';
 import { getBenefitProviderDisplayName, getBenefitProviderSummary } from '../utils/benefitDisplay';
 import BankLogo from '../components/BankLogos/BankLogo';
 import { getOptimizedImageUrl } from '../utils/images';
+import { hasInAppHistory } from '../utils/navigation';
 
 const ALL_DAYS = ['lunes', 'martes', 'miércoles', 'miercoles', 'jueves', 'viernes', 'sábado', 'sabado', 'domingo'];
 const DAY_ABBR: Record<string, string> = {
@@ -379,6 +380,13 @@ function BusinessDetailPage() {
     navigate(buildBenefitPath(business.id, selectedBenefit, selectedIndex), { state: { business } });
   };
 
+  const handleBack = () => {
+    // Direct/deep link (e.g. coming up from a shared benefit URL): go to the
+    // search page instead of leaving the app.
+    if (hasInAppHistory()) navigate(-1);
+    else navigate('/search', { replace: true });
+  };
+
   const handleOpenMap = () => {
     if (!business) return;
     trackStartNavigation({ source: 'business_detail_page', destinationBusinessId: business.id, provider: 'in_app_map' });
@@ -399,7 +407,7 @@ function BusinessDetailPage() {
           <span className="material-symbols-outlined text-blink-muted" style={{ fontSize: 32 }}>storefront_off</span>
         </div>
         <p className="font-semibold text-blink-ink">{error || 'No encontrado'}</p>
-        <button onClick={() => navigate(-1)} className="text-primary font-medium text-sm">← Volver</button>
+        <button onClick={handleBack} className="text-primary font-medium text-sm">← Volver</button>
       </div>
     );
   }
@@ -417,7 +425,7 @@ function BusinessDetailPage() {
         {/* Top row */}
         <div className="flex items-center gap-3 px-4 py-4">
           <button
-            onClick={() => navigate(-1)}
+            onClick={handleBack}
             className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full active:bg-gray-100 transition-colors"
           >
             <span className="material-symbols-outlined text-blink-ink" style={{ fontSize: 22 }}>arrow_back</span>

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,5 @@
+// React Router keeps its history index in window.history.state.idx.
+// idx === 0 means the current entry is the first in-app location, i.e. the
+// user landed here directly (deep link) and navigate(-1) would leave the app.
+export const hasInAppHistory = (): boolean =>
+  ((window.history.state as { idx?: number } | null)?.idx ?? 0) > 0;


### PR DESCRIPTION
## Problema

Cuando alguien entra a la app mediante un link directo a un beneficio (p. ej. desde Reddit/WhatsApp), la flecha hacia atrás llamaba `navigate(-1)`, que saca al usuario de la app — un callejón sin salida.

## Solución

Cuando no hay historial dentro de la app (entrada directa, React Router `history.state.idx === 0`):

- **Benefit page** → la flecha atrás lleva al **business page del mismo merchant** (URL canónica `/comercios/...`, pasando el `business` por state para carga instantánea).
- **Business page** → la flecha atrás lleva al **search page** (`/search`).

Las navegaciones de fallback usan `replace: true`, de modo que la cadena beneficio → comercio → búsqueda funciona paso a paso (el índice de historial se mantiene en 0).

Cuando el usuario navegó dentro de la app, la flecha sigue usando `navigate(-1)` como hasta ahora (se preserva la restauración de scroll del search page).

## Verificación

- `pnpm test`: 559/559 tests pasan
- `pnpm run build`: OK
- `eslint` sobre los archivos modificados: limpio

https://claude.ai/code/session_01M84KriB4ir2DtgtKhvpqSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01M84KriB4ir2DtgtKhvpqSy)_