### PR TITLE
[codex] Fix search terminal loading states

### DIFF
--- a/ANALYTICS_EVENTS.md
+++ b/ANALYTICS_EVENTS.md
@@ -1,6 +1,6 @@
 # Analytics Event Dictionary
 
-Last updated: 2026-06-11
+Last updated: 2026-06-15
 
 Maintenance rule:
 - Any change to analytics event names or params in `/Users/tomas/Dev/Blink/Blink-v2/src/analytics/googleAnalytics.ts` or `/Users/tomas/Dev/Blink/Blink-v2/src/analytics/intentTracking.ts` must update this file in the same PR.
@@ -308,6 +308,20 @@ Current sources:
 - `search_page`
 - `map_page`
 - `map_page_single_business`
+
+### `search_error`
+Params:
+- `source`
+- `search_term`
+- `search_term_state` (`provided` | `empty`)
+- `active_filter_count`
+- `has_filters_state` (`filters_applied` | `no_filters`)
+- `category` (normalized token)
+- `category_raw`
+- `error_message`
+
+Current sources:
+- `search_page`
 
 ## Normalization Rules (applies to all events)
 - Event names are normalized to snake_case.

--- a/src/analytics/intentTracking.ts
+++ b/src/analytics/intentTracking.ts
@@ -61,10 +61,19 @@ interface NoResultsParams extends BaseIntentParams {
   category?: string;
 }
 
+interface SearchErrorParams extends NoResultsParams {
+  errorMessage: string;
+}
+
 const normalizeText = (value: string | undefined): string | undefined => {
   if (!value) return undefined;
   const trimmed = value.trim();
   return trimmed || undefined;
+};
+
+const normalizeErrorMessage = (value: string): string => {
+  const normalized = normalizeText(value) ?? 'unknown';
+  return normalized.slice(0, 120);
 };
 
 const normalizeFilterValue = (value: string | number | boolean | undefined): string | number | boolean | undefined => {
@@ -141,7 +150,11 @@ const formatFilterValue = (
     return `${normalizedType}_${normalizedValue}`;
   }
 
-  return `${normalizedType}_${toSlug(normalizedValue)}`;
+  if (typeof normalizedValue === 'string') {
+    return `${normalizedType}_${toSlug(normalizedValue)}`;
+  }
+
+  return `${normalizedType}_none`;
 };
 
 export function trackSearchIntent(params: SearchIntentParams): void {
@@ -252,5 +265,21 @@ export function trackNoResults(params: NoResultsParams): void {
     has_filters_state: params.activeFilterCount > 0 ? 'filters_applied' : 'no_filters',
     category: category.token,
     category_raw: category.raw,
+  });
+}
+
+export function trackSearchError(params: SearchErrorParams): void {
+  const category = normalizeCategory(params.category);
+  const searchTerm = normalizeText(params.searchTerm);
+
+  trackEvent('search_error', {
+    source: normalizeEnum(params.source),
+    search_term: searchTerm,
+    search_term_state: searchTerm ? 'provided' : 'empty',
+    active_filter_count: params.activeFilterCount,
+    has_filters_state: params.activeFilterCount > 0 ? 'filters_applied' : 'no_filters',
+    category: category.token,
+    category_raw: category.raw,
+    error_message: normalizeErrorMessage(params.errorMessage),
   });
 }

--- a/src/hooks/__tests__/useBenefitsData.test.tsx
+++ b/src/hooks/__tests__/useBenefitsData.test.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBenefitsData } from '../useBenefitsData';
+import { fetchBusinessesPaginated } from '../../services/api';
+import { getRawBenefits } from '../../services/rawBenefitsApi';
+
+vi.mock('../../services/api', () => ({
+  fetchBusinessesPaginated: vi.fn(),
+}));
+
+vi.mock('../../services/rawBenefitsApi', () => ({
+  getRawBenefits: vi.fn(),
+}));
+
+vi.mock('../useGeolocation', () => ({
+  useGeolocation: () => ({
+    position: null,
+    loading: false,
+  }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+};
+
+describe('useBenefitsData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRawBenefits).mockResolvedValue([]);
+  });
+
+  it('surfaces unsuccessful business responses as primary search errors', async () => {
+    vi.mocked(fetchBusinessesPaginated).mockResolvedValue({
+      success: false,
+      businesses: [],
+      pagination: {
+        total: 0,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      },
+      filters: {},
+    });
+
+    const { result } = renderHook(() => useBenefitsData({ search: 'prune' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.primarySearchError).toBe('Business search failed');
+    });
+
+    expect(result.current.error).toBe('Business search failed');
+    expect(result.current.businesses).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useBenefitsData.test.tsx
+++ b/src/hooks/__tests__/useBenefitsData.test.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBenefitsData } from '../useBenefitsData';
 import { fetchBusinessesPaginated } from '../../services/api';
 import { getRawBenefits } from '../../services/rawBenefitsApi';
+import { type Business } from '../../types';
 
 vi.mock('../../services/api', () => ({
   fetchBusinessesPaginated: vi.fn(),
@@ -36,6 +37,26 @@ const createWrapper = () => {
   };
 };
 
+const mockBusiness: Business = {
+  id: 'merchant_1',
+  name: 'Cafe Market',
+  category: 'gastronomia',
+  description: 'Market',
+  rating: 4.5,
+  location: [],
+  image: '',
+  benefits: [
+    {
+      bankName: 'Galicia',
+      cardName: 'Visa',
+      benefit: '20% OFF',
+      rewardRate: '20%',
+      color: '#000',
+      icon: 'credit_card',
+    },
+  ],
+};
+
 describe('useBenefitsData', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,5 +86,54 @@ describe('useBenefitsData', () => {
 
     expect(result.current.error).toBe('Business search failed');
     expect(result.current.businesses).toEqual([]);
+  });
+
+  it('stops pagination without surfacing a primary error when a later page fails', async () => {
+    vi.mocked(fetchBusinessesPaginated)
+      .mockResolvedValueOnce({
+        success: true,
+        businesses: [mockBusiness],
+        pagination: {
+          total: 40,
+          limit: 20,
+          offset: 0,
+          hasMore: true,
+        },
+        filters: {},
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        businesses: [],
+        pagination: {
+          total: 0,
+          limit: 20,
+          offset: 20,
+          hasMore: true,
+        },
+        filters: {},
+      });
+
+    const { result } = renderHook(() => useBenefitsData({ search: 'cafe' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.businesses).toEqual([mockBusiness]);
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(fetchBusinessesPaginated).toHaveBeenCalledTimes(2);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+
+    expect(result.current.primarySearchError).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.businesses).toEqual([mockBusiness]);
+    expect(result.current.hasMore).toBe(false);
   });
 });

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -15,6 +15,7 @@ export const queryKeys = {
 };
 
 const ITEMS_PER_PAGE = 20;
+const BUSINESS_SEARCH_ERROR_MESSAGE = 'Business search failed';
 
 interface UseBenefitsDataReturn {
     businesses: Business[];
@@ -47,6 +48,14 @@ export interface BenefitsFilters {
     onlineOnly?: boolean; // Filter for businesses with online benefits (server-side)
     sortByDistance?: boolean; // Send exact coords to server for precise distance sort (bypasses CDN)
 }
+
+const requireSuccessfulBusinessesResponse = (response: BusinessesApiResponse): BusinessesApiResponse => {
+    if (!response.success) {
+        throw new Error(BUSINESS_SEARCH_ERROR_MESSAGE);
+    }
+
+    return response;
+};
 
 /**
  * Hook for accessing benefits data with React Query
@@ -83,7 +92,7 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             ? [...queryKeys.businesses, 'exact', position!.latitude, position!.longitude, filtersKey]
             : [...queryKeys.businesses, geohash, filtersKey],
         queryFn: async ({ pageParam = 0 }) => {
-            return fetchBusinessesPaginated({
+            const response = await fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
                 offset: pageParam,
                 ...(sortByDistance && position
@@ -95,6 +104,7 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
                 ...(filters?.subscription && { subscription: filters.subscription }),
                 ...(filters?.onlineOnly && { online: true }),
             });
+            return requireSuccessfulBusinessesResponse(response);
         },
         getNextPageParam: (lastPage: BusinessesApiResponse) => {
             if (lastPage.pagination.hasMore) {

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -20,8 +20,10 @@ interface UseBenefitsDataReturn {
     businesses: Business[];
     featuredBenefits: RawMongoBenefit[];
     isLoading: boolean;
+    isPrimarySearchLoading: boolean;
     isLoadingMore: boolean;
     error: string | null;
+    primarySearchError: string | null;
     hasMore: boolean;
     loadMore: () => void;
     refreshData: () => Promise<void>;
@@ -138,11 +140,14 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
 
     const totalBusinesses = data?.pages[0]?.pagination.total ?? 0;
 
-    const isLoading = isLoadingBusinesses || isLoadingFeatured;
+    const isPrimarySearchLoading = positionLoading || isLoadingBusinesses;
+    const isLoading = isPrimarySearchLoading || isLoadingFeatured;
     const isLoadingMore = isFetchingNextPage;
 
-    const error = businessesError
-        ? (businessesError as Error).message
+    const primarySearchError = businessesError ? (businessesError as Error).message : null;
+
+    const error = primarySearchError
+        ? primarySearchError
         : featuredError
             ? (featuredError as Error).message
             : null;
@@ -164,8 +169,10 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
         businesses,
         featuredBenefits,
         isLoading,
+        isPrimarySearchLoading,
         isLoadingMore,
         error,
+        primarySearchError,
         hasMore: hasNextPage ?? false,
         loadMore,
         refreshData,

--- a/src/hooks/useBenefitsData.ts
+++ b/src/hooks/useBenefitsData.ts
@@ -49,8 +49,11 @@ export interface BenefitsFilters {
     sortByDistance?: boolean; // Send exact coords to server for precise distance sort (bypasses CDN)
 }
 
-const requireSuccessfulBusinessesResponse = (response: BusinessesApiResponse): BusinessesApiResponse => {
-    if (!response.success) {
+const requireSuccessfulBusinessesResponse = (
+    response: BusinessesApiResponse,
+    shouldThrowOnFailure = true,
+): BusinessesApiResponse => {
+    if (!response.success && shouldThrowOnFailure) {
         throw new Error(BUSINESS_SEARCH_ERROR_MESSAGE);
     }
 
@@ -92,9 +95,10 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
             ? [...queryKeys.businesses, 'exact', position!.latitude, position!.longitude, filtersKey]
             : [...queryKeys.businesses, geohash, filtersKey],
         queryFn: async ({ pageParam = 0 }) => {
+            const offset = Number(pageParam) || 0;
             const response = await fetchBusinessesPaginated({
                 limit: ITEMS_PER_PAGE,
-                offset: pageParam,
+                offset,
                 ...(sortByDistance && position
                     ? { lat: position.latitude, lng: position.longitude }
                     : geohash ? { geohash } : {}),
@@ -104,9 +108,13 @@ export function useBenefitsData(filters?: BenefitsFilters): UseBenefitsDataRetur
                 ...(filters?.subscription && { subscription: filters.subscription }),
                 ...(filters?.onlineOnly && { online: true }),
             });
-            return requireSuccessfulBusinessesResponse(response);
+            return requireSuccessfulBusinessesResponse(response, offset === 0);
         },
         getNextPageParam: (lastPage: BusinessesApiResponse) => {
+            if (!lastPage.success) {
+                return undefined;
+            }
+
             if (lastPage.pagination.hasMore) {
                 return lastPage.pagination.offset + lastPage.pagination.limit;
             }

--- a/src/hooks/useFallbackSearch.ts
+++ b/src/hooks/useFallbackSearch.ts
@@ -87,16 +87,18 @@ export function useFallbackSearch({
     staleTime: 1000 * 60 * 10,
   });
 
-  const isFallbackSearchLoading =
-    (otherBanksEnabled && !isOtherBanksFetched && !isOtherBanksError) ||
-    (relativeEnabled && !isRelativeFetched && !isRelativeError);
+  const isOtherBanksSearchLoading = otherBanksEnabled && !isOtherBanksFetched && !isOtherBanksError;
+  const isRelativeSearchLoading = relativeEnabled && !isRelativeFetched && !isRelativeError;
+  const isFallbackSearchLoading = isOtherBanksSearchLoading || isRelativeSearchLoading;
 
   return {
     otherBanksBusinesses: otherBanksData?.businesses ?? [],
     resolvedTotalOtherBanks: otherBanksData?.pagination.total ?? 0,
     isOtherBanksLoading,
+    isOtherBanksSearchLoading,
     relativeBusinesses: relativeData?.businesses ?? [],
     isRelativeLoading,
+    isRelativeSearchLoading,
     isFallbackSearchLoading,
   };
 }

--- a/src/hooks/useFallbackSearch.ts
+++ b/src/hooks/useFallbackSearch.ts
@@ -5,12 +5,18 @@ import { encodeGeohash } from '../utils/geohash';
 import { BenefitsFilters, queryKeys } from './useBenefitsData';
 
 interface FallbackSearchParams {
-  primaryResultsEmpty: boolean;
+  shouldFetchOtherBanks: boolean;
+  shouldFetchRelative: boolean;
   filters: BenefitsFilters;
   searchIntentSignature: string;
 }
 
-export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSignature }: FallbackSearchParams) {
+export function useFallbackSearch({
+  shouldFetchOtherBanks,
+  shouldFetchRelative,
+  filters,
+  searchIntentSignature,
+}: FallbackSearchParams) {
   const { position, loading: positionLoading } = useGeolocation();
 
   const hasSelectedBanks = !!filters.bank;
@@ -26,10 +32,15 @@ export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSi
     ? ['exact', position!.latitude, position!.longitude]
     : [geohash];
 
+  const otherBanksEnabled = !!(shouldFetchOtherBanks && hasSelectedBanks && !positionLoading);
+  const relativeEnabled = !!(shouldFetchRelative && hasSearchTerm && !positionLoading);
+
   // Case 1: Same search without bank filter — are there results in other banks?
   const {
     data: otherBanksData,
     isLoading: isOtherBanksLoading,
+    isFetched: isOtherBanksFetched,
+    isError: isOtherBanksError,
   } = useQuery({
     queryKey: [
       ...queryKeys.businesses,
@@ -48,7 +59,7 @@ export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSi
           : geohash ? { geohash } : {}),
         online: filters.onlineOnly,
       }),
-    enabled: !!(primaryResultsEmpty && hasSelectedBanks && !positionLoading),
+    enabled: otherBanksEnabled,
     staleTime: 1000 * 60 * 5,
   });
 
@@ -56,6 +67,8 @@ export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSi
   const {
     data: relativeData,
     isLoading: isRelativeLoading,
+    isFetched: isRelativeFetched,
+    isError: isRelativeError,
   } = useQuery({
     queryKey: [
       ...queryKeys.businesses,
@@ -70,9 +83,13 @@ export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSi
           ? { lat: position.latitude, lng: position.longitude }
           : geohash ? { geohash } : {}),
       }),
-    enabled: !!(primaryResultsEmpty && hasSearchTerm && !positionLoading),
+    enabled: relativeEnabled,
     staleTime: 1000 * 60 * 10,
   });
+
+  const isFallbackSearchLoading =
+    (otherBanksEnabled && !isOtherBanksFetched && !isOtherBanksError) ||
+    (relativeEnabled && !isRelativeFetched && !isRelativeError);
 
   return {
     otherBanksBusinesses: otherBanksData?.businesses ?? [],
@@ -80,5 +97,6 @@ export function useFallbackSearch({ primaryResultsEmpty, filters, searchIntentSi
     isOtherBanksLoading,
     relativeBusinesses: relativeData?.businesses ?? [],
     isRelativeLoading,
+    isFallbackSearchLoading,
   };
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -843,7 +843,7 @@ function SearchPage() {
       selectedCategory,
       currentFilterState.selectedBanksKey,
       activeFilterCount,
-      enrichedBusinesses.length,
+      strictMatches.length,
     ].join('|');
 
     if (searchIntentSignatureRef.current === signature) return;
@@ -852,7 +852,7 @@ function SearchPage() {
     trackSearchIntent({
       source: 'search_page',
       searchTerm: normalizedSearch,
-      resultsCount: enrichedBusinesses.length,
+      resultsCount: strictMatches.length,
       hasFilters,
       activeFilterCount,
       category: selectedCategory || undefined,
@@ -861,10 +861,10 @@ function SearchPage() {
     activeFilterCount,
     currentFilterState.selectedBanksKey,
     debouncedSearch,
-    enrichedBusinesses.length,
     isPrimarySearchLoading,
     selectedCategory,
     showPrimarySearchError,
+    strictMatches.length,
   ]);
 
   useEffect(() => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -472,9 +472,10 @@ function SearchPage() {
     otherBanksBusinesses,
     resolvedTotalOtherBanks,
     isOtherBanksLoading,
+    isOtherBanksSearchLoading,
     relativeBusinesses,
     isRelativeLoading,
-    isFallbackSearchLoading,
+    isRelativeSearchLoading,
   } = useFallbackSearch({
     shouldFetchOtherBanks: primaryResultsEmpty,
     shouldFetchRelative: primaryResultsEmpty || showPrimarySearchError,
@@ -488,21 +489,33 @@ function SearchPage() {
     searchIntentSignature,
   });
 
+  const hasOtherBanksFallback =
+    primaryResultsEmpty &&
+    hasSelectedBanks &&
+    otherBanksBusinesses.length > 0;
+
+  const shouldWaitForFallbackDecision =
+    primaryResultsEmpty &&
+    (
+      (hasSelectedBanks && isOtherBanksSearchLoading) ||
+      (!hasOtherBanksFallback && isRelativeSearchLoading)
+    );
+
   const shouldShowResultsLoader =
     (isPrimarySearchLoading && !businesses.length) ||
-    (primaryResultsEmpty && isFallbackSearchLoading);
+    shouldWaitForFallbackDecision;
 
   // Case 1: bank filter active + empty primary + other-bank results exist
   const showOtherBanksFallback =
     primaryResultsEmpty &&
     !showPrimarySearchError &&
-    !isFallbackSearchLoading &&
+    !isOtherBanksSearchLoading &&
     hasSelectedBanks &&
     otherBanksBusinesses.length > 0;
   // Case 2: still empty (no banks narrowing things down, or banks also failed)
   const showRelativesFallback =
     primaryResultsEmpty &&
-    !isFallbackSearchLoading &&
+    !shouldWaitForFallbackDecision &&
     !showOtherBanksFallback;
 
   const resultsStatusLabel = showPrimarySearchError
@@ -887,7 +900,7 @@ function SearchPage() {
   ]);
 
   useEffect(() => {
-    if (isPrimarySearchLoading || isFallbackSearchLoading || showPrimarySearchError) return;
+    if (isPrimarySearchLoading || shouldWaitForFallbackDecision || showPrimarySearchError) return;
     if (showOtherBanksFallback) return;
     if (strictMatches.length > 0) return;
 
@@ -915,11 +928,11 @@ function SearchPage() {
     activeFilterCount,
     currentFilterState.selectedBanksKey,
     debouncedSearch,
-    isFallbackSearchLoading,
     isPrimarySearchLoading,
     selectedCategory,
     showOtherBanksFallback,
     showPrimarySearchError,
+    shouldWaitForFallbackDecision,
     strictMatches.length,
   ]);
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -21,6 +21,7 @@ import { buildBankOptions, toBankDescriptor } from '../utils/banks';
 import {
   trackFilterApply,
   trackNoResults,
+  trackSearchError,
   trackSearchIntent,
   trackSelectBusiness,
 } from '../analytics/intentTracking';
@@ -388,10 +389,12 @@ function SearchPage() {
 
   const {
     businesses,
-    isLoading,
+    isPrimarySearchLoading,
     isLoadingMore,
+    primarySearchError,
     hasMore,
     loadMore,
+    refreshData,
     totalBusinesses,
     proximityUnavailable,
   } = useBenefitsData({
@@ -447,7 +450,16 @@ function SearchPage() {
     });
     return () => { cancelled = true; };
   }, [enrichedIds, hasSelectedBanks]);
-  const primaryResultsEmpty = !isLoading && strictMatches.length === 0 && hasSearchTerm;
+  const showPrimarySearchError =
+    !isPrimarySearchLoading &&
+    !!primarySearchError &&
+    businesses.length === 0;
+
+  const primaryResultsEmpty =
+    !isPrimarySearchLoading &&
+    !showPrimarySearchError &&
+    strictMatches.length === 0 &&
+    hasSearchTerm;
 
   // Stable signature to re-trigger fallback queries when intent changes
   const searchIntentSignature = [
@@ -462,8 +474,10 @@ function SearchPage() {
     isOtherBanksLoading,
     relativeBusinesses,
     isRelativeLoading,
+    isFallbackSearchLoading,
   } = useFallbackSearch({
-    primaryResultsEmpty,
+    shouldFetchOtherBanks: primaryResultsEmpty,
+    shouldFetchRelative: primaryResultsEmpty || showPrimarySearchError,
     filters: {
       search: debouncedSearch.trim() || undefined,
       category: selectedCategory && selectedCategory !== 'all' ? selectedCategory : undefined,
@@ -474,10 +488,26 @@ function SearchPage() {
     searchIntentSignature,
   });
 
+  const shouldShowResultsLoader =
+    (isPrimarySearchLoading && !businesses.length) ||
+    (primaryResultsEmpty && isFallbackSearchLoading);
+
   // Case 1: bank filter active + empty primary + other-bank results exist
-  const showOtherBanksFallback = primaryResultsEmpty && hasSelectedBanks && otherBanksBusinesses.length > 0;
+  const showOtherBanksFallback =
+    primaryResultsEmpty &&
+    !showPrimarySearchError &&
+    !isFallbackSearchLoading &&
+    hasSelectedBanks &&
+    otherBanksBusinesses.length > 0;
   // Case 2: still empty (no banks narrowing things down, or banks also failed)
-  const showRelativesFallback = primaryResultsEmpty && !showOtherBanksFallback;
+  const showRelativesFallback =
+    primaryResultsEmpty &&
+    !isFallbackSearchLoading &&
+    !showOtherBanksFallback;
+
+  const resultsStatusLabel = showPrimarySearchError
+    ? 'No disponible'
+    : shouldShowResultsLoader ? 'Buscando...' : `${totalBusinesses} resultados`;
 
   // Label for the relatives section
   const relativesLabel = (() => {
@@ -547,6 +577,7 @@ function SearchPage() {
   const hasInitializedFiltersRef = useRef(false);
   const searchIntentSignatureRef = useRef('');
   const noResultsSignatureRef = useRef('');
+  const searchErrorSignatureRef = useRef('');
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Infinite scroll sentinel — primary results
@@ -581,7 +612,7 @@ function SearchPage() {
   // Derives the category from the first search result and fetches more businesses
   // from that category so the list never feels empty.
   const firstEnrichedBusiness = enrichedBusinesses[0] as BusinessWithCategories | undefined;
-  const matchedCategory = hasSearchTerm && !isLoading && firstEnrichedBusiness
+  const matchedCategory = hasSearchTerm && !isPrimarySearchLoading && !showPrimarySearchError && firstEnrichedBusiness
     ? (firstEnrichedBusiness.category || firstEnrichedBusiness.categories?.[0])?.toLowerCase()
     : undefined;
 
@@ -680,12 +711,12 @@ function SearchPage() {
   }, []);
 
   useEffect(() => {
-    if (!isLoading && pendingScrollRef.current !== null) {
+    if (!isPrimarySearchLoading && pendingScrollRef.current !== null) {
       const y = pendingScrollRef.current;
       pendingScrollRef.current = null;
       window.scrollTo({ top: y, behavior: 'instant' });
     }
-  }, [isLoading]);
+  }, [isPrimarySearchLoading]);
 
   useEffect(() => {
     if (!hasInitializedFiltersRef.current) {
@@ -788,7 +819,7 @@ function SearchPage() {
   }, [activeFilterCount, currentFilterState]);
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isPrimarySearchLoading || showPrimarySearchError) return;
 
     const normalizedSearch = debouncedSearch.trim();
     const hasFilters = activeFilterCount > 0;
@@ -818,13 +849,47 @@ function SearchPage() {
     currentFilterState.selectedBanksKey,
     debouncedSearch,
     enrichedBusinesses.length,
-    isLoading,
+    isPrimarySearchLoading,
     selectedCategory,
+    showPrimarySearchError,
   ]);
 
   useEffect(() => {
-    if (isLoading) return;
-    if (enrichedBusinesses.length > 0) return;
+    if (!showPrimarySearchError || !primarySearchError) return;
+
+    const normalizedSearch = debouncedSearch.trim();
+
+    const signature = [
+      normalizedSearch,
+      selectedCategory,
+      currentFilterState.selectedBanksKey,
+      activeFilterCount,
+      primarySearchError,
+    ].join('|');
+
+    if (searchErrorSignatureRef.current === signature) return;
+    searchErrorSignatureRef.current = signature;
+
+    trackSearchError({
+      source: 'search_page',
+      searchTerm: normalizedSearch,
+      activeFilterCount,
+      category: selectedCategory || undefined,
+      errorMessage: primarySearchError,
+    });
+  }, [
+    activeFilterCount,
+    currentFilterState.selectedBanksKey,
+    debouncedSearch,
+    primarySearchError,
+    selectedCategory,
+    showPrimarySearchError,
+  ]);
+
+  useEffect(() => {
+    if (isPrimarySearchLoading || isFallbackSearchLoading || showPrimarySearchError) return;
+    if (showOtherBanksFallback) return;
+    if (strictMatches.length > 0) return;
 
     const normalizedSearch = debouncedSearch.trim();
     if (!normalizedSearch && activeFilterCount === 0) return;
@@ -850,9 +915,12 @@ function SearchPage() {
     activeFilterCount,
     currentFilterState.selectedBanksKey,
     debouncedSearch,
-    enrichedBusinesses.length,
-    isLoading,
+    isFallbackSearchLoading,
+    isPrimarySearchLoading,
     selectedCategory,
+    showOtherBanksFallback,
+    showPrimarySearchError,
+    strictMatches.length,
   ]);
 
   // Get max discount for a business
@@ -926,6 +994,33 @@ function SearchPage() {
       position,
     });
     navigate(getMerchantSeoPath({ id: business.id, name: business.name }), { state: { business } });
+  };
+
+  const renderNeutralSuggestions = () => {
+    if (!isRelativeLoading && relativeBusinesses.length === 0) return null;
+
+    return (
+      <>
+        <div className="flex items-center gap-2 mb-3 px-0.5">
+          <span className="material-symbols-outlined" style={{ fontSize: 18, color: '#6366F1' }}>auto_awesome</span>
+          <p className="font-semibold text-sm text-blink-ink">{relativesLabel}</p>
+        </div>
+        <div className="space-y-3">
+          {relativeItems.map((business, index) => (
+            business ? (
+              <BusinessResultCard
+                key={`suggestion-${business.id}`}
+                business={business}
+                badgeSource={fullBusinessesMap.get(business.id) ?? business}
+                onClick={() => handleBusinessSelect(business, index + 1)}
+              />
+            ) : (
+              <SkeletonCard key={`suggestion-skeleton-${index}`} />
+            )
+          ))}
+        </div>
+      </>
+    );
   };
 
   return (
@@ -1261,15 +1356,41 @@ function SearchPage() {
             className="text-xs font-semibold px-2.5 py-1 rounded-full"
             style={{ background: '#EEF2FF', color: '#4338CA' }}
           >
-            {totalBusinesses} resultados
+            {resultsStatusLabel}
           </span>
         </div>
 
-        {isLoading && !enrichedBusinesses.length ? (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        {shouldShowResultsLoader ? (
+          <div
+            role="status"
+            aria-label="Cargando resultados"
+            className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3"
+          >
             {Array.from({ length: 6 }).map((_, index) => (
-            <SkeletonCard key={index} />
+              <SkeletonCard key={index} />
             ))}
+          </div>
+        ) : showPrimarySearchError ? (
+          <div>
+            <div className="text-center pt-8 pb-6">
+              <div
+                className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-3"
+                style={{ background: '#FEE2E2' }}
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: 32, color: '#DC2626' }}>error</span>
+              </div>
+              <p className="font-semibold text-lg text-blink-ink">No pudimos buscar ahora</p>
+              <p className="text-sm text-blink-muted mt-1">Reintentá en unos segundos</p>
+              <button
+                type="button"
+                onClick={() => void refreshData()}
+                className="mt-4 inline-flex h-10 items-center gap-2 rounded-xl bg-primary px-4 text-sm font-bold text-white transition-all active:scale-95"
+              >
+                <span className="material-symbols-outlined" style={{ fontSize: 18 }}>refresh</span>
+                Reintentar
+              </button>
+            </div>
+            {renderNeutralSuggestions()}
           </div>
         ) : showOtherBanksFallback ? (
           /* ── CASE 1: Selected banks have no match, but other banks do ── */
@@ -1497,7 +1618,7 @@ function SearchPage() {
         )}
 
         {/* Related by category - show when we have results or when starting to load them */}
-        {!isLoading && (isRelatedLoading || relatedBusinesses.length > 0) && (
+        {!isPrimarySearchLoading && !showPrimarySearchError && (isRelatedLoading || relatedBusinesses.length > 0) && (
           <div className="mt-8 pt-10 border-t border-blink-border">
             <h2 className="mb-4 font-bold text-lg text-blink-ink">
               {relatedCategoryLabel ? `Más en ${relatedCategoryLabel}` : 'Más opciones relacionadas'}

--- a/src/pages/__tests__/SearchPage.loadingStates.test.tsx
+++ b/src/pages/__tests__/SearchPage.loadingStates.test.tsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SearchPage from '../SearchPage';
+import { useBenefitsData } from '../../hooks/useBenefitsData';
+import { useFallbackSearch } from '../../hooks/useFallbackSearch';
+import { useEnrichedBusinesses } from '../../hooks/useEnrichedBusinesses';
+import { trackSearchError } from '../../analytics/intentTracking';
+
+const queryMocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  useInfiniteQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: queryMocks.useQuery,
+  useInfiniteQuery: queryMocks.useInfiniteQuery,
+}));
+
+vi.mock('../../hooks/useBenefitsData', () => ({
+  useBenefitsData: vi.fn(),
+}));
+
+vi.mock('../../hooks/useFallbackSearch', () => ({
+  useFallbackSearch: vi.fn(),
+}));
+
+vi.mock('../../hooks/useEnrichedBusinesses', () => ({
+  useEnrichedBusinesses: vi.fn(),
+}));
+
+vi.mock('../../hooks/useGeolocation', () => ({
+  useGeolocation: () => ({
+    position: null,
+    loading: false,
+    permissionDenied: false,
+    requestPermission: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/neo/BottomNav', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/neo/BankFilterSheet', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../components/neo/CategoryFilterSheet', () => ({
+  CATEGORY_OPTIONS: [
+    { token: 'gastronomia', label: 'Gastronomia', emoji: '' },
+  ],
+  default: () => null,
+}));
+
+vi.mock('../../components/neo/UnifiedFilterSheet', () => ({
+  DAY_OPTIONS: [],
+  DISCOUNT_OPTIONS: [],
+  default: () => null,
+}));
+
+vi.mock('../../components/BusinessResultCard', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../services/api', () => ({
+  fetchBanks: vi.fn(),
+  fetchBusinessesPaginated: vi.fn(),
+  fetchBusinessById: vi.fn(),
+}));
+
+vi.mock('../../analytics/intentTracking', () => ({
+  trackFilterApply: vi.fn(),
+  trackNoResults: vi.fn(),
+  trackSearchError: vi.fn(),
+  trackSearchIntent: vi.fn(),
+  trackSelectBusiness: vi.fn(),
+}));
+
+const renderSearchPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/buscar?q=prune']}>
+      <SearchPage />
+    </MemoryRouter>,
+  );
+
+describe('SearchPage loading states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    window.scrollTo = vi.fn();
+    window.IntersectionObserver = vi.fn(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+      takeRecords: vi.fn(() => []),
+    })) as unknown as typeof IntersectionObserver;
+
+    queryMocks.useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isFetched: true,
+      isError: false,
+    });
+    queryMocks.useInfiniteQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    });
+
+    vi.mocked(useBenefitsData).mockReturnValue({
+      businesses: [],
+      featuredBenefits: [],
+      isLoading: false,
+      isPrimarySearchLoading: false,
+      isLoadingMore: false,
+      error: null,
+      primarySearchError: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refreshData: vi.fn(),
+      totalBusinesses: 0,
+      proximityUnavailable: false,
+    });
+    vi.mocked(useEnrichedBusinesses).mockReturnValue([]);
+  });
+
+  it('keeps the loader visible while fallback calls are still pending', () => {
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [],
+      resolvedTotalOtherBanks: 0,
+      isOtherBanksLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: true,
+      isFallbackSearchLoading: true,
+    });
+
+    renderSearchPage();
+
+    expect(screen.getByRole('status', { name: 'Cargando resultados' })).toBeInTheDocument();
+    expect(screen.getByText('Buscando...')).toBeInTheDocument();
+    expect(screen.queryByText(/No encontramos/)).not.toBeInTheDocument();
+  });
+
+  it('shows the not-found state only after fallback calls have settled', () => {
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [],
+      resolvedTotalOtherBanks: 0,
+      isOtherBanksLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: false,
+      isFallbackSearchLoading: false,
+    });
+
+    renderSearchPage();
+
+    expect(screen.queryByRole('status', { name: 'Cargando resultados' })).not.toBeInTheDocument();
+    expect(screen.getByText('No encontramos "prune"')).toBeInTheDocument();
+  });
+
+  it('does not block the terminal state on unrelated featured-benefits loading', () => {
+    vi.mocked(useBenefitsData).mockReturnValue({
+      businesses: [],
+      featuredBenefits: [],
+      isLoading: true,
+      isPrimarySearchLoading: false,
+      isLoadingMore: false,
+      error: null,
+      primarySearchError: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refreshData: vi.fn(),
+      totalBusinesses: 0,
+      proximityUnavailable: false,
+    });
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [],
+      resolvedTotalOtherBanks: 0,
+      isOtherBanksLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: false,
+      isFallbackSearchLoading: false,
+    });
+
+    renderSearchPage();
+
+    expect(screen.queryByRole('status', { name: 'Cargando resultados' })).not.toBeInTheDocument();
+    expect(screen.getByText('No encontramos "prune"')).toBeInTheDocument();
+  });
+
+  it('renders a primary search error with retry and neutral suggestions', async () => {
+    const refreshData = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useBenefitsData).mockReturnValue({
+      businesses: [],
+      featuredBenefits: [],
+      isLoading: false,
+      isPrimarySearchLoading: false,
+      isLoadingMore: false,
+      error: 'Search failed',
+      primarySearchError: 'Search failed',
+      hasMore: false,
+      loadMore: vi.fn(),
+      refreshData,
+      totalBusinesses: 0,
+      proximityUnavailable: false,
+    });
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [],
+      resolvedTotalOtherBanks: 0,
+      isOtherBanksLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: true,
+      isFallbackSearchLoading: true,
+    });
+
+    renderSearchPage();
+
+    expect(screen.queryByRole('status', { name: 'Cargando resultados' })).not.toBeInTheDocument();
+    expect(screen.getByText('No disponible')).toBeInTheDocument();
+    expect(screen.getByText('No pudimos buscar ahora')).toBeInTheDocument();
+    expect(screen.queryByText(/No encontramos/)).not.toBeInTheDocument();
+    expect(screen.getByText(/interese/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reintentar/ }));
+
+    expect(refreshData).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(vi.mocked(trackSearchError)).toHaveBeenCalledWith({
+        source: 'search_page',
+        searchTerm: 'prune',
+        activeFilterCount: expect.any(Number),
+        category: undefined,
+        errorMessage: 'Search failed',
+      });
+    });
+  });
+});

--- a/src/pages/__tests__/SearchPage.loadingStates.test.tsx
+++ b/src/pages/__tests__/SearchPage.loadingStates.test.tsx
@@ -5,7 +5,7 @@ import SearchPage from '../SearchPage';
 import { useBenefitsData } from '../../hooks/useBenefitsData';
 import { useFallbackSearch } from '../../hooks/useFallbackSearch';
 import { useEnrichedBusinesses } from '../../hooks/useEnrichedBusinesses';
-import { trackSearchError } from '../../analytics/intentTracking';
+import { trackNoResults, trackSearchError, trackSearchIntent } from '../../analytics/intentTracking';
 import { type Business } from '../../types';
 
 const queryMocks = vi.hoisted(() => ({
@@ -105,6 +105,13 @@ const mockBusiness: Business = {
   ],
 };
 
+const nonStrictMatchBusiness: Business = {
+  ...mockBusiness,
+  id: 'merchant_2',
+  name: 'Cafe Market',
+  aliases: ['coffee shop'],
+};
+
 describe('SearchPage loading states', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -184,6 +191,50 @@ describe('SearchPage loading states', () => {
 
     expect(screen.queryByRole('status', { name: 'Cargando resultados' })).not.toBeInTheDocument();
     expect(screen.getByText('No encontramos "prune"')).toBeInTheDocument();
+  });
+
+  it('tracks search results using the visible strict-match count', async () => {
+    vi.mocked(useBenefitsData).mockReturnValue({
+      businesses: [nonStrictMatchBusiness],
+      featuredBenefits: [],
+      isLoading: false,
+      isPrimarySearchLoading: false,
+      isLoadingMore: false,
+      error: null,
+      primarySearchError: null,
+      hasMore: false,
+      loadMore: vi.fn(),
+      refreshData: vi.fn(),
+      totalBusinesses: 1,
+      proximityUnavailable: false,
+    });
+    vi.mocked(useEnrichedBusinesses).mockReturnValue([nonStrictMatchBusiness]);
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [],
+      resolvedTotalOtherBanks: 0,
+      isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: false,
+      isRelativeSearchLoading: false,
+      isFallbackSearchLoading: false,
+    });
+
+    renderSearchPage();
+
+    await waitFor(() => {
+      expect(vi.mocked(trackSearchIntent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchTerm: 'prune',
+          resultsCount: 0,
+        }),
+      );
+    });
+    expect(vi.mocked(trackNoResults)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchTerm: 'prune',
+      }),
+    );
   });
 
   it('does not block the terminal state on unrelated featured-benefits loading', () => {

--- a/src/pages/__tests__/SearchPage.loadingStates.test.tsx
+++ b/src/pages/__tests__/SearchPage.loadingStates.test.tsx
@@ -6,6 +6,7 @@ import { useBenefitsData } from '../../hooks/useBenefitsData';
 import { useFallbackSearch } from '../../hooks/useFallbackSearch';
 import { useEnrichedBusinesses } from '../../hooks/useEnrichedBusinesses';
 import { trackSearchError } from '../../analytics/intentTracking';
+import { type Business } from '../../types';
 
 const queryMocks = vi.hoisted(() => ({
   useQuery: vi.fn(),
@@ -77,12 +78,32 @@ vi.mock('../../analytics/intentTracking', () => ({
   trackSelectBusiness: vi.fn(),
 }));
 
-const renderSearchPage = () =>
+const renderSearchPage = (initialEntry = '/buscar?q=prune') =>
   render(
-    <MemoryRouter initialEntries={['/buscar?q=prune']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <SearchPage />
     </MemoryRouter>,
   );
+
+const mockBusiness: Business = {
+  id: 'merchant_1',
+  name: 'Prune Market',
+  category: 'gastronomia',
+  description: 'Market',
+  rating: 4.5,
+  location: [],
+  image: '',
+  benefits: [
+    {
+      bankName: 'Galicia',
+      cardName: 'Visa',
+      benefit: '20% OFF',
+      rewardRate: '20%',
+      color: '#000',
+      icon: 'credit_card',
+    },
+  ],
+};
 
 describe('SearchPage loading states', () => {
   beforeEach(() => {
@@ -133,8 +154,10 @@ describe('SearchPage loading states', () => {
       otherBanksBusinesses: [],
       resolvedTotalOtherBanks: 0,
       isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
       relativeBusinesses: [],
       isRelativeLoading: true,
+      isRelativeSearchLoading: true,
       isFallbackSearchLoading: true,
     });
 
@@ -150,8 +173,10 @@ describe('SearchPage loading states', () => {
       otherBanksBusinesses: [],
       resolvedTotalOtherBanks: 0,
       isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
       relativeBusinesses: [],
       isRelativeLoading: false,
+      isRelativeSearchLoading: false,
       isFallbackSearchLoading: false,
     });
 
@@ -180,8 +205,10 @@ describe('SearchPage loading states', () => {
       otherBanksBusinesses: [],
       resolvedTotalOtherBanks: 0,
       isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
       relativeBusinesses: [],
       isRelativeLoading: false,
+      isRelativeSearchLoading: false,
       isFallbackSearchLoading: false,
     });
 
@@ -211,8 +238,10 @@ describe('SearchPage loading states', () => {
       otherBanksBusinesses: [],
       resolvedTotalOtherBanks: 0,
       isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
       relativeBusinesses: [],
       isRelativeLoading: true,
+      isRelativeSearchLoading: true,
       isFallbackSearchLoading: true,
     });
 
@@ -236,5 +265,25 @@ describe('SearchPage loading states', () => {
         errorMessage: 'Search failed',
       });
     });
+  });
+
+  it('shows other-bank results without waiting for popular fallback suggestions', () => {
+    vi.mocked(useFallbackSearch).mockReturnValue({
+      otherBanksBusinesses: [mockBusiness],
+      resolvedTotalOtherBanks: 1,
+      isOtherBanksLoading: false,
+      isOtherBanksSearchLoading: false,
+      relativeBusinesses: [],
+      isRelativeLoading: true,
+      isRelativeSearchLoading: true,
+      isFallbackSearchLoading: true,
+    });
+
+    renderSearchPage('/buscar?q=prune&bank=bbva');
+
+    expect(screen.queryByRole('status', { name: 'Cargando resultados' })).not.toBeInTheDocument();
+    expect(screen.getByText('No hay resultados para tus bancos')).toBeInTheDocument();
+    expect(screen.getByText('1 opción')).toBeInTheDocument();
+    expect(screen.queryByText(/No encontramos/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Gate the search empty state on the primary business search and enabled fallback probes only.
- Add a primary search error state with retry and neutral suggestions.
- Track primary search failures through a new `search_error` analytics event and document it.
- Add regression coverage for pending fallback, settled not-found, featured loading, and primary error states.

## Why
The search page could briefly render `No encontramos "..."` and `0 resultados` before the current search/fallback calls had settled. That made an in-flight request look like a terminal empty result.

## Validation
- `pnpm exec vitest --run src/pages/__tests__/SearchPage.loadingStates.test.tsx`
- `pnpm exec eslint src/hooks/useBenefitsData.ts src/hooks/useFallbackSearch.ts src/pages/SearchPage.tsx src/pages/__tests__/SearchPage.loadingStates.test.tsx src/analytics/intentTracking.ts`
- Pre-push hook: `pnpm run build`
- Pre-push hook: `pnpm test`