### PR TITLE
[codex] fix PostHog session splitting

### DIFF
--- a/src/analytics/__tests__/posthogAnalytics.test.ts
+++ b/src/analytics/__tests__/posthogAnalytics.test.ts
@@ -103,6 +103,10 @@ describe('posthogAnalytics', () => {
     expect(posthogMock.identify).toHaveBeenCalledTimes(1);
     expect(posthogMock.identify).toHaveBeenCalledWith('auth0|user-1');
     expect(posthogMock.identify.mock.calls[0]).toHaveLength(1);
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      'blink.analytics.posthog.identified_user_id',
+      'auth0|user-1',
+    );
   });
 
   it('resets before identifying a different user in the same session', async () => {
@@ -119,13 +123,46 @@ describe('posthogAnalytics', () => {
     );
   });
 
-  it('resets persisted identity even when no user was identified in this JS session', async () => {
+  it('does not reset anonymous visitors', async () => {
+    const { resetPostHogUser } = await import('../posthogAnalytics');
+
+    resetPostHogUser();
+
+    expect(posthogMock.reset).not.toHaveBeenCalled();
+  });
+
+  it('resets known identified state once', async () => {
+    const { identifyPostHogUser, resetPostHogUser } = await import('../posthogAnalytics');
+
+    identifyPostHogUser('auth0|user-1');
+    posthogMock.reset.mockClear();
+
+    resetPostHogUser();
+    resetPostHogUser();
+
+    expect(posthogMock.reset).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith(
+      'blink.analytics.posthog.identified_user_id',
+    );
+  });
+
+  it('resets persisted identified state even when no user was identified in this JS session', async () => {
+    const storageKey = 'blink.analytics.posthog.identified_user_id';
+    let storedUserId: string | null = 'auth0|stored-user';
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) => (
+      key === storageKey ? storedUserId : null
+    ));
+    vi.mocked(window.localStorage.removeItem).mockImplementation((key) => {
+      if (key === storageKey) {
+        storedUserId = null;
+      }
+    });
     const { resetPostHogUser } = await import('../posthogAnalytics');
 
     resetPostHogUser();
     resetPostHogUser();
 
-    expect(posthogMock.reset).toHaveBeenCalledTimes(2);
+    expect(posthogMock.reset).toHaveBeenCalledTimes(1);
   });
 
   it('falls back for feature flags when PostHog is disabled', async () => {

--- a/src/analytics/posthogAnalytics.ts
+++ b/src/analytics/posthogAnalytics.ts
@@ -5,10 +5,43 @@ type AnalyticsProperties = Record<string, AnalyticsParamValue>;
 
 const POSTHOG_PROJECT_TOKEN = (import.meta.env.VITE_POSTHOG_PROJECT_TOKEN ?? '').trim();
 const POSTHOG_HOST = (import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com').trim() || 'https://us.i.posthog.com';
+const POSTHOG_IDENTIFIED_USER_STORAGE_KEY = 'blink.analytics.posthog.identified_user_id';
 
 let isInitialized = false;
 let isUnavailable = false;
 let identifiedUserId: string | null = null;
+
+function getStoredIdentifiedUserId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(POSTHOG_IDENTIFIED_USER_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function storeIdentifiedUserId(userId: string): void {
+  try {
+    window.localStorage.setItem(POSTHOG_IDENTIFIED_USER_STORAGE_KEY, userId);
+  } catch {
+    // Analytics persistence should not affect product flows.
+  }
+}
+
+function clearStoredIdentifiedUserId(): void {
+  try {
+    window.localStorage.removeItem(POSTHOG_IDENTIFIED_USER_STORAGE_KEY);
+  } catch {
+    // Analytics persistence should not affect product flows.
+  }
+}
+
+function getKnownIdentifiedUserId(): string | null {
+  return identifiedUserId ?? getStoredIdentifiedUserId();
+}
 
 export function isPostHogConfigured(): boolean {
   return POSTHOG_PROJECT_TOKEN.length > 0;
@@ -77,22 +110,31 @@ export function identifyPostHogUser(userId: string | undefined): void {
   }
 
   try {
-    if (identifiedUserId && identifiedUserId !== normalizedUserId) {
+    const knownIdentifiedUserId = getKnownIdentifiedUserId();
+
+    if (knownIdentifiedUserId && knownIdentifiedUserId !== normalizedUserId) {
       client.reset();
       identifiedUserId = null;
+      clearStoredIdentifiedUserId();
     }
 
     client.identify(normalizedUserId);
     identifiedUserId = normalizedUserId;
+    storeIdentifiedUserId(normalizedUserId);
   } catch {
     // Analytics must never break auth flows.
   }
 }
 
 export function resetPostHogUser(): void {
+  if (!getKnownIdentifiedUserId()) {
+    return;
+  }
+
   const client = initializePostHog();
   if (!client) {
     identifiedUserId = null;
+    clearStoredIdentifiedUserId();
     return;
   }
 
@@ -102,6 +144,7 @@ export function resetPostHogUser(): void {
     // Analytics must never break logout flows.
   } finally {
     identifiedUserId = null;
+    clearStoredIdentifiedUserId();
   }
 }
 

--- a/src/components/analytics/AnalyticsTracker.tsx
+++ b/src/components/analytics/AnalyticsTracker.tsx
@@ -8,7 +8,6 @@ import {
 import {
   identifyPostHogUser,
   initializePostHog,
-  resetPostHogUser,
 } from '../../analytics/posthogAnalytics';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -30,10 +29,7 @@ function AnalyticsTracker() {
 
     if (isAuthenticated && user?.id) {
       identifyPostHogUser(user.id);
-      return;
     }
-
-    resetPostHogUser();
   }, [isAuthenticated, isLoading, user?.id]);
 
   useEffect(() => {

--- a/src/components/analytics/__tests__/AnalyticsTracker.test.tsx
+++ b/src/components/analytics/__tests__/AnalyticsTracker.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AnalyticsTracker from '../AnalyticsTracker';
+
+const authState = vi.hoisted(() => ({
+  current: {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null as { id: string } | null,
+  },
+}));
+
+const googleAnalyticsMock = vi.hoisted(() => ({
+  initializeGoogleAnalytics: vi.fn(),
+  setupGlobalEventTracking: vi.fn(() => vi.fn()),
+  trackPageView: vi.fn(),
+}));
+
+const posthogAnalyticsMock = vi.hoisted(() => ({
+  identifyPostHogUser: vi.fn(),
+  initializePostHog: vi.fn(),
+  resetPostHogUser: vi.fn(),
+}));
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => authState.current,
+}));
+
+vi.mock('../../../analytics/googleAnalytics', () => googleAnalyticsMock);
+
+vi.mock('../../../analytics/posthogAnalytics', () => posthogAnalyticsMock);
+
+function renderTracker() {
+  return render(
+    <MemoryRouter>
+      <AnalyticsTracker />
+    </MemoryRouter>,
+  );
+}
+
+describe('AnalyticsTracker', () => {
+  beforeEach(() => {
+    authState.current = {
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+    };
+    vi.clearAllMocks();
+    googleAnalyticsMock.setupGlobalEventTracking.mockReturnValue(vi.fn());
+  });
+
+  it('does not rotate PostHog identity for an anonymous visitor after auth resolves', () => {
+    renderTracker();
+
+    expect(posthogAnalyticsMock.resetPostHogUser).not.toHaveBeenCalled();
+    expect(posthogAnalyticsMock.identifyPostHogUser).not.toHaveBeenCalled();
+  });
+
+  it('identifies authenticated users', () => {
+    authState.current = {
+      isAuthenticated: true,
+      isLoading: false,
+      user: { id: 'auth0|user-1' },
+    };
+
+    renderTracker();
+
+    expect(posthogAnalyticsMock.identifyPostHogUser).toHaveBeenCalledWith('auth0|user-1');
+  });
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useCallback, useState, useEffect, type ReactNode } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import { resetPostHogUser } from '../analytics/posthogAnalytics';
 
 interface AuthUser {
   id: string;
@@ -118,6 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     setOtpUser(null);
+    resetPostHogUser();
     if (sdkAuth) {
       auth0Logout({ logoutParams: { returnTo: LOGOUT_URL } });
     }


### PR DESCRIPTION
## Summary

Fixes PostHog session fragmentation caused by treating an unauthenticated auth state as a logout.

## Root cause

`AnalyticsTracker` called `resetPostHogUser()` whenever auth resolved as unauthenticated. PostHog `reset()` rotates the anonymous `distinct_id` and session, so anonymous visits could be split into adjacent sessions for the same URL.

## Changes

- Stop resetting PostHog from the anonymous auth state in `AnalyticsTracker`.
- Guard `resetPostHogUser()` so it only resets known identified users.
- Reset PostHog from the explicit logout path.
- Add regression coverage for anonymous auth resolution and identified-user resets.

## Validation

- `pnpm vitest --run src/analytics/__tests__/posthogAnalytics.test.ts src/components/analytics/__tests__/AnalyticsTracker.test.tsx`
- `pnpm test -- --runInBand`
- `pnpm build`
- Push hook also ran `pnpm build` and `pnpm test` successfully.