### PR TITLE
[codex] Add crawlable core SEO pages

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -13,6 +13,7 @@ import {
   tokenizeSearchText
 } from './search/normalize.js';
 import {
+  FALLBACK_CORE_SEO_SUMMARY,
   renderCoreSeoHtml
 } from './core-seo.js';
 import {
@@ -2089,56 +2090,65 @@ async function handleGetStats(req, res, url, db) {
 }
 
 async function loadCoreSeoSummary(db) {
-  const merchantCollection = db.collection(MERCHANT_ASSETS_COLLECTION);
-  const benefitsCollection = db.collection(DEFAULT_COLLECTION);
-  const activeBenefitMatch = getActiveBenefitsMatch(new URLSearchParams()) || {};
-  const indexableMerchantQuery = {
-    isActive: { $ne: false },
-    merchantId: { $exists: true, $type: 'string' },
-    benefitCount: { $gt: 0 }
-  };
-  const activeMerchantQuery = {
-    ...indexableMerchantQuery,
-    activeBenefitCount: { $gt: 0 }
-  };
+  if (!db) {
+    return FALLBACK_CORE_SEO_SUMMARY;
+  }
 
-  const [
-    totalBenefits,
-    merchantCount,
-    activeMerchantCount,
-    topCategories,
-    topBanks
-  ] = await Promise.all([
-    benefitsCollection.countDocuments(activeBenefitMatch),
-    merchantCollection.countDocuments(indexableMerchantQuery),
-    merchantCollection.countDocuments(activeMerchantQuery),
-    merchantCollection
-      .aggregate([
-        { $match: activeMerchantQuery },
-        { $unwind: '$categories' },
-        { $group: { _id: '$categories', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-        { $limit: 6 }
-      ])
-      .toArray(),
-    merchantCollection
-      .aggregate([
-        { $match: activeMerchantQuery },
-        { $unwind: '$banks' },
-        { $group: { _id: '$banks', count: { $sum: 1 } } },
-        { $sort: { count: -1 } },
-        { $limit: 6 }
-      ])
-      .toArray()
-  ]);
+  try {
+    const merchantCollection = db.collection(MERCHANT_ASSETS_COLLECTION);
+    const benefitsCollection = db.collection(DEFAULT_COLLECTION);
+    const activeBenefitMatch = getActiveBenefitsMatch(new URLSearchParams()) || {};
+    const indexableMerchantQuery = {
+      isActive: { $ne: false },
+      merchantId: { $exists: true, $type: 'string' },
+      benefitCount: { $gt: 0 }
+    };
+    const activeMerchantQuery = {
+      ...indexableMerchantQuery,
+      activeBenefitCount: { $gt: 0 }
+    };
 
-  return {
-    totalBenefits,
-    merchantCount,
-    activeMerchantCount,
-    topCategories,
-    topBanks
-  };
+    const [
+      totalBenefits,
+      merchantCount,
+      activeMerchantCount,
+      topCategories,
+      topBanks
+    ] = await Promise.all([
+      benefitsCollection.countDocuments(activeBenefitMatch),
+      merchantCollection.countDocuments(indexableMerchantQuery),
+      merchantCollection.countDocuments(activeMerchantQuery),
+      merchantCollection
+        .aggregate([
+          { $match: activeMerchantQuery },
+          { $unwind: '$categories' },
+          { $group: { _id: '$categories', count: { $sum: 1 } } },
+          { $sort: { count: -1 } },
+          { $limit: 6 }
+        ])
+        .toArray(),
+      merchantCollection
+        .aggregate([
+          { $match: activeMerchantQuery },
+          { $unwind: '$banks' },
+          { $group: { _id: '$banks', count: { $sum: 1 } } },
+          { $sort: { count: -1 } },
+          { $limit: 6 }
+        ])
+        .toArray()
+    ]);
+
+    return {
+      totalBenefits,
+      merchantCount,
+      activeMerchantCount,
+      topCategories,
+      topBanks
+    };
+  } catch (error) {
+    console.warn('[Vercel API] Core SEO summary unavailable, rendering fallback shell:', error);
+    return FALLBACK_CORE_SEO_SUMMARY;
+  }
 }
 
 async function handleHomeSeoPage(req, res, url, db, options = {}) {
@@ -2922,6 +2932,21 @@ export default async function handler(req, res) {
   const path = resolveRequestPath(url);
 
   try {
+    if (isReadMethod(req) && (path === '/api/__page/home' || path === '/api/__page/search')) {
+      let coreSeoDb = null;
+      try {
+        coreSeoDb = await getDb();
+      } catch (error) {
+        console.warn('[Vercel API] Core SEO database unavailable, rendering fallback shell:', error);
+      }
+
+      if (path === '/api/__page/home') {
+        return await handleHomeSeoPage(req, res, url, coreSeoDb);
+      }
+
+      return await handleSearchSeoPage(req, res, url, coreSeoDb);
+    }
+
     const db = await getDb();
 
     if (req.method === 'GET' && path === '/api/benefits') {
@@ -2937,14 +2962,6 @@ export default async function handler(req, res) {
     }
 
     if (isReadMethod(req)) {
-      if (path === '/api/__page/home') {
-        return await handleHomeSeoPage(req, res, url, db);
-      }
-
-      if (path === '/api/__page/search') {
-        return await handleSearchSeoPage(req, res, url, db);
-      }
-
       const categorySeoMatch = path.match(/^\/api\/categorias\/([^/]+)(?:\/page\/([^/]+))?$/);
       if (categorySeoMatch) {
         return await handleCategorySeoPage(

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -13,6 +13,9 @@ import {
   tokenizeSearchText
 } from './search/normalize.js';
 import {
+  renderCoreSeoHtml
+} from './core-seo.js';
+import {
   getMerchantSeoPathFromMerchant,
   parseMerchantSeoSlugId,
   readViteAppShell,
@@ -2085,6 +2088,89 @@ async function handleGetStats(req, res, url, db) {
   });
 }
 
+async function loadCoreSeoSummary(db) {
+  const merchantCollection = db.collection(MERCHANT_ASSETS_COLLECTION);
+  const benefitsCollection = db.collection(DEFAULT_COLLECTION);
+  const activeBenefitMatch = getActiveBenefitsMatch(new URLSearchParams()) || {};
+  const indexableMerchantQuery = {
+    isActive: { $ne: false },
+    merchantId: { $exists: true, $type: 'string' },
+    benefitCount: { $gt: 0 }
+  };
+  const activeMerchantQuery = {
+    ...indexableMerchantQuery,
+    activeBenefitCount: { $gt: 0 }
+  };
+
+  const [
+    totalBenefits,
+    merchantCount,
+    activeMerchantCount,
+    topCategories,
+    topBanks
+  ] = await Promise.all([
+    benefitsCollection.countDocuments(activeBenefitMatch),
+    merchantCollection.countDocuments(indexableMerchantQuery),
+    merchantCollection.countDocuments(activeMerchantQuery),
+    merchantCollection
+      .aggregate([
+        { $match: activeMerchantQuery },
+        { $unwind: '$categories' },
+        { $group: { _id: '$categories', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 6 }
+      ])
+      .toArray(),
+    merchantCollection
+      .aggregate([
+        { $match: activeMerchantQuery },
+        { $unwind: '$banks' },
+        { $group: { _id: '$banks', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 6 }
+      ])
+      .toArray()
+  ]);
+
+  return {
+    totalBenefits,
+    merchantCount,
+    activeMerchantCount,
+    topCategories,
+    topBanks
+  };
+}
+
+async function handleHomeSeoPage(req, res, url, db, options = {}) {
+  const appShell = options.appShell || readViteAppShell();
+  const summary = options.summary || await loadCoreSeoSummary(db);
+  const renderedHtml = renderCoreSeoHtml({
+    appShell,
+    page: 'home',
+    path: '/',
+    siteUrl: options.siteUrl || getCanonicalSiteUrl(url),
+    summary
+  });
+
+  setCacheControl(res, CC_CONTENT);
+  return html(res, 200, renderedHtml);
+}
+
+async function handleSearchSeoPage(req, res, url, db, options = {}) {
+  const appShell = options.appShell || readViteAppShell();
+  const summary = options.summary || await loadCoreSeoSummary(db);
+  const renderedHtml = renderCoreSeoHtml({
+    appShell,
+    page: 'search',
+    path: '/search',
+    siteUrl: options.siteUrl || getCanonicalSiteUrl(url),
+    summary
+  });
+
+  setCacheControl(res, CC_CONTENT);
+  return html(res, 200, renderedHtml);
+}
+
 async function handleGetNearbyBenefits(req, res, url, db) {
   const searchParams = url.searchParams;
   const collectionName = getCollectionName(searchParams);
@@ -2772,10 +2858,12 @@ export {
   handleGetBenefitById,
   handleGetBenefits,
   handleGetBusinesses,
+  handleHomeSeoPage,
   handleCategorySeoPage,
   handleLandingSeoPage,
   handleLegacyBusinessRedirect,
   handleMerchantSeoPage,
+  handleSearchSeoPage,
   handleSearch,
   rehydrateBenefitDoc
 };
@@ -2849,6 +2937,14 @@ export default async function handler(req, res) {
     }
 
     if (isReadMethod(req)) {
+      if (path === '/api/__page/home') {
+        return await handleHomeSeoPage(req, res, url, db);
+      }
+
+      if (path === '/api/__page/search') {
+        return await handleSearchSeoPage(req, res, url, db);
+      }
+
       const categorySeoMatch = path.match(/^\/api\/categorias\/([^/]+)(?:\/page\/([^/]+))?$/);
       if (categorySeoMatch) {
         return await handleCategorySeoPage(
@@ -2961,6 +3057,8 @@ export default async function handler(req, res) {
         'GET /api/descuentos/:bank/:category/:city',
         'GET /api/comercios/:slugId',
         'GET /api/business/:id',
+        'GET /',
+        'GET /search',
         'GET /api/search',
         'GET /api/categories',
         'GET /api/banks',

--- a/api/core-seo.js
+++ b/api/core-seo.js
@@ -20,6 +20,14 @@ const FEATURED_DISCOUNTS = [
   { label: 'ICBC en Belleza', href: '/descuentos/icbc/belleza' },
 ];
 
+export const FALLBACK_CORE_SEO_SUMMARY = {
+  totalBenefits: null,
+  merchantCount: null,
+  activeMerchantCount: null,
+  topCategories: [],
+  topBanks: [],
+};
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replace(/&/g, '&amp;')
@@ -78,9 +86,20 @@ function injectBody(shell, bodyHtml) {
   return `${shell}\n<div id="root">${bodyHtml}</div>`;
 }
 
-function formatCount(value) {
+function hasPositiveCount(value) {
   const numeric = Number(value || 0);
-  if (!Number.isFinite(numeric) || numeric <= 0) return '0';
+  return Number.isFinite(numeric) && numeric > 0;
+}
+
+function formatCount(value, fallback = '0') {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric) || numeric <= 0) return fallback;
+  return Math.round(numeric).toLocaleString('es-AR');
+}
+
+function formatMetric(value, fallback) {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric) || numeric <= 0) return fallback;
   return Math.round(numeric).toLocaleString('es-AR');
 }
 
@@ -94,9 +113,15 @@ function formatNamedCounts(items, fallback) {
 }
 
 function buildDescription(summary) {
-  const benefitCount = formatCount(summary.totalBenefits);
-  const merchantCount = formatCount(summary.activeMerchantCount || summary.merchantCount);
-  return `Blink es un buscador de descuentos bancarios en Argentina con ${benefitCount} beneficios y ${merchantCount} comercios activos. Compara bancos, billeteras, cuotas, dias de vigencia y topes antes de pagar.`;
+  const merchantCountValue = summary.activeMerchantCount || summary.merchantCount;
+  const benefitText = hasPositiveCount(summary.totalBenefits)
+    ? `${formatCount(summary.totalBenefits)} beneficios`
+    : 'beneficios activos';
+  const merchantText = hasPositiveCount(merchantCountValue)
+    ? `${formatCount(merchantCountValue)} comercios activos`
+    : 'comercios activos';
+
+  return `Blink es un buscador de descuentos bancarios en Argentina con ${benefitText} y ${merchantText}. Compara bancos, billeteras, cuotas, dias de vigencia y topes antes de pagar.`;
 }
 
 function buildStructuredData({ absoluteUrl, description, page }) {
@@ -151,8 +176,8 @@ function renderLinkList(links) {
 
 function renderFactList(summary) {
   const facts = [
-    ['Beneficios activos', formatCount(summary.totalBenefits)],
-    ['Comercios activos', formatCount(summary.activeMerchantCount || summary.merchantCount)],
+    ['Beneficios activos', formatMetric(summary.totalBenefits, 'Actualizando')],
+    ['Comercios activos', formatMetric(summary.activeMerchantCount || summary.merchantCount, 'Actualizando')],
     ['Bancos frecuentes', formatNamedCounts(summary.topBanks, 'Galicia, Santander, BBVA, Macro, Nacion e ICBC')],
     ['Categorias frecuentes', formatNamedCounts(summary.topCategories, 'Gastronomia, moda, supermercado, hogar, deportes y belleza')],
   ];
@@ -170,12 +195,17 @@ function renderFactList(summary) {
 }
 
 function renderFaq(summary) {
-  const benefitCount = formatCount(summary.totalBenefits);
-  const merchantCount = formatCount(summary.activeMerchantCount || summary.merchantCount);
+  const merchantCountValue = summary.activeMerchantCount || summary.merchantCount;
+  const benefitText = hasPositiveCount(summary.totalBenefits)
+    ? `${formatCount(summary.totalBenefits)} beneficios`
+    : 'beneficios activos';
+  const merchantText = hasPositiveCount(merchantCountValue)
+    ? `${formatCount(merchantCountValue)} comercios activos`
+    : 'comercios activos';
   const items = [
     {
       question: 'Que es Blink?',
-      answer: `Blink es un buscador argentino de descuentos, cuotas y beneficios de bancos, billeteras, clubes y suscripciones. Reune ${benefitCount} beneficios para comparar antes de pagar.`,
+      answer: `Blink es un buscador argentino de descuentos, cuotas y beneficios de bancos, billeteras, clubes y suscripciones. Reune ${benefitText} para comparar antes de pagar.`,
     },
     {
       question: 'Como se usa Blink para encontrar descuentos?',
@@ -183,7 +213,7 @@ function renderFaq(summary) {
     },
     {
       question: 'Que comercios y bancos cubre Blink?',
-      answer: `Blink publica beneficios de ${merchantCount} comercios activos en Argentina e incluye bancos y billeteras como Galicia, Santander, BBVA, Macro, Nacion, ICBC, NaranjaX, Mercado Pago y MODO.`,
+      answer: `Blink publica beneficios de ${merchantText} en Argentina e incluye bancos y billeteras como Galicia, Santander, BBVA, Macro, Nacion, ICBC, NaranjaX, Mercado Pago y MODO.`,
     },
     {
       question: 'De donde salen los datos de Blink?',

--- a/api/core-seo.js
+++ b/api/core-seo.js
@@ -1,0 +1,310 @@
+const DEFAULT_SITE_NAME = 'Blink';
+const DEFAULT_SITE_URL = 'https://www.blinkapp.com.ar';
+const DEFAULT_OG_IMAGE = '/pwa-512x512.png';
+
+const FEATURED_CATEGORIES = [
+  { label: 'Gastronomia', href: '/categorias/gastronomia' },
+  { label: 'Moda', href: '/categorias/moda' },
+  { label: 'Supermercado', href: '/categorias/supermercado' },
+  { label: 'Hogar', href: '/categorias/hogar' },
+  { label: 'Deportes', href: '/categorias/deportes' },
+  { label: 'Belleza', href: '/categorias/belleza' },
+];
+
+const FEATURED_DISCOUNTS = [
+  { label: 'Galicia en Gastronomia', href: '/descuentos/galicia/gastronomia' },
+  { label: 'Santander en Moda', href: '/descuentos/santander/moda' },
+  { label: 'BBVA en Supermercado', href: '/descuentos/bbva/shopping' },
+  { label: 'Macro en Hogar', href: '/descuentos/macro/hogar' },
+  { label: 'Banco Nacion en Deportes', href: '/descuentos/nacion/deportes' },
+  { label: 'ICBC en Belleza', href: '/descuentos/icbc/belleza' },
+];
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeJsonForHtml(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function toAbsoluteUrl(siteUrl, pathOrUrl) {
+  if (/^https?:\/\//i.test(pathOrUrl)) {
+    return pathOrUrl;
+  }
+
+  const normalizedSiteUrl = String(siteUrl || DEFAULT_SITE_URL).replace(/\/$/, '');
+  const normalizedPath = String(pathOrUrl || '/').startsWith('/') ? pathOrUrl : `/${pathOrUrl}`;
+  return `${normalizedSiteUrl}${normalizedPath}`;
+}
+
+function stripDefaultSeo(shell) {
+  return shell
+    .replace(/<title>[\s\S]*?<\/title>\s*/i, '')
+    .replace(/<meta\s+(name|property)=["'](?:description|robots|keywords|og:[^"']+|twitter:[^"']+)["'][^>]*>\s*/gi, '')
+    .replace(/<link\s+rel=["']canonical["'][^>]*>\s*/gi, '')
+    .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>\s*/gi, '');
+}
+
+function injectHead(shell, headHtml) {
+  const strippedShell = stripDefaultSeo(shell);
+  if (strippedShell.includes('</head>')) {
+    return strippedShell.replace('</head>', `${headHtml}\n  </head>`);
+  }
+
+  return `${headHtml}\n${strippedShell}`;
+}
+
+function injectBody(shell, bodyHtml) {
+  const rootPattern = /<div\s+id=["']root["']\s*><\/div>/i;
+  if (rootPattern.test(shell)) {
+    return shell.replace(rootPattern, `<div id="root">${bodyHtml}</div>`);
+  }
+
+  if (shell.includes('<body>')) {
+    return shell.replace('<body>', `<body>\n<div id="root">${bodyHtml}</div>`);
+  }
+
+  return `${shell}\n<div id="root">${bodyHtml}</div>`;
+}
+
+function formatCount(value) {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '0';
+  return Math.round(numeric).toLocaleString('es-AR');
+}
+
+function formatNamedCounts(items, fallback) {
+  const values = (items || [])
+    .map((item) => String(item?._id || item?.name || '').trim())
+    .filter(Boolean)
+    .slice(0, 5);
+
+  return values.length > 0 ? values.join(', ') : fallback;
+}
+
+function buildDescription(summary) {
+  const benefitCount = formatCount(summary.totalBenefits);
+  const merchantCount = formatCount(summary.activeMerchantCount || summary.merchantCount);
+  return `Blink es un buscador de descuentos bancarios en Argentina con ${benefitCount} beneficios y ${merchantCount} comercios activos. Compara bancos, billeteras, cuotas, dias de vigencia y topes antes de pagar.`;
+}
+
+function buildStructuredData({ absoluteUrl, description, page }) {
+  const searchUrl = new URL('/search?q={search_term_string}', absoluteUrl).toString();
+  const website = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: DEFAULT_SITE_NAME,
+    url: new URL('/', absoluteUrl).toString(),
+    inLanguage: 'es-AR',
+    description,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: searchUrl,
+      'query-input': 'required name=search_term_string',
+    },
+  };
+
+  const organization = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: DEFAULT_SITE_NAME,
+    url: new URL('/', absoluteUrl).toString(),
+    logo: new URL(DEFAULT_OG_IMAGE, absoluteUrl).toString(),
+  };
+
+  if (page === 'search') {
+    return [
+      website,
+      organization,
+      {
+        '@context': 'https://schema.org',
+        '@type': 'SearchResultsPage',
+        name: 'Buscar descuentos y promociones bancarias',
+        url: absoluteUrl,
+        inLanguage: 'es-AR',
+        isPartOf: website,
+      },
+    ];
+  }
+
+  return [organization, website];
+}
+
+function renderLinkList(links) {
+  return [
+    '<ul class="blink-core-links">',
+    ...links.map((link) => `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`),
+    '</ul>',
+  ].join('\n');
+}
+
+function renderFactList(summary) {
+  const facts = [
+    ['Beneficios activos', formatCount(summary.totalBenefits)],
+    ['Comercios activos', formatCount(summary.activeMerchantCount || summary.merchantCount)],
+    ['Bancos frecuentes', formatNamedCounts(summary.topBanks, 'Galicia, Santander, BBVA, Macro, Nacion e ICBC')],
+    ['Categorias frecuentes', formatNamedCounts(summary.topCategories, 'Gastronomia, moda, supermercado, hogar, deportes y belleza')],
+  ];
+
+  return [
+    '<dl class="blink-core-facts">',
+    ...facts.map(([label, value]) => [
+      '<div>',
+      `  <dt>${escapeHtml(label)}</dt>`,
+      `  <dd>${escapeHtml(value)}</dd>`,
+      '</div>',
+    ].join('\n')),
+    '</dl>',
+  ].join('\n');
+}
+
+function renderFaq(summary) {
+  const benefitCount = formatCount(summary.totalBenefits);
+  const merchantCount = formatCount(summary.activeMerchantCount || summary.merchantCount);
+  const items = [
+    {
+      question: 'Que es Blink?',
+      answer: `Blink es un buscador argentino de descuentos, cuotas y beneficios de bancos, billeteras, clubes y suscripciones. Reune ${benefitCount} beneficios para comparar antes de pagar.`,
+    },
+    {
+      question: 'Como se usa Blink para encontrar descuentos?',
+      answer: 'Puedes buscar por comercio, banco, categoria, descuento minimo, cuotas, modalidad online o beneficios cercanos. Cada pagina muestra condiciones, dias de aplicacion y topes cuando estan disponibles.',
+    },
+    {
+      question: 'Que comercios y bancos cubre Blink?',
+      answer: `Blink publica beneficios de ${merchantCount} comercios activos en Argentina e incluye bancos y billeteras como Galicia, Santander, BBVA, Macro, Nacion, ICBC, NaranjaX, Mercado Pago y MODO.`,
+    },
+    {
+      question: 'De donde salen los datos de Blink?',
+      answer: 'Blink organiza informacion publica de beneficios bancarios y comercios adheridos. Las condiciones finales siempre dependen del banco, billetera o programa que emite cada promocion.',
+    },
+  ];
+
+  return [
+    '<section class="blink-core-section blink-core-faq">',
+    '  <h2>Preguntas frecuentes</h2>',
+    ...items.map((item) => [
+      '<article>',
+      `  <h3>${escapeHtml(item.question)}</h3>`,
+      `  <p>${escapeHtml(item.answer)}</p>`,
+      '</article>',
+    ].join('\n')),
+    '</section>',
+  ].join('\n');
+}
+
+function buildBodyHtml({ page, summary, description }) {
+  const isSearch = page === 'search';
+  const h1 = isSearch
+    ? 'Buscar descuentos y promociones bancarias'
+    : 'Descuentos bancarios en Argentina';
+  const intro = isSearch
+    ? 'Usa Blink para encontrar beneficios por comercio, banco, billetera, categoria, cuotas, topes y dias de vigencia.'
+    : description;
+
+  return [
+    '<main class="blink-core-shell" data-blink-core-seo>',
+    '  <section class="blink-core-hero">',
+    `    <p class="blink-core-kicker">${isSearch ? 'Buscador de beneficios' : 'Blink'}</p>`,
+    `    <h1>${escapeHtml(h1)}</h1>`,
+    `    <p>${escapeHtml(intro)}</p>`,
+    '    <form class="blink-core-search" action="/search" method="get" role="search">',
+    '      <label for="blink-core-query">Buscar comercio, banco o beneficio</label>',
+    '      <input id="blink-core-query" name="q" type="search" placeholder="Ej: supermercado Galicia" />',
+    '      <button type="submit">Buscar</button>',
+    '    </form>',
+    renderFactList(summary),
+    '  </section>',
+    '  <section class="blink-core-section">',
+    '    <h2>Categorias principales</h2>',
+    renderLinkList(FEATURED_CATEGORIES),
+    '  </section>',
+    '  <section class="blink-core-section">',
+    '    <h2>Descuentos por banco</h2>',
+    renderLinkList(FEATURED_DISCOUNTS),
+    '  </section>',
+    '  <section class="blink-core-section">',
+    '    <h2>Como evaluamos los beneficios</h2>',
+    '    <p>Para cada comercio, Blink prioriza promociones activas y muestra bancos, tarjetas, cuotas, topes de reintegro, vigencia y ubicaciones disponibles cuando esos datos existen.</p>',
+    '  </section>',
+    renderFaq(summary),
+    '</main>',
+  ].join('\n');
+}
+
+function buildHeadHtml({ title, description, absoluteUrl, structuredData }) {
+  const escapedTitle = escapeHtml(title);
+  const escapedDescription = escapeHtml(description);
+  const escapedUrl = escapeHtml(absoluteUrl);
+  const escapedImage = escapeHtml(toAbsoluteUrl(new URL(absoluteUrl).origin, DEFAULT_OG_IMAGE));
+
+  return [
+    `    <title>${escapedTitle}</title>`,
+    `    <meta name="description" content="${escapedDescription}" />`,
+    '    <meta name="robots" content="index, follow" />',
+    `    <link rel="canonical" href="${escapedUrl}" />`,
+    '    <meta property="og:site_name" content="Blink" />',
+    '    <meta property="og:locale" content="es_AR" />',
+    '    <meta property="og:type" content="website" />',
+    `    <meta property="og:title" content="${escapedTitle}" />`,
+    `    <meta property="og:description" content="${escapedDescription}" />`,
+    `    <meta property="og:url" content="${escapedUrl}" />`,
+    `    <meta property="og:image" content="${escapedImage}" />`,
+    '    <meta name="twitter:card" content="summary_large_image" />',
+    `    <meta name="twitter:title" content="${escapedTitle}" />`,
+    `    <meta name="twitter:description" content="${escapedDescription}" />`,
+    `    <meta name="twitter:image" content="${escapedImage}" />`,
+    `    <script type="application/ld+json" data-blink-core-seo="structured-data" data-blink-seo-url="${escapedUrl}">${escapeJsonForHtml(structuredData)}</script>`,
+    '    <style data-blink-core-seo>',
+    '      .blink-core-shell{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;max-width:1040px;margin:0 auto;padding:32px 20px 56px;color:#111827;background:#fff}',
+    '      .blink-core-kicker{text-transform:uppercase;font-size:12px;letter-spacing:.08em;font-weight:700;color:#4f46e5}.blink-core-hero h1{font-size:42px;line-height:1.05;margin:8px 0 12px}.blink-core-hero p{font-size:18px;line-height:1.55;color:#374151;max-width:760px}',
+    '      .blink-core-search{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;max-width:620px;margin:24px 0}.blink-core-search label{grid-column:1/-1;font-size:14px;font-weight:700;color:#374151}.blink-core-search input{min-height:44px;border:1px solid #d1d5db;border-radius:8px;padding:0 12px;font-size:16px}.blink-core-search button{min-height:44px;border:0;border-radius:8px;background:#4f46e5;color:#fff;font-weight:700;padding:0 18px}',
+    '      .blink-core-facts{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin:22px 0 0;padding:0}.blink-core-facts div,.blink-core-faq article{border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fafafa}.blink-core-facts dt{font-size:12px;text-transform:uppercase;color:#6b7280}.blink-core-facts dd{margin:4px 0 0;font-weight:800}',
+    '      .blink-core-section{margin-top:36px}.blink-core-section h2{font-size:24px;margin:0 0 14px}.blink-core-section p{line-height:1.6;color:#374151}.blink-core-links{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;list-style:none;margin:0;padding:0}.blink-core-links a{display:block;border:1px solid #e5e7eb;border-radius:8px;padding:12px;color:#111827;text-decoration:none;background:#fafafa;font-weight:700}.blink-core-faq{display:grid;gap:12px}.blink-core-faq h2{grid-column:1/-1}.blink-core-faq h3{font-size:18px;margin:0 0 8px}.blink-core-faq p{margin:0}',
+    '      @media (max-width:640px){.blink-core-shell{padding:24px 16px 48px}.blink-core-hero h1{font-size:32px}.blink-core-search{grid-template-columns:1fr}.blink-core-search button{width:100%}}',
+    '    </style>',
+  ].join('\n');
+}
+
+export function renderCoreSeoHtml({
+  appShell,
+  page,
+  path,
+  siteUrl,
+  summary = {},
+}) {
+  const absoluteUrl = toAbsoluteUrl(siteUrl, path);
+  const description = buildDescription(summary);
+  const title = page === 'search'
+    ? `Buscar descuentos y promociones bancarias | ${DEFAULT_SITE_NAME}`
+    : `Descuentos bancarios en Argentina | ${DEFAULT_SITE_NAME}`;
+  const structuredData = buildStructuredData({
+    absoluteUrl,
+    description,
+    page,
+  });
+  const headHtml = buildHeadHtml({
+    title,
+    description,
+    absoluteUrl,
+    structuredData,
+  });
+  const bodyHtml = buildBodyHtml({
+    page,
+    summary,
+    description,
+  });
+
+  return injectBody(injectHead(appShell, headHtml), bodyHtml);
+}

--- a/src/seo/__tests__/seo.test.ts
+++ b/src/seo/__tests__/seo.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { applySEO, toAbsoluteUrl } from '../seo';
 
 function addServerStructuredData(
-  kind: 'merchant' | 'category',
+  kind: 'merchant' | 'category' | 'core',
   url: string | undefined,
   value: unknown
 ): HTMLScriptElement {
@@ -10,8 +10,10 @@ function addServerStructuredData(
   script.type = 'application/ld+json';
   if (kind === 'merchant') {
     script.dataset.blinkMerchantSeo = 'structured-data';
-  } else {
+  } else if (kind === 'category') {
     script.dataset.blinkCategorySeo = 'structured-data';
+  } else {
+    script.dataset.blinkCoreSeo = 'structured-data';
   }
   if (url) {
     script.dataset.blinkSeoUrl = url;
@@ -49,6 +51,30 @@ describe('applySEO structured data handling', () => {
     expect(scripts).toHaveLength(1);
     expect(scripts[0].textContent).toContain('FAQPage');
     expect(scripts[0]).toHaveAttribute('data-blink-merchant-seo', 'structured-data');
+    expect(document.querySelector('script[data-blink-seo="structured-data"]')).toBeNull();
+  });
+
+  it('preserves matching core server-rendered JSON-LD instead of duplicating client schema', () => {
+    addServerStructuredData('core', toAbsoluteUrl('/'), [
+      { '@context': 'https://schema.org', '@type': 'Organization', name: 'Blink' },
+      { '@context': 'https://schema.org', '@type': 'WebSite' },
+    ]);
+
+    applySEO({
+      title: 'Descuentos bancarios en Argentina | Blink',
+      description: 'Client description',
+      path: '/',
+      structuredData: [
+        { '@context': 'https://schema.org', '@type': 'Organization', name: 'Thin client schema' },
+        { '@context': 'https://schema.org', '@type': 'WebSite' },
+      ],
+    });
+
+    const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0]).toHaveAttribute('data-blink-core-seo', 'structured-data');
+    expect(scripts[0].textContent).toContain('Organization');
+    expect(scripts[0].textContent).not.toContain('Thin client schema');
     expect(document.querySelector('script[data-blink-seo="structured-data"]')).toBeNull();
   });
 

--- a/src/seo/seo.ts
+++ b/src/seo/seo.ts
@@ -44,6 +44,7 @@ const SERVER_STRUCTURED_DATA_SELECTOR = [
   'script[type="application/ld+json"][data-blink-category-seo="structured-data"]',
   'script[type="application/ld+json"][data-blink-merchant-seo="structured-data"]',
   'script[type="application/ld+json"][data-blink-landing-seo="structured-data"]',
+  'script[type="application/ld+json"][data-blink-core-seo="structured-data"]',
 ].join(', ');
 
 function getSiteUrl(): string {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -93,6 +93,7 @@ function createAggregateCursor<T>(data: T[]) {
 describe('merchant-first serverless helpers', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it('resolveRequestPath honors Vercel path rewrites for pretty merchant URLs', () => {
@@ -577,6 +578,35 @@ describe('merchant-first serverless helpers', () => {
     expect(benefitQueries).toHaveLength(1);
     expect(merchantQueries).toHaveLength(2);
     expect(merchantAggregatePipelines).toHaveLength(2);
+  });
+
+  it('handleHomeSeoPage falls back to crawlable HTML when summary queries fail', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const db = {
+      collection() {
+        throw new Error('Mongo unavailable');
+      }
+    };
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/?path=__page/home');
+
+    await handleHomeSeoPage(req as never, res as never, url, db as never, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.body).toContain('<h1>Descuentos bancarios en Argentina</h1>');
+    expect(res.body).toContain('beneficios activos y comercios activos');
+    expect(res.body).toContain('<dd>Actualizando</dd>');
+    expect(res.body).toContain('data-blink-core-seo="structured-data"');
+    expect(res.body).toContain('src="/assets/index-test.js"');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Core SEO summary unavailable'),
+      expect.any(Error)
+    );
   });
 
   it('handleSearchSeoPage returns crawlable search overview HTML', async () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -6,9 +6,11 @@ import {
   handleGetBenefitById,
   handleGetBenefits,
   handleGetBusinesses,
+  handleHomeSeoPage,
   handleLegacyBusinessRedirect,
   handleLandingSeoPage,
   handleMerchantSeoPage,
+  handleSearchSeoPage,
   resolveRequestPath,
   rehydrateBenefitDoc
 } from '../../../api/[...path].js';
@@ -100,6 +102,8 @@ describe('merchant-first serverless helpers', () => {
     expect(resolveRequestPath(new URL('https://example.com/categorias/moda/page/2?path=categorias/moda/page/2'))).toBe('/api/categorias/moda/page/2');
     expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia?path=descuentos/galicia/gastronomia'))).toBe('/api/descuentos/galicia/gastronomia');
     expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia/caba?path=descuentos/galicia/gastronomia/caba'))).toBe('/api/descuentos/galicia/gastronomia/caba');
+    expect(resolveRequestPath(new URL('https://example.com/?path=__page/home'))).toBe('/api/__page/home');
+    expect(resolveRequestPath(new URL('https://example.com/search?path=__page/search'))).toBe('/api/__page/search');
   });
 
   it('rehydrateBenefitDoc prefers merchant-owned fields', () => {
@@ -511,6 +515,100 @@ describe('merchant-first serverless helpers', () => {
       error: 'Merchant not found',
       merchantId: 'missing'
     });
+  });
+
+  it('handleHomeSeoPage returns crawlable homepage HTML with counts and JSON-LD', async () => {
+    const merchantQueries: unknown[] = [];
+    const benefitQueries: unknown[] = [];
+    const merchantAggregatePipelines: unknown[] = [];
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments(query: unknown) {
+              merchantQueries.push(query);
+              return merchantQueries.length === 1 ? 20 : 12;
+            },
+            aggregate(pipeline: unknown[]) {
+              merchantAggregatePipelines.push(pipeline);
+              const serialized = JSON.stringify(pipeline);
+              return createAggregateCursor(
+                serialized.includes('$categories')
+                  ? [{ _id: 'gastronomia', count: 8 }, { _id: 'moda', count: 5 }]
+                  : [{ _id: 'Banco Galicia', count: 7 }, { _id: 'BBVA', count: 4 }]
+              );
+            }
+          };
+        }
+
+        if (name === 'confirmed_benefits') {
+          return {
+            async countDocuments(query: unknown) {
+              benefitQueries.push(query);
+              return 150;
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/?path=__page/home');
+
+    await handleHomeSeoPage(req as never, res as never, url, db as never, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.body).toContain('<title>Descuentos bancarios en Argentina | Blink</title>');
+    expect(res.body).toContain('<h1>Descuentos bancarios en Argentina</h1>');
+    expect(res.body).toContain('150 beneficios');
+    expect(res.body).toContain('12 comercios activos');
+    expect(res.body).toContain('data-blink-core-seo="structured-data"');
+    expect(res.body).toContain('SearchAction');
+    expect(res.body).toContain('Organization');
+    expect(res.body).toContain('href="https://www.blinkapp.com.ar/"');
+    expect(res.body).toContain('src="/assets/index-test.js"');
+    expect(benefitQueries).toHaveLength(1);
+    expect(merchantQueries).toHaveLength(2);
+    expect(merchantAggregatePipelines).toHaveLength(2);
+  });
+
+  it('handleSearchSeoPage returns crawlable search overview HTML', async () => {
+    const db = {
+      collection() {
+        throw new Error('Search SEO test uses an injected summary');
+      }
+    };
+    const req = {};
+    const res = createResponseCapture();
+    const url = new URL('https://www.blinkapp.com.ar/search?path=__page/search');
+
+    await handleSearchSeoPage(req as never, res as never, url, db as never, {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar',
+      summary: {
+        totalBenefits: 200,
+        activeMerchantCount: 30,
+        topCategories: [{ _id: 'supermercado', count: 10 }],
+        topBanks: [{ _id: 'Santander', count: 9 }]
+      }
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.body).toContain('<title>Buscar descuentos y promociones bancarias | Blink</title>');
+    expect(res.body).toContain('<h1>Buscar descuentos y promociones bancarias</h1>');
+    expect(res.body).toContain('Usa Blink para encontrar beneficios por comercio');
+    expect(res.body).toContain('SearchResultsPage');
+    expect(res.body).toContain('href="https://www.blinkapp.com.ar/search"');
+    expect(res.body).toContain('href="/categorias/supermercado"');
+    expect(res.body).toContain('src="/assets/index-test.js"');
   });
 
   it('handleMerchantSeoPage returns HTML for a canonical merchant URL', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -62,6 +62,14 @@
       "dest": "/api/[...path]?path=$1"
     },
     {
+      "src": "/",
+      "dest": "/api/[...path]?path=__page/home"
+    },
+    {
+      "src": "/search",
+      "dest": "/api/[...path]?path=__page/search"
+    },
+    {
       "src": "/business/([^/]+)",
       "dest": "/api/[...path]?path=business/$1"
     },


### PR DESCRIPTION
## What changed

- Routes `/` and `/search` through the serverless SEO handler instead of serving only the Vite app shell.
- Adds crawler-readable homepage/search overview HTML with definition copy, counts, featured category/bank links, methodology copy, FAQ content, and JSON-LD.
- Preserves the client app script in the rendered shell so React still takes over for users.

## Why

The AI SEO audit found that the homepage and `/search` returned only app-shell HTML to non-JS fetchers. That left AI crawlers with no visible `<h1>`, body copy, or structured data for broad Blink/category queries.

## Validation

- `pnpm vitest run src/services/__tests__/merchantFirstServerless.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm exec eslint 'api/[...path].js' api/core-seo.js src/services/__tests__/merchantFirstServerless.test.ts`

Note: `pnpm lint` still fails on existing unrelated `no-explicit-any` issues across mobile/services/test files that were present outside this PR scope.