### PR TITLE
[codex] Serve noindex app shell for private routes

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -136,6 +136,14 @@ const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || process.env.VITE_
 const AUTH0_DOMAIN = (process.env.AUTH0_DOMAIN || process.env.VITE_AUTH0_DOMAIN || '').replace(/\/$/, '');
 
 const USER_DATA_COLLECTION = 'user_data';
+const NOINDEX_APP_ROUTES = new Set([
+  '/profile',
+  '/saved',
+  '/login',
+  '/signup',
+  '/notifications',
+  '/auth/callback'
+]);
 
 const globalState = globalThis;
 if (!globalState.__blinkMongo) {
@@ -313,6 +321,15 @@ function html(res, statusCode, payload) {
   res.send(payload);
 }
 
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Cache-Control directives
 const CC_METADATA = 's-maxage=43200, stale-while-revalidate=86400, max-age=3600';  // 12h CDN, 1h browser
 const CC_CONTENT  = 's-maxage=3600, stale-while-revalidate=7200, max-age=300';     // 1h CDN, 5m browser
@@ -332,8 +349,52 @@ function getCanonicalSiteUrl(url) {
   );
 }
 
+function toAbsoluteSiteUrl(siteUrl, pathOrUrl) {
+  if (/^https?:\/\//i.test(pathOrUrl)) {
+    return pathOrUrl;
+  }
+
+  const normalizedSiteUrl = String(siteUrl || 'https://www.blinkapp.com.ar').replace(/\/$/, '');
+  const normalizedPath = String(pathOrUrl || '/').startsWith('/') ? pathOrUrl : `/${pathOrUrl}`;
+  return `${normalizedSiteUrl}${normalizedPath}`;
+}
+
 function isReadMethod(req) {
   return req.method === 'GET' || req.method === 'HEAD';
+}
+
+function normalizeNoindexAppPath(pathname) {
+  const normalized = `/${String(pathname || '')
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .join('/')}`.replace(/\/+$/, '') || '/';
+
+  return NOINDEX_APP_ROUTES.has(normalized) ? normalized : null;
+}
+
+function stripDefaultSeo(shell) {
+  return shell
+    .replace(/<title>[\s\S]*?<\/title>\s*/i, '')
+    .replace(/<meta\s+(name|property)=["'](?:description|robots|keywords|og:[^"']+|twitter:[^"']+)["'][^>]*>\s*/gi, '')
+    .replace(/<link\s+rel=["']canonical["'][^>]*>\s*/gi, '')
+    .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>\s*/gi, '');
+}
+
+function renderNoindexAppHtml({ appShell, path: routePath, siteUrl }) {
+  const absoluteUrl = toAbsoluteSiteUrl(siteUrl, routePath);
+  const headHtml = [
+    '    <title>Blink</title>',
+    '    <meta name="robots" content="noindex, nofollow" />',
+    `    <link rel="canonical" href="${escapeHtml(absoluteUrl)}" />`
+  ].join('\n');
+  const strippedShell = stripDefaultSeo(appShell);
+
+  if (strippedShell.includes('</head>')) {
+    return strippedShell.replace('</head>', `${headHtml}\n  </head>`);
+  }
+
+  return `${headHtml}\n${strippedShell}`;
 }
 
 /**
@@ -2764,6 +2825,28 @@ async function handlePlaceDetails(req, res) {
   });
 }
 
+function handleNoindexAppShell(req, res, url, routePath, options = {}) {
+  const normalizedRoutePath = normalizeNoindexAppPath(routePath);
+  if (!normalizedRoutePath) {
+    return json(res, 404, {
+      success: false,
+      error: 'Noindex app route not found',
+      path: routePath
+    });
+  }
+
+  const appShell = options.appShell || readViteAppShell();
+  const renderedHtml = renderNoindexAppHtml({
+    appShell,
+    path: normalizedRoutePath,
+    siteUrl: options.siteUrl || getCanonicalSiteUrl(url)
+  });
+
+  setCacheControl(res, 'private, no-store');
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  return html(res, 200, renderedHtml);
+}
+
 export {
   applyLocalDistanceGuardrail,
   buildBusinessBenefitSummary,
@@ -2776,6 +2859,7 @@ export {
   handleLandingSeoPage,
   handleLegacyBusinessRedirect,
   handleMerchantSeoPage,
+  handleNoindexAppShell,
   handleSearch,
   rehydrateBenefitDoc
 };
@@ -2834,6 +2918,13 @@ export default async function handler(req, res) {
   const path = resolveRequestPath(url);
 
   try {
+    if (isReadMethod(req)) {
+      const noindexAppMatch = path.match(/^\/api\/__app_noindex\/(.+)$/);
+      if (noindexAppMatch) {
+        return handleNoindexAppShell(req, res, url, noindexAppMatch[1]);
+      }
+    }
+
     const db = await getDb();
 
     if (req.method === 'GET' && path === '/api/benefits') {

--- a/src/components/seo/RouteSEO.tsx
+++ b/src/components/seo/RouteSEO.tsx
@@ -3,6 +3,15 @@ import { useSEO } from '../../hooks/useSEO';
 import { SEOConfig, SITE_NAME, toAbsoluteUrl } from '../../seo/seo';
 import { resolveSeoCategory } from '../../seo/categoryPages';
 
+const NOINDEX_APP_ROUTES = new Set([
+  '/profile',
+  '/saved',
+  '/login',
+  '/signup',
+  '/notifications',
+  '/auth/callback',
+]);
+
 function normalizePathname(pathname: string): string {
   return pathname.replace(/\/+$/, '') || '/';
 }
@@ -111,7 +120,7 @@ function RouteSEO() {
       path: location.pathname,
       type: 'article',
     };
-  } else if (normalizedPathname === '/saved' || normalizedPathname === '/profile') {
+  } else if (NOINDEX_APP_ROUTES.has(normalizedPathname)) {
     seoConfig = {
       title: `${SITE_NAME}`,
       description: baseDescription,

--- a/src/components/seo/__tests__/RouteSEO.test.tsx
+++ b/src/components/seo/__tests__/RouteSEO.test.tsx
@@ -21,14 +21,17 @@ describe('RouteSEO', () => {
     vi.mocked(useSEO).mockClear();
   });
 
-  it.each(['/profile/', '/saved/'])('marks private trailing slash route %s as noindex', (pathname) => {
-    renderRouteSEO(pathname);
+  it.each(['/profile/', '/saved/', '/login/', '/signup/', '/notifications/', '/auth/callback/'])(
+    'marks private trailing slash route %s as noindex',
+    (pathname) => {
+      renderRouteSEO(pathname);
 
-    expect(vi.mocked(useSEO)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: pathname.replace(/\/+$/, ''),
-        robots: 'noindex, nofollow',
-      })
-    );
-  });
+      expect(vi.mocked(useSEO)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: pathname.replace(/\/+$/, ''),
+          robots: 'noindex, nofollow',
+        })
+      );
+    }
+  );
 });

--- a/src/services/__tests__/canonicalSite.test.ts
+++ b/src/services/__tests__/canonicalSite.test.ts
@@ -8,6 +8,21 @@ import {
 } from '../../../api/canonical-site.js';
 import { normalizeBlinkSiteUrl } from '../../seo/seo';
 
+const NOINDEX_APP_ROUTE_SOURCES = [
+  '/profile',
+  '/profile/',
+  '/saved',
+  '/saved/',
+  '/login',
+  '/login/',
+  '/signup',
+  '/signup/',
+  '/notifications',
+  '/notifications/',
+  '/auth/callback',
+  '/auth/callback/',
+];
+
 describe('canonical site URL normalization', () => {
   it('canonicalizes Blink apex URLs to the https www origin', () => {
     expect(normalizeSiteUrl('https://blinkapp.com.ar/categorias/gastronomia')).toBe(
@@ -57,46 +72,46 @@ describe('Vercel host redirect config', () => {
       fs.readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8')
     );
 
-    expect(vercelConfig.headers).toEqual(
+    for (const source of NOINDEX_APP_ROUTE_SOURCES) {
+      expect(vercelConfig.headers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source,
+            headers: expect.arrayContaining([
+              {
+                key: 'X-Robots-Tag',
+                value: 'noindex, nofollow',
+              },
+            ]),
+          }),
+        ])
+      );
+    }
+  });
+
+  it('routes private app pages through the server noindex shell before filesystem fallback', () => {
+    const vercelConfig = JSON.parse(
+      fs.readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8')
+    );
+
+    const filesystemIndex = vercelConfig.routes.findIndex((route: { handle?: string }) => route.handle === 'filesystem');
+    const noindexRoutes = vercelConfig.routes
+      .map((route: { src?: string; dest?: string }, index: number) => ({ ...route, index }))
+      .filter((route: { dest?: string }) => route.dest?.includes('__app_noindex'));
+
+    expect(noindexRoutes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          source: '/profile',
-          headers: expect.arrayContaining([
-            {
-              key: 'X-Robots-Tag',
-              value: 'noindex, nofollow',
-            },
-          ]),
+          src: '/(profile|saved|login|signup|notifications)/?',
+          dest: '/api/[...path]?path=__app_noindex/$1',
         }),
         expect.objectContaining({
-          source: '/profile/',
-          headers: expect.arrayContaining([
-            {
-              key: 'X-Robots-Tag',
-              value: 'noindex, nofollow',
-            },
-          ]),
-        }),
-        expect.objectContaining({
-          source: '/saved',
-          headers: expect.arrayContaining([
-            {
-              key: 'X-Robots-Tag',
-              value: 'noindex, nofollow',
-            },
-          ]),
-        }),
-        expect.objectContaining({
-          source: '/saved/',
-          headers: expect.arrayContaining([
-            {
-              key: 'X-Robots-Tag',
-              value: 'noindex, nofollow',
-            },
-          ]),
+          src: '/auth/callback/?',
+          dest: '/api/[...path]?path=__app_noindex/auth/callback',
         }),
       ])
     );
+    expect(noindexRoutes.every((route: { index: number }) => route.index < filesystemIndex)).toBe(true);
   });
 });
 

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -9,6 +9,7 @@ import {
   handleLegacyBusinessRedirect,
   handleLandingSeoPage,
   handleMerchantSeoPage,
+  handleNoindexAppShell,
   resolveRequestPath,
   rehydrateBenefitDoc
 } from '../../../api/[...path].js';
@@ -100,6 +101,27 @@ describe('merchant-first serverless helpers', () => {
     expect(resolveRequestPath(new URL('https://example.com/categorias/moda/page/2?path=categorias/moda/page/2'))).toBe('/api/categorias/moda/page/2');
     expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia?path=descuentos/galicia/gastronomia'))).toBe('/api/descuentos/galicia/gastronomia');
     expect(resolveRequestPath(new URL('https://example.com/descuentos/galicia/gastronomia/caba?path=descuentos/galicia/gastronomia/caba'))).toBe('/api/descuentos/galicia/gastronomia/caba');
+    expect(resolveRequestPath(new URL('https://example.com/auth/callback?path=__app_noindex/auth/callback'))).toBe('/api/__app_noindex/auth/callback');
+  });
+
+  it('handleNoindexAppShell returns an app shell with server-side noindex controls', () => {
+    const req = { method: 'GET' };
+    const res = createResponseCapture();
+    const url = new URL('https://blinkapp.com.ar/profile?path=__app_noindex/profile');
+
+    handleNoindexAppShell(req as never, res as never, url, 'profile', {
+      appShell: merchantSeoAppShell,
+      siteUrl: 'https://www.blinkapp.com.ar'
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.headers['X-Robots-Tag']).toBe('noindex, nofollow');
+    expect(res.headers['Cache-Control']).toBe('private, no-store');
+    expect(res.body).toContain('<meta name="robots" content="noindex, nofollow" />');
+    expect(res.body).toContain('<link rel="canonical" href="https://www.blinkapp.com.ar/profile" />');
+    expect(res.body).not.toContain('<link rel="canonical" href="/" />');
+    expect(res.body).toContain('<script type="module" src="/assets/index-test.js"></script>');
   });
 
   it('rehydrateBenefitDoc prefers merchant-owned fields', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -54,12 +54,92 @@
           "value": "noindex, nofollow"
         }
       ]
+    },
+    {
+      "source": "/login",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/login/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/signup",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/signup/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/notifications",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/notifications/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/auth/callback",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
+    },
+    {
+      "source": "/auth/callback/",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow"
+        }
+      ]
     }
   ],
   "routes": [
     {
       "src": "/api/(.*)",
       "dest": "/api/[...path]?path=$1"
+    },
+    {
+      "src": "/(profile|saved|login|signup|notifications)/?",
+      "dest": "/api/[...path]?path=__app_noindex/$1"
+    },
+    {
+      "src": "/auth/callback/?",
+      "dest": "/api/[...path]?path=__app_noindex/auth/callback"
     },
     {
       "src": "/business/([^/]+)",


### PR DESCRIPTION
## Summary
- Route `/profile`, `/saved`, `/login`, `/signup`, `/notifications`, and `/auth/callback` through a server-rendered app shell that sends `X-Robots-Tag: noindex, nofollow` and an HTML robots meta tag before React loads.
- Extend Vercel noindex headers and client-side `RouteSEO` noindex handling to the same private/auth route set.
- Add tests for the server noindex shell, rewrite order before filesystem fallback, expanded header coverage, and client SEO metadata.

## Validation
- `pnpm vitest run src/services/__tests__/merchantFirstServerless.test.ts src/services/__tests__/canonicalSite.test.ts src/components/seo/__tests__/RouteSEO.test.tsx`
- `pnpm exec eslint 'api/[...path].js' src/components/seo/RouteSEO.tsx src/components/seo/__tests__/RouteSEO.test.tsx src/services/__tests__/merchantFirstServerless.test.ts src/services/__tests__/canonicalSite.test.ts`
- `pnpm test`
- `pnpm build`
- Pre-push hook: `pnpm build` and `pnpm test` passed