### PR TITLE
No pedir ubicación al cargar; pedirla con un gesto del usuario

### DIFF
--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 interface Coordinates {
   latitude: number;
@@ -19,11 +19,20 @@ const STORAGE_KEYS = {
   permission: 'locationPermission',
 } as const;
 
-// Module-level listeners so all hook instances stay in sync when any one
-// instance successfully obtains or loses location.
+const POSITION_OPTIONS: PositionOptions = {
+  enableHighAccuracy: true,
+  timeout: 10000,
+  maximumAge: CACHE_DURATION,
+};
+
+// Module-level listeners so all hook instances stay in sync. Any instance that
+// starts/finishes a location request broadcasts here, so siblings (e.g. the
+// separate useGeolocation() inside useBenefitsData) reflect the same state.
 type LocationUpdate =
   | { type: 'position'; coordinates: Coordinates }
-  | { type: 'denied' };
+  | { type: 'denied' }
+  | { type: 'pending' }
+  | { type: 'error'; message: string };
 
 const locationListeners = new Set<(update: LocationUpdate) => void>();
 
@@ -31,12 +40,53 @@ const notifyListeners = (update: LocationUpdate) => {
   locationListeners.forEach((fn) => fn(update));
 };
 
+// Shared across all hook instances: true while a browser geolocation request is
+// pending. Lets sibling instances avoid idling out (loading:false) mid-request.
+let requestInFlight = false;
+
 const getCachedPosition = (): Coordinates | null => {
   const cached = localStorage.getItem(STORAGE_KEYS.position);
   const timestamp = localStorage.getItem(STORAGE_KEYS.timestamp);
   if (!cached || !timestamp) return null;
   if (Date.now() - parseInt(timestamp) > CACHE_DURATION) return null;
   return JSON.parse(cached);
+};
+
+// Marks the permission as denied and broadcasts it to every instance.
+const resolveDenied = () => {
+  requestInFlight = false;
+  localStorage.setItem(STORAGE_KEYS.permission, 'denied');
+  notifyListeners({ type: 'denied' });
+};
+
+// Starts a browser geolocation request, broadcasting the pending state up front
+// and the outcome (position / denied / error) to every instance when it settles.
+const runRequest = () => {
+  requestInFlight = true;
+  notifyListeners({ type: 'pending' });
+
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      const coordinates = {
+        latitude: pos.coords.latitude,
+        longitude: pos.coords.longitude,
+      };
+      localStorage.setItem(STORAGE_KEYS.position, JSON.stringify(coordinates));
+      localStorage.setItem(STORAGE_KEYS.timestamp, Date.now().toString());
+      localStorage.setItem(STORAGE_KEYS.permission, 'granted');
+      requestInFlight = false;
+      notifyListeners({ type: 'position', coordinates });
+    },
+    (err) => {
+      requestInFlight = false;
+      if (err.code === err.PERMISSION_DENIED) {
+        resolveDenied();
+      } else {
+        notifyListeners({ type: 'error', message: err.message });
+      }
+    },
+    POSITION_OPTIONS,
+  );
 };
 
 interface UseGeolocationOptions {
@@ -60,19 +110,24 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
     permissionDenied: false,
   });
 
-  // Tracks an in-flight explicit request (requestPermission). The mount effect's
-  // async permissions.query() can resolve *after* such a request started; without
-  // this guard its 'prompt' branch would call setIdle() and clobber the in-flight
-  // request's loading:true, making consumers treat geolocation as settled.
-  const manualRequestRef = useRef(false);
-
   useEffect(() => {
-    // Subscribe to updates from other instances (e.g. requestPermission called elsewhere)
+    // Subscribe to updates from any instance (its own requests included).
     const handleUpdate = (update: LocationUpdate) => {
-      if (update.type === 'position') {
-        setState({ position: update.coordinates, error: null, loading: false, permissionDenied: false });
-      } else {
-        setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
+      switch (update.type) {
+        case 'position':
+          setState({ position: update.coordinates, error: null, loading: false, permissionDenied: false });
+          break;
+        case 'denied':
+          setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
+          break;
+        case 'pending':
+          // A request started somewhere — reflect loading without dropping a
+          // position we may already have.
+          setState((prev) => ({ ...prev, error: null, loading: true, permissionDenied: false }));
+          break;
+        case 'error':
+          setState({ position: null, error: update.message, loading: false, permissionDenied: false });
+          break;
       }
     };
     locationListeners.add(handleUpdate);
@@ -96,71 +151,46 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
       return;
     }
 
-    const onSuccess = (pos: GeolocationPosition) => {
-      const coordinates = {
-        latitude: pos.coords.latitude,
-        longitude: pos.coords.longitude,
-      };
-      localStorage.setItem(STORAGE_KEYS.position, JSON.stringify(coordinates));
-      localStorage.setItem(STORAGE_KEYS.timestamp, Date.now().toString());
-      localStorage.setItem(STORAGE_KEYS.permission, 'granted');
-      setState({ position: coordinates, error: null, loading: false, permissionDenied: false });
-      notifyListeners({ type: 'position', coordinates });
-    };
-
-    const onError = (err: GeolocationPositionError) => {
-      const isDenied = err.code === err.PERMISSION_DENIED;
-      if (isDenied) {
-        localStorage.setItem(STORAGE_KEYS.permission, 'denied');
-        notifyListeners({ type: 'denied' });
-      }
-      setState({ position: null, error: err.message, loading: false, permissionDenied: isDenied });
-    };
-
-    const options: PositionOptions = {
-      enableHighAccuracy: true,
-      timeout: 10000,
-      maximumAge: CACHE_DURATION,
-    };
-
-    const requestLocation = () =>
-      navigator.geolocation.getCurrentPosition(onSuccess, onError, options);
-
     // Idle state used when we intentionally don't request location (no prompt,
     // no error, not denied) — consumers see position=null and can offer a gesture.
-    // Skip if an explicit request is already in flight so we don't clobber its
-    // loading:true (it will set the final state when the GPS callback returns).
+    // Skip if a request is already in flight (possibly from a sibling instance)
+    // so we don't report positionLoading=false while a prompt/GPS call is pending.
     const setIdle = () => {
-      if (manualRequestRef.current) return;
+      if (requestInFlight) return;
       setState({ position: null, error: null, loading: false, permissionDenied: false });
     };
+
+    // If this instance will actively request on mount, mark in-flight
+    // synchronously (before the async permission check) so sibling instances
+    // mounting alongside us don't idle out before the request actually starts.
+    if (autoRequest) requestInFlight = true;
 
     if ('permissions' in navigator) {
       navigator.permissions.query({ name: 'geolocation' }).then((result) => {
         if (result.state === 'denied') {
-          localStorage.setItem(STORAGE_KEYS.permission, 'denied');
-          setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
+          resolveDenied();
         } else if (result.state === 'granted') {
-          // Already granted in a previous session: reuse it silently. querying
+          // Already granted in a previous session: reuse it silently. Querying
           // permission state never shows a prompt, and getCurrentPosition won't
           // either once granted, so this is safe and non-invasive.
-          requestLocation();
+          runRequest();
         } else {
           // 'prompt': permission undecided. Only ask if the caller explicitly
           // opted in (autoRequest). Otherwise stay idle until a user gesture.
-          if (autoRequest) requestLocation();
+          if (autoRequest) runRequest();
           else setIdle();
         }
       });
     } else {
-      // Fallback for browsers without Permissions API
+      // Fallback for browsers without the Permissions API: we can't read the
+      // real permission state, so we must not silently call getCurrentPosition
+      // (a stale localStorage 'granted' could still trigger a prompt). Only
+      // request when the caller explicitly opted in.
       const stored = localStorage.getItem(STORAGE_KEYS.permission);
       if (stored === 'denied') {
         setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
-      } else if (stored === 'granted') {
-        requestLocation();
       } else if (autoRequest) {
-        requestLocation();
+        runRequest();
       } else {
         setIdle();
       }
@@ -178,31 +208,7 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
       return;
     }
 
-    manualRequestRef.current = true;
-    setState((prev) => ({ ...prev, loading: true }));
-
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        const coordinates = {
-          latitude: pos.coords.latitude,
-          longitude: pos.coords.longitude,
-        };
-        localStorage.setItem(STORAGE_KEYS.position, JSON.stringify(coordinates));
-        localStorage.setItem(STORAGE_KEYS.timestamp, Date.now().toString());
-        localStorage.setItem(STORAGE_KEYS.permission, 'granted');
-        setState({ position: coordinates, error: null, loading: false, permissionDenied: false });
-        notifyListeners({ type: 'position', coordinates });
-      },
-      (err) => {
-        const isDenied = err.code === err.PERMISSION_DENIED;
-        if (isDenied) {
-          localStorage.setItem(STORAGE_KEYS.permission, 'denied');
-          notifyListeners({ type: 'denied' });
-        }
-        setState({ position: null, error: err.message, loading: false, permissionDenied: isDenied });
-      },
-      { enableHighAccuracy: true, timeout: 10000 }
-    );
+    runRequest();
   };
 
   return {

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -41,8 +41,15 @@ const notifyListeners = (update: LocationUpdate) => {
 };
 
 // Shared across all hook instances: true while a browser geolocation request is
-// pending. Lets sibling instances avoid idling out (loading:false) mid-request.
+// pending (or imminent). Lets sibling instances avoid idling out (loading:false)
+// mid-request.
 let requestInFlight = false;
+
+// Shared across all hook instances: true while a getCurrentPosition() call is
+// actually outstanding. Used to dedupe concurrent requests so only one runs at a
+// time — otherwise a slow duplicate's later timeout/error could overwrite a
+// position that another request already obtained.
+let requestDispatched = false;
 
 const getCachedPosition = (): Coordinates | null => {
   const cached = localStorage.getItem(STORAGE_KEYS.position);
@@ -65,6 +72,14 @@ const runRequest = () => {
   requestInFlight = true;
   notifyListeners({ type: 'pending' });
 
+  // Dedupe: if a request is already outstanding (e.g. started by another
+  // useGeolocation instance entering the granted branch), don't fire a second
+  // getCurrentPosition. The single in-flight request broadcasts its outcome to
+  // every instance, so a slow duplicate can't later overwrite a position that
+  // another request already obtained.
+  if (requestDispatched) return;
+  requestDispatched = true;
+
   navigator.geolocation.getCurrentPosition(
     (pos) => {
       const coordinates = {
@@ -74,10 +89,12 @@ const runRequest = () => {
       localStorage.setItem(STORAGE_KEYS.position, JSON.stringify(coordinates));
       localStorage.setItem(STORAGE_KEYS.timestamp, Date.now().toString());
       localStorage.setItem(STORAGE_KEYS.permission, 'granted');
+      requestDispatched = false;
       requestInFlight = false;
       notifyListeners({ type: 'position', coordinates });
     },
     (err) => {
+      requestDispatched = false;
       requestInFlight = false;
       if (err.code === err.PERMISSION_DENIED) {
         resolveDenied();

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -39,7 +39,20 @@ const getCachedPosition = (): Coordinates | null => {
   return JSON.parse(cached);
 };
 
-export const useGeolocation = () => {
+interface UseGeolocationOptions {
+  /**
+   * When true, actively prompts the user for location on mount if permission
+   * hasn't been decided yet ('prompt' state). When false (default), we never
+   * trigger the browser permission prompt automatically — we only reuse a
+   * previously granted permission silently. The actual prompt is then deferred
+   * to an explicit user gesture via `requestPermission()` (e.g. the "Cerca"
+   * pill in search). This avoids the invasive "ask on first load" pattern.
+   */
+  autoRequest?: boolean;
+}
+
+export const useGeolocation = (options: UseGeolocationOptions = {}) => {
+  const { autoRequest = false } = options;
   const [state, setState] = useState<GeolocationState>({
     position: null,
     error: null,
@@ -107,15 +120,26 @@ export const useGeolocation = () => {
     const requestLocation = () =>
       navigator.geolocation.getCurrentPosition(onSuccess, onError, options);
 
+    // Idle state used when we intentionally don't request location (no prompt,
+    // no error, not denied) — consumers see position=null and can offer a gesture.
+    const setIdle = () =>
+      setState({ position: null, error: null, loading: false, permissionDenied: false });
+
     if ('permissions' in navigator) {
       navigator.permissions.query({ name: 'geolocation' }).then((result) => {
         if (result.state === 'denied') {
           localStorage.setItem(STORAGE_KEYS.permission, 'denied');
           setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
-        } else {
-          // 'granted' or 'prompt': always request. The 24h cache above prevents spam —
-          // this code only runs when cache is expired or absent (i.e. first visit or stale).
+        } else if (result.state === 'granted') {
+          // Already granted in a previous session: reuse it silently. querying
+          // permission state never shows a prompt, and getCurrentPosition won't
+          // either once granted, so this is safe and non-invasive.
           requestLocation();
+        } else {
+          // 'prompt': permission undecided. Only ask if the caller explicitly
+          // opted in (autoRequest). Otherwise stay idle until a user gesture.
+          if (autoRequest) requestLocation();
+          else setIdle();
         }
       });
     } else {
@@ -123,11 +147,15 @@ export const useGeolocation = () => {
       const stored = localStorage.getItem(STORAGE_KEYS.permission);
       if (stored === 'denied') {
         setState({ position: null, error: 'Permission denied', loading: false, permissionDenied: true });
-      } else {
+      } else if (stored === 'granted') {
         requestLocation();
+      } else if (autoRequest) {
+        requestLocation();
+      } else {
+        setIdle();
       }
     }
-  }, []);
+  }, [autoRequest]);
 
   const requestPermission = () => {
     setState((prev) => ({ ...prev, loading: true }));

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 interface Coordinates {
   latitude: number;
@@ -59,6 +59,12 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
     loading: true,
     permissionDenied: false,
   });
+
+  // Tracks an in-flight explicit request (requestPermission). The mount effect's
+  // async permissions.query() can resolve *after* such a request started; without
+  // this guard its 'prompt' branch would call setIdle() and clobber the in-flight
+  // request's loading:true, making consumers treat geolocation as settled.
+  const manualRequestRef = useRef(false);
 
   useEffect(() => {
     // Subscribe to updates from other instances (e.g. requestPermission called elsewhere)
@@ -122,8 +128,12 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
 
     // Idle state used when we intentionally don't request location (no prompt,
     // no error, not denied) — consumers see position=null and can offer a gesture.
-    const setIdle = () =>
+    // Skip if an explicit request is already in flight so we don't clobber its
+    // loading:true (it will set the final state when the GPS callback returns).
+    const setIdle = () => {
+      if (manualRequestRef.current) return;
       setState({ position: null, error: null, loading: false, permissionDenied: false });
+    };
 
     if ('permissions' in navigator) {
       navigator.permissions.query({ name: 'geolocation' }).then((result) => {
@@ -158,6 +168,17 @@ export const useGeolocation = (options: UseGeolocationOptions = {}) => {
   }, [autoRequest]);
 
   const requestPermission = () => {
+    if (!navigator.geolocation) {
+      setState({
+        position: null,
+        error: 'Geolocation is not supported by your browser',
+        loading: false,
+        permissionDenied: false,
+      });
+      return;
+    }
+
+    manualRequestRef.current = true;
     setState((prev) => ({ ...prev, loading: true }));
 
     navigator.geolocation.getCurrentPosition(

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -93,7 +93,10 @@ function MapPage() {
   const { isDesktop } = useResponsive();
   const focusBusinessId = searchParams.get('business');
 
-  const { position } = useGeolocation();
+  // The map is centered on the user's location, so entering it is a clear
+  // intent — prompt for permission here (unlike Home/Search/Detail, which only
+  // reuse a previously granted permission).
+  const { position } = useGeolocation({ autoRequest: true });
 
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -338,13 +338,16 @@ function SearchPage() {
   const [cardMode, setCardMode] = useState<'credit' | 'debit' | undefined>((searchParams.get('card') || undefined) as 'credit' | 'debit' | undefined);
   const [network] = useState<string | undefined>(searchParams.get('network') || undefined);
   const [hasInstallments, setHasInstallments] = useState<boolean | undefined>(searchParams.get('installments') === '1' ? true : undefined);
-  const [sortByDistance, setSortByDistance] = useState(() => {
-    if (searchParams.get('nearby') === '1') return true;
-    if (!searchParams.has('nearby')) {
-      return localStorage.getItem('locationPermission') === 'granted';
-    }
-    return false;
-  });
+  // Proximity sort is enabled only via explicit intent: a `nearby=1` deeplink
+  // (e.g. the "Cerca tuyo" pill on Home) or tapping the "Cerca" pill here. We do
+  // NOT derive it from a stored `locationPermission=granted` flag — that flag can
+  // be stale (browser reset to 'prompt'), which would leave the pill active
+  // without a usable position and make the first tap turn it off instead of
+  // requesting location. Returning granted users still get geohash-based
+  // proximity ordering silently, and a tap upgrades to exact distance sort.
+  const [sortByDistance, setSortByDistance] = useState(
+    () => searchParams.get('nearby') === '1',
+  );
 
   const { data: availableBankNames = [] } = useQuery({
     queryKey: ['availableBanks'],

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -925,6 +925,9 @@ function SearchPage() {
     setOnlineOnly(values.onlineOnly);
     setHasInstallments(values.hasInstallments);
     setSortByDistance(values.sortByDistance);
+    // Enabling proximity from the full filter sheet is an explicit gesture too:
+    // request location if it's newly turned on and we don't have a position yet.
+    if (values.sortByDistance && !sortByDistance && !position) requestPermission();
     setShowFilters(false);
   };
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -387,20 +387,15 @@ function SearchPage() {
     window.localStorage.setItem(BANK_STORAGE_KEY, JSON.stringify(selectedBanks));
   }, [selectedBanks]);
 
-  const { position, requestPermission } = useGeolocation();
-
-  // Honor an explicit proximity intent that arrives before we have a position:
-  // either a `nearby=1` deeplink (e.g. the "Cerca tuyo" pill on Home) or a
-  // previously granted permission whose location hasn't resolved yet. Fires
-  // once; for already-granted users this never shows a prompt.
-  const proximityRequested = useRef(false);
-  useEffect(() => {
-    if (proximityRequested.current) return;
-    if (sortByDistance && !position) {
-      proximityRequested.current = true;
-      requestPermission();
-    }
-  }, [sortByDistance, position, requestPermission]);
+  // A `nearby=1` deeplink (e.g. the "Cerca tuyo" pill on Home) is an explicit
+  // proximity intent, so we let the hook prompt for permission on mount. We
+  // capture it once: later URL syncs (toggling the pill writes nearby=1) must
+  // not flip this on and re-trigger the request. Note this is intentionally NOT
+  // derived from a stale `locationPermission=granted` in localStorage — that
+  // would re-introduce an unprompted request on load; truly-granted permission
+  // is reused silently by the hook instead.
+  const [nearbyDeeplink] = useState(() => searchParams.get('nearby') === '1');
+  const { position, requestPermission } = useGeolocation({ autoRequest: nearbyDeeplink });
 
   const {
     businesses,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -67,7 +67,7 @@ interface DesktopSearchFiltersProps {
   hasInstallments: boolean | undefined;
   sortByDistance: boolean;
   activeFilterCount: number;
-  permissionDenied: boolean;
+  hasPosition: boolean;
   onBanksChange: (tokens: string[]) => void;
   onCategoryChange: (category: string) => void;
   onMinDiscountChange: (value: number | undefined) => void;
@@ -91,7 +91,7 @@ function DesktopSearchFilters({
   hasInstallments,
   sortByDistance,
   activeFilterCount,
-  permissionDenied,
+  hasPosition,
   onBanksChange,
   onCategoryChange,
   onMinDiscountChange,
@@ -112,8 +112,11 @@ function DesktopSearchFilters({
   };
 
   const handleDistanceToggle = () => {
-    if (permissionDenied) onRequestPermission();
-    onSortByDistanceChange(!sortByDistance);
+    const next = !sortByDistance;
+    onSortByDistanceChange(next);
+    // Request location only on this explicit gesture, and only if we don't
+    // already have a position.
+    if (next && !hasPosition) onRequestPermission();
   };
 
   const Toggle = ({
@@ -384,7 +387,20 @@ function SearchPage() {
     window.localStorage.setItem(BANK_STORAGE_KEY, JSON.stringify(selectedBanks));
   }, [selectedBanks]);
 
-  const { position, permissionDenied, requestPermission } = useGeolocation();
+  const { position, requestPermission } = useGeolocation();
+
+  // Honor an explicit proximity intent that arrives before we have a position:
+  // either a `nearby=1` deeplink (e.g. the "Cerca tuyo" pill on Home) or a
+  // previously granted permission whose location hasn't resolved yet. Fires
+  // once; for already-granted users this never shows a prompt.
+  const proximityRequested = useRef(false);
+  useEffect(() => {
+    if (proximityRequested.current) return;
+    if (sortByDistance && !position) {
+      proximityRequested.current = true;
+      requestPermission();
+    }
+  }, [sortByDistance, position, requestPermission]);
 
   const {
     businesses,
@@ -1063,12 +1079,11 @@ function SearchPage() {
                 <button
                   key="proximity"
                   onClick={() => {
-                    if (permissionDenied) {
-                      requestPermission();
-                      setSortByDistance(true);
-                    } else {
-                      setSortByDistance(!sortByDistance);
-                    }
+                    const next = !sortByDistance;
+                    setSortByDistance(next);
+                    // Request location only now, on this explicit gesture, and
+                    // only if we don't already have a position.
+                    if (next && !position) requestPermission();
                   }}
                   className={`flex items-center h-9 gap-1.5 px-3 rounded-xl text-sm font-medium transition-all duration-150 active:scale-95 ${
                     sortByDistance
@@ -1203,7 +1218,7 @@ function SearchPage() {
           hasInstallments={hasInstallments}
           sortByDistance={sortByDistance}
           activeFilterCount={activeFilterCount}
-          permissionDenied={permissionDenied}
+          hasPosition={position !== null}
           onBanksChange={setSelectedBanks}
           onCategoryChange={setSelectedCategory}
           onMinDiscountChange={setMinDiscount}


### PR DESCRIPTION
Antes useGeolocation disparaba el prompt de permisos al montarse en
cualquier página (Home, Search, Map, Detalle), pidiendo la ubicación
apenas el usuario entraba a la app.

Ahora:
- useGeolocation no dispara el prompt por defecto: solo reutiliza en
  silencio un permiso ya concedido en una sesión anterior.
- Nueva opción autoRequest para optar explícitamente por pedirlo.
- Search: el prompt aparece al apretar la pill 'Cerca' (mobile y
  desktop) y al llegar via deeplink nearby=1 (pill 'Cerca tuyo' del home).
- Map: pide el permiso al entrar, ya que centrar el mapa en la posición
  del usuario es una intención clara.
- Home y Detalle: solo usan la ubicación si ya fue concedida antes.