### PR TITLE
[codex] support multi-merchant benefit APIs

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -625,6 +625,65 @@ function hasMeaningfulSingularMerchantField(value, field) {
   return Boolean(toNonEmptyString(fieldValue));
 }
 
+function trimMongoStringExpression(input) {
+  return {
+    $trim: {
+      input: {
+        $convert: {
+          input,
+          to: 'string',
+          onError: '',
+          onNull: ''
+        }
+      }
+    }
+  };
+}
+
+function normalizedMerchantIdsExpression(input = '$merchantIds') {
+  return {
+    $filter: {
+      input: {
+        $cond: [{ $isArray: input }, input, []]
+      },
+      as: 'merchantId',
+      cond: {
+        $ne: [trimMongoStringExpression('$$merchantId'), '']
+      }
+    }
+  };
+}
+
+function meaningfulSingularMerchantFieldExpression(path) {
+  return {
+    $let: {
+      vars: {
+        value: { $ifNull: [path, null] },
+        valueType: { $type: { $ifNull: [path, null] } }
+      },
+      in: {
+        $switch: {
+          branches: [
+            {
+              case: { $eq: ['$$valueType', 'null'] },
+              then: false
+            },
+            {
+              case: { $eq: ['$$valueType', 'object'] },
+              then: { $gt: [{ $size: { $objectToArray: '$$value' } }, 0] }
+            },
+            {
+              case: { $eq: ['$$valueType', 'array'] },
+              then: { $gt: [{ $size: '$$value' }, 0] }
+            }
+          ],
+          default: { $ne: [trimMongoStringExpression('$$value'), ''] }
+        }
+      }
+    }
+  };
+}
+
 function assertValidBenefitMerchantLinkage(benefit) {
   const merchantIds = normalizeBenefitMerchantIds(benefit?.merchantIds);
   if (merchantIds.length <= 1) return;
@@ -663,11 +722,7 @@ function collectEffectiveBenefitMerchantIds(benefits) {
 
 function missingOrEmptyMerchantIdsQuery() {
   return {
-    $or: [
-      { merchantIds: { $exists: false } },
-      { merchantIds: null },
-      { merchantIds: { $size: 0 } }
-    ]
+    $expr: { $eq: [{ $size: normalizedMerchantIdsExpression('$merchantIds') }, 0] }
   };
 }
 
@@ -695,10 +750,11 @@ function buildBenefitMerchantLinkQuery(merchantId) {
 function invalidMultiMerchantBenefitQuery() {
   return {
     'merchantIds.1': { $exists: true },
+    $expr: { $gt: [{ $size: normalizedMerchantIdsExpression('$merchantIds') }, 1] },
     $or: [
-      { merchantId: { $exists: true, $nin: [null, ''] } },
-      { merchant: { $exists: true, $ne: null } },
-      { merchantSnapshot: { $exists: true, $ne: null } }
+      { $expr: meaningfulSingularMerchantFieldExpression('$merchantId') },
+      { $expr: meaningfulSingularMerchantFieldExpression('$merchant') },
+      { $expr: meaningfulSingularMerchantFieldExpression('$merchantSnapshot') }
     ]
   };
 }
@@ -707,18 +763,7 @@ function effectiveMerchantIdsExpression() {
   return {
     $let: {
       vars: {
-        merchantIds: {
-          $filter: {
-            input: { $ifNull: ['$merchantIds', []] },
-            as: 'merchantId',
-            cond: {
-              $and: [
-                { $ne: ['$$merchantId', null] },
-                { $ne: ['$$merchantId', ''] }
-              ]
-            }
-          }
-        },
+        merchantIds: normalizedMerchantIdsExpression('$merchantIds'),
         legacyMerchantId: '$merchantId'
       },
       in: {

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -741,17 +741,10 @@ function buildBenefitMerchantLinkQueryForIds(merchantIds) {
   const ids = Array.from(new Set((merchantIds || []).map((id) => String(id || '').trim()).filter(Boolean)));
   if (ids.length === 0) return { _id: { $exists: false } };
 
+  // Merchant hydration is a hot path; stored merchantIds are normalized before write.
   return {
     $or: [
       { merchantIds: { $in: ids } },
-      {
-        $expr: {
-          $gt: [
-            { $size: { $setIntersection: [normalizedMerchantIdsExpression('$merchantIds'), ids] } },
-            0
-          ]
-        }
-      },
       {
         $and: [
           { merchantId: { $in: ids } },
@@ -815,7 +808,7 @@ async function countBenefitApplications(collection, match = {}) {
     .aggregate([
       ...(Object.keys(match).length > 0 ? [{ $match: match }] : []),
       { $project: { effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-      { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
+      { $unwind: '$effectiveMerchantIds' },
       { $count: 'count' }
     ])
     .toArray();
@@ -2446,7 +2439,7 @@ async function handleGetStats(req, res, url, db) {
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
         { $project: { categories: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-        { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
+        { $unwind: '$effectiveMerchantIds' },
         { $unwind: '$categories' },
         { $group: { _id: '$categories', count: { $sum: 1 } } },
         { $sort: { count: -1 } },
@@ -2457,7 +2450,7 @@ async function handleGetStats(req, res, url, db) {
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
         { $project: { eligibilities: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-        { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
+        { $unwind: '$effectiveMerchantIds' },
         { $unwind: '$eligibilities' },
         { $group: { _id: '$eligibilities.bank', count: { $sum: 1 } } },
         { $sort: { count: -1 } },

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -99,6 +99,7 @@ const BENEFIT_SUMMARY_PROJECTION = {
   _id: 1,
   id: 1,
   merchantId: 1,
+  merchantIds: 1,
   eligibilities: 1,
   benefitTitle: 1,
   availableDays: 1,
@@ -597,13 +598,191 @@ function combineQueriesWithAnd(...conditions) {
   };
 }
 
+function normalizeBenefitMerchantIds(value) {
+  if (!Array.isArray(value)) return [];
+
+  const ids = [];
+  const seen = new Set();
+  for (const entry of value) {
+    const merchantId = typeof entry === 'string' ? entry.trim() : String(entry || '').trim();
+    if (!merchantId || seen.has(merchantId)) continue;
+    seen.add(merchantId);
+    ids.push(merchantId);
+  }
+  return ids;
+}
+
+function hasOwnField(value, field) {
+  return Boolean(value && Object.prototype.hasOwnProperty.call(value, field));
+}
+
+function assertValidBenefitMerchantLinkage(benefit) {
+  const merchantIds = normalizeBenefitMerchantIds(benefit?.merchantIds);
+  if (merchantIds.length <= 1) return;
+
+  const singularFields = ['merchantId', 'merchant', 'merchantSnapshot'].filter((field) => hasOwnField(benefit, field));
+  if (singularFields.length === 0) return;
+
+  const id = benefit?.id || benefit?._id?.toString?.() || '(unknown)';
+  throw new Error(`Confirmed benefit ${id} has multiple merchantIds and singular merchant field(s): ${singularFields.join(', ')}`);
+}
+
+function getEffectiveBenefitMerchantIds(benefit) {
+  assertValidBenefitMerchantLinkage(benefit);
+
+  const merchantIds = normalizeBenefitMerchantIds(benefit?.merchantIds);
+  if (merchantIds.length > 0) return merchantIds;
+
+  const legacyMerchantId = typeof benefit?.merchantId === 'string' ? benefit.merchantId.trim() : '';
+  return legacyMerchantId ? [legacyMerchantId] : [];
+}
+
+function collectEffectiveBenefitMerchantIds(benefits) {
+  const ids = [];
+  const seen = new Set();
+  for (const benefit of benefits || []) {
+    for (const merchantId of getEffectiveBenefitMerchantIds(benefit)) {
+      if (seen.has(merchantId)) continue;
+      seen.add(merchantId);
+      ids.push(merchantId);
+    }
+  }
+  return ids;
+}
+
+function missingOrEmptyMerchantIdsQuery() {
+  return {
+    $or: [
+      { merchantIds: { $exists: false } },
+      { merchantIds: null },
+      { merchantIds: { $size: 0 } }
+    ]
+  };
+}
+
+function buildBenefitMerchantLinkQueryForIds(merchantIds) {
+  const ids = Array.from(new Set((merchantIds || []).map((id) => String(id || '').trim()).filter(Boolean)));
+  if (ids.length === 0) return { _id: { $exists: false } };
+
+  return {
+    $or: [
+      { merchantIds: { $in: ids } },
+      {
+        $and: [
+          { merchantId: { $in: ids } },
+          missingOrEmptyMerchantIdsQuery()
+        ]
+      }
+    ]
+  };
+}
+
+function buildBenefitMerchantLinkQuery(merchantId) {
+  return buildBenefitMerchantLinkQueryForIds([merchantId]);
+}
+
+function invalidMultiMerchantBenefitQuery() {
+  return {
+    'merchantIds.1': { $exists: true },
+    $or: [
+      { merchantId: { $exists: true } },
+      { merchant: { $exists: true } },
+      { merchantSnapshot: { $exists: true } }
+    ]
+  };
+}
+
+function effectiveMerchantIdsExpression() {
+  return {
+    $let: {
+      vars: {
+        merchantIds: {
+          $filter: {
+            input: { $ifNull: ['$merchantIds', []] },
+            as: 'merchantId',
+            cond: {
+              $and: [
+                { $ne: ['$$merchantId', null] },
+                { $ne: ['$$merchantId', ''] }
+              ]
+            }
+          }
+        },
+        legacyMerchantId: '$merchantId'
+      },
+      in: {
+        $cond: [
+          { $gt: [{ $size: '$$merchantIds' }, 0] },
+          { $setUnion: ['$$merchantIds', []] },
+          {
+            $cond: [
+              {
+                $and: [
+                  { $ne: ['$$legacyMerchantId', null] },
+                  { $ne: ['$$legacyMerchantId', ''] }
+                ]
+              },
+              ['$$legacyMerchantId'],
+              []
+            ]
+          }
+        ]
+      }
+    }
+  };
+}
+
+async function assertNoInvalidMultiMerchantBenefits(collection, match = {}) {
+  const query = combineQueriesWithAnd(match, invalidMultiMerchantBenefitQuery());
+  const invalid = await collection.findOne(query, { projection: { _id: 1, id: 1 } });
+  if (!invalid) return;
+
+  throw new Error(`Confirmed benefit ${invalid.id || invalid._id?.toString?.() || '(unknown)'} has multiple merchantIds and singular merchant fields`);
+}
+
+async function countBenefitApplications(collection, match = {}) {
+  const [result] = await collection
+    .aggregate([
+      ...(Object.keys(match).length > 0 ? [{ $match: match }] : []),
+      { $project: { effectiveMerchantIds: effectiveMerchantIdsExpression() } },
+      { $unwind: '$effectiveMerchantIds' },
+      { $count: 'count' }
+    ])
+    .toArray();
+
+  return Number(result?.count || 0);
+}
+
+function groupBenefitSummariesByMerchant(rawBenefits, cardNameLookup, allowedMerchantIds = null) {
+  const allowed = allowedMerchantIds ? new Set(allowedMerchantIds) : null;
+  const grouped = new Map();
+
+  for (const benefit of rawBenefits || []) {
+    const summary = buildBusinessBenefitSummary(benefit, cardNameLookup);
+    for (const merchantId of getEffectiveBenefitMerchantIds(benefit)) {
+      if (allowed && !allowed.has(merchantId)) continue;
+      if (!grouped.has(merchantId)) {
+        grouped.set(merchantId, []);
+      }
+      grouped.get(merchantId).push(summary);
+    }
+  }
+
+  return grouped;
+}
+
 function rehydrateBenefitDoc(benefit, merchant) {
-  if (!merchant) {
-    return serializeDocWithId(benefit);
+  const merchantIds = getEffectiveBenefitMerchantIds(benefit);
+  if (!merchant || merchantIds.length !== 1) {
+    return serializeDocWithId({
+      ...benefit,
+      merchantIds
+    });
   }
 
   return serializeDocWithId({
     ...benefit,
+    merchantIds,
     merchant: {
       name: merchant.merchantName || benefit?.merchant?.name || 'Unknown Merchant'
     },
@@ -763,6 +942,7 @@ function buildBusinessBenefitSummary(benefit, cardNameLookup) {
 
   return {
     id: benefit?.id || benefit?._id?.toString?.() || null,
+    merchantIds: getEffectiveBenefitMerchantIds(benefit),
     eligibilities,
     bankName: providerNames.length > 0 ? providerNames.join(', ') : 'Proveedor',
     cardName: cardNames[0] || 'Tarjeta de credito',
@@ -1454,9 +1634,7 @@ async function hydrateSearchMerchantsWithBenefits(db, collectionName, merchants,
     return merchants || [];
   }
 
-  const benefitQuery = {
-    merchantId: { $in: merchantIds }
-  };
+  let benefitQuery = buildBenefitMerchantLinkQueryForIds(merchantIds);
   const bank = searchParams.get('bank');
   const bankPatterns = buildProviderFilterRegexes(providerCatalog, bank);
 
@@ -1470,16 +1648,7 @@ async function hydrateSearchMerchantsWithBenefits(db, collectionName, merchants,
     .sort({ 'eligibilities.bank': 1, benefitTitle: 1 })
     .toArray();
   const cardNameLookup = await resolveCardNameLookup(db, rawBenefits);
-  const benefitsByMerchant = new Map();
-
-  for (const benefit of rawBenefits) {
-    const key = benefit?.merchantId;
-    if (!key) continue;
-    if (!benefitsByMerchant.has(key)) {
-      benefitsByMerchant.set(key, []);
-    }
-    benefitsByMerchant.get(key).push(buildBusinessBenefitSummary(benefit, cardNameLookup));
-  }
+  const benefitsByMerchant = groupBenefitSummariesByMerchant(rawBenefits, cardNameLookup, merchantIds);
 
   return merchants.map((merchant) => {
     if (!merchant?.merchantId) {
@@ -1989,7 +2158,7 @@ async function handleGetBenefits(req, res, url, db) {
   const limitNum = toPositiveInt(searchParams.get('limit'), 50, 100);
   const offsetNum = toPositiveInt(searchParams.get('offset'), 0);
 
-  const query = {};
+  let query = {};
 
   if (bank) {
     const bankPatterns = buildProviderFilterRegexes(providerCatalog, bank);
@@ -2035,7 +2204,7 @@ async function handleGetBenefits(req, res, url, db) {
         }
       });
     }
-    query.merchantId = { $in: merchantIds };
+    query = combineQueriesWithAnd(query, buildBenefitMerchantLinkQueryForIds(merchantIds));
   }
 
   applyActiveBenefitsFilter(query, searchParams);
@@ -2047,13 +2216,17 @@ async function handleGetBenefits(req, res, url, db) {
   ]);
   const merchantMap = await loadMerchantMapByIds(
     db,
-    benefits.map((benefit) => benefit.merchantId).filter(Boolean)
+    collectEffectiveBenefitMerchantIds(benefits)
   );
 
   setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
-    benefits: benefits.map((benefit) => rehydrateBenefitDoc(benefit, merchantMap.get(benefit.merchantId))),
+    benefits: benefits.map((benefit) => {
+      const merchantIdsForBenefit = getEffectiveBenefitMerchantIds(benefit);
+      const merchant = merchantIdsForBenefit.length === 1 ? merchantMap.get(merchantIdsForBenefit[0]) : null;
+      return rehydrateBenefitDoc(benefit, merchant);
+    }),
     pagination: {
       total,
       limit: limitNum,
@@ -2094,11 +2267,13 @@ async function handleGetBenefitById(req, res, url, db, id) {
     });
   }
 
-  const merchantMap = await loadMerchantMapByIds(db, [benefit.merchantId].filter(Boolean));
+  const merchantIdsForBenefit = getEffectiveBenefitMerchantIds(benefit);
+  const merchantMap = await loadMerchantMapByIds(db, merchantIdsForBenefit);
+  const merchant = merchantIdsForBenefit.length === 1 ? merchantMap.get(merchantIdsForBenefit[0]) : null;
   setCacheControl(res, CC_CONTENT);
   return json(res, 200, {
     success: true,
-    benefit: rehydrateBenefitDoc(benefit, merchantMap.get(benefit.merchantId))
+    benefit: rehydrateBenefitDoc(benefit, merchant)
   });
 }
 
@@ -2185,6 +2360,7 @@ async function handleGetStats(req, res, url, db) {
   const collectionName = getCollectionName(searchParams);
   const collection = db.collection(collectionName);
   const activeMatch = getActiveBenefitsMatch(searchParams) || {};
+  await assertNoInvalidMultiMerchantBenefits(collection, activeMatch);
 
   const [
     totalBenefits,
@@ -2193,12 +2369,14 @@ async function handleGetStats(req, res, url, db) {
     topCategories,
     topBanks
   ] = await Promise.all([
-    collection.countDocuments(activeMatch),
-    collection.countDocuments({ ...activeMatch, online: true }),
-    collection.countDocuments({ ...activeMatch, online: false }),
+    countBenefitApplications(collection, activeMatch),
+    countBenefitApplications(collection, combineQueriesWithAnd(activeMatch, { online: true })),
+    countBenefitApplications(collection, combineQueriesWithAnd(activeMatch, { online: false })),
     collection
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
+        { $project: { categories: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
+        { $unwind: '$effectiveMerchantIds' },
         { $unwind: '$categories' },
         { $group: { _id: '$categories', count: { $sum: 1 } } },
         { $sort: { count: -1 } },
@@ -2208,6 +2386,8 @@ async function handleGetStats(req, res, url, db) {
     collection
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
+        { $project: { eligibilities: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
+        { $unwind: '$effectiveMerchantIds' },
         { $unwind: '$eligibilities' },
         { $group: { _id: '$eligibilities.bank', count: { $sum: 1 } } },
         { $sort: { count: -1 } },
@@ -2261,7 +2441,7 @@ async function loadCoreSeoSummary(db) {
       topCategories,
       topBanks
     ] = await Promise.all([
-      benefitsCollection.countDocuments(activeBenefitMatch),
+      countBenefitApplications(benefitsCollection, activeBenefitMatch),
       merchantCollection.countDocuments(indexableMerchantQuery),
       merchantCollection.countDocuments(activeMerchantQuery),
       merchantCollection
@@ -2695,9 +2875,7 @@ async function handleGetBusinesses(req, res, url, db) {
   }
 
   const merchantIds = pagedMerchants.map((merchant) => merchant.merchantId).filter(Boolean);
-  const benefitQuery = {
-    merchantId: { $in: merchantIds }
-  };
+  let benefitQuery = buildBenefitMerchantLinkQueryForIds(merchantIds);
 
   if (bankPatterns && bankPatterns.length > 0) {
     benefitQuery['eligibilities.bank'] = { $in: bankPatterns };
@@ -2717,15 +2895,7 @@ async function handleGetBusinesses(req, res, url, db) {
       .toArray()
     : [];
   const cardNameLookup = await resolveCardNameLookup(db, rawBenefits);
-  const benefitsByMerchant = new Map();
-  for (const benefit of rawBenefits) {
-    const key = benefit.merchantId;
-    if (!key) continue;
-    if (!benefitsByMerchant.has(key)) {
-      benefitsByMerchant.set(key, []);
-    }
-    benefitsByMerchant.get(key).push(buildBusinessBenefitSummary(benefit, cardNameLookup));
-  }
+  const benefitsByMerchant = groupBenefitSummariesByMerchant(rawBenefits, cardNameLookup, merchantIds);
 
   const businesses = pagedMerchants
     .map((merchant) => ({
@@ -2808,9 +2978,7 @@ async function handleMerchantSeoPage(req, res, url, db, slugId, options = {}) {
 
   const rawBenefits = await db.collection(DEFAULT_COLLECTION)
     .find(
-      {
-        merchantId: parsed.merchantId
-      },
+      buildBenefitMerchantLinkQuery(parsed.merchantId),
       {
         projection: BENEFIT_SUMMARY_PROJECTION
       }
@@ -3036,6 +3204,7 @@ export {
   handleGetBenefitById,
   handleGetBenefits,
   handleGetBanks,
+  handleGetStats,
   handleGetBusinesses,
   handleDiscountSearchGuideSeoPage,
   handleHomeSeoPage,

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -642,15 +642,26 @@ function trimMongoStringExpression(input) {
 
 function normalizedMerchantIdsExpression(input = '$merchantIds') {
   return {
-    $filter: {
-      input: {
-        $cond: [{ $isArray: input }, input, []]
+    $setUnion: [
+      {
+        $filter: {
+          input: {
+            $map: {
+              input: {
+                $cond: [{ $isArray: input }, input, []]
+              },
+              as: 'merchantId',
+              in: trimMongoStringExpression('$$merchantId')
+            }
+          },
+          as: 'merchantId',
+          cond: {
+            $ne: ['$$merchantId', '']
+          }
+        }
       },
-      as: 'merchantId',
-      cond: {
-        $ne: [trimMongoStringExpression('$$merchantId'), '']
-      }
-    }
+      []
+    ]
   };
 }
 
@@ -734,6 +745,14 @@ function buildBenefitMerchantLinkQueryForIds(merchantIds) {
     $or: [
       { merchantIds: { $in: ids } },
       {
+        $expr: {
+          $gt: [
+            { $size: { $setIntersection: [normalizedMerchantIdsExpression('$merchantIds'), ids] } },
+            0
+          ]
+        }
+      },
+      {
         $and: [
           { merchantId: { $in: ids } },
           missingOrEmptyMerchantIdsQuery()
@@ -764,20 +783,15 @@ function effectiveMerchantIdsExpression() {
     $let: {
       vars: {
         merchantIds: normalizedMerchantIdsExpression('$merchantIds'),
-        legacyMerchantId: '$merchantId'
+        legacyMerchantId: trimMongoStringExpression('$merchantId')
       },
       in: {
         $cond: [
           { $gt: [{ $size: '$$merchantIds' }, 0] },
-          { $setUnion: ['$$merchantIds', []] },
+          '$$merchantIds',
           {
             $cond: [
-              {
-                $and: [
-                  { $ne: ['$$legacyMerchantId', null] },
-                  { $ne: ['$$legacyMerchantId', ''] }
-                ]
-              },
+              { $ne: ['$$legacyMerchantId', ''] },
               ['$$legacyMerchantId'],
               []
             ]

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -612,15 +612,26 @@ function normalizeBenefitMerchantIds(value) {
   return ids;
 }
 
-function hasOwnField(value, field) {
-  return Boolean(value && Object.prototype.hasOwnProperty.call(value, field));
+function toNonEmptyString(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
+}
+
+function hasMeaningfulSingularMerchantField(value, field) {
+  const fieldValue = value?.[field];
+  if (fieldValue === null || fieldValue === undefined) return false;
+  if (field === 'merchantId') return Boolean(toNonEmptyString(fieldValue));
+  if (typeof fieldValue === 'object') return Object.keys(fieldValue).length > 0;
+  return Boolean(toNonEmptyString(fieldValue));
 }
 
 function assertValidBenefitMerchantLinkage(benefit) {
   const merchantIds = normalizeBenefitMerchantIds(benefit?.merchantIds);
   if (merchantIds.length <= 1) return;
 
-  const singularFields = ['merchantId', 'merchant', 'merchantSnapshot'].filter((field) => hasOwnField(benefit, field));
+  const singularFields = ['merchantId', 'merchant', 'merchantSnapshot'].filter((field) =>
+    hasMeaningfulSingularMerchantField(benefit, field)
+  );
   if (singularFields.length === 0) return;
 
   const id = benefit?.id || benefit?._id?.toString?.() || '(unknown)';
@@ -685,9 +696,9 @@ function invalidMultiMerchantBenefitQuery() {
   return {
     'merchantIds.1': { $exists: true },
     $or: [
-      { merchantId: { $exists: true } },
-      { merchant: { $exists: true } },
-      { merchantSnapshot: { $exists: true } }
+      { merchantId: { $exists: true, $nin: [null, ''] } },
+      { merchant: { $exists: true, $ne: null } },
+      { merchantSnapshot: { $exists: true, $ne: null } }
     ]
   };
 }
@@ -745,7 +756,7 @@ async function countBenefitApplications(collection, match = {}) {
     .aggregate([
       ...(Object.keys(match).length > 0 ? [{ $match: match }] : []),
       { $project: { effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-      { $unwind: '$effectiveMerchantIds' },
+      { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
       { $count: 'count' }
     ])
     .toArray();
@@ -2376,7 +2387,7 @@ async function handleGetStats(req, res, url, db) {
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
         { $project: { categories: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-        { $unwind: '$effectiveMerchantIds' },
+        { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
         { $unwind: '$categories' },
         { $group: { _id: '$categories', count: { $sum: 1 } } },
         { $sort: { count: -1 } },
@@ -2387,7 +2398,7 @@ async function handleGetStats(req, res, url, db) {
       .aggregate([
         ...(Object.keys(activeMatch).length > 0 ? [{ $match: activeMatch }] : []),
         { $project: { eligibilities: 1, effectiveMerchantIds: effectiveMerchantIdsExpression() } },
-        { $unwind: '$effectiveMerchantIds' },
+        { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
         { $unwind: '$eligibilities' },
         { $group: { _id: '$eligibilities.bank', count: { $sum: 1 } } },
         { $sort: { count: -1 } },

--- a/mobile/src/screens/BenefitDetailScreen.tsx
+++ b/mobile/src/screens/BenefitDetailScreen.tsx
@@ -56,6 +56,11 @@ export default function BenefitDetailScreen() {
           const rawData = await getRawBenefitById(businessId);
           if (rawData) {
             setRawBenefit(rawData);
+            const merchantName =
+              rawData.merchant?.name ||
+              rawData.merchantSnapshot?.merchantName ||
+              rawData.merchantIds?.filter(Boolean).join(', ') ||
+              'Comercio';
             const converted: BankBenefit = {
               bankName: rawData.bank,
               cardName: rawData.cardTypes[0]?.name || 'Credit Card',
@@ -74,7 +79,7 @@ export default function BenefitDetailScreen() {
 
             const biz: Business = {
               id: rawData._id.$oid,
-              name: rawData.merchant.name,
+              name: merchantName,
               category: rawData.categories[0] || 'otros',
               description: `Business offering ${rawData.benefitTitle}`,
               rating: 5,

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -17,6 +17,7 @@ export interface BankBenefit {
   originalAnalyzedText?: string;
   description?: string;
   installments?: number | null;
+  merchantIds?: string[];
 }
 
 export interface Business {

--- a/mobile/src/types/mongodb.ts
+++ b/mobile/src/types/mongodb.ts
@@ -62,10 +62,18 @@ export interface MongoDate {
 
 export interface RawMongoBenefit {
   _id: MongoObjectId;
-  merchant: {
+  merchant?: {
     name: string;
     type: string;
   };
+  merchantId?: string | null;
+  merchantIds?: string[];
+  merchantSnapshot?: {
+    merchantId?: string;
+    merchantKey?: string;
+    merchantName?: string;
+    kind?: string;
+  } | null;
   bank: string;
   network: string;
   cardTypes: {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -70,17 +70,17 @@ function expectAnyRegexMatches(patterns: RegExp[], value: string) {
 }
 
 function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
-  expect(query).toMatchObject({
-    $or: [
+  expect(query).toHaveProperty('$or');
+  expect((query as { $or: unknown[] }).$or).toEqual(expect.arrayContaining([
       { merchantIds: { $in: merchantIds } },
+      { $expr: expect.any(Object) },
       {
         $and: [
           { merchantId: { $in: merchantIds } },
           { $expr: expect.any(Object) },
         ],
       },
-    ],
-  });
+  ]));
 }
 
 function createPaginatedCursor<T>(data: T[]) {
@@ -637,6 +637,7 @@ describe('merchant-first serverless helpers', () => {
 
     expect(benefit.id).toBe('benefit-object-id');
     expect(benefit.merchant.name).toBe('Unknown Merchant');
+    expect(benefit.merchantIds).toEqual(['merchant_1', 'merchant_2']);
     expect(benefit.categories).toEqual(['deportes']);
   });
 

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -73,7 +73,6 @@ function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
   expect(query).toHaveProperty('$or');
   expect((query as { $or: unknown[] }).$or).toEqual(expect.arrayContaining([
       { merchantIds: { $in: merchantIds } },
-      { $expr: expect.any(Object) },
       {
         $and: [
           { merchantId: { $in: merchantIds } },
@@ -443,7 +442,7 @@ describe('merchant-first serverless helpers', () => {
     expect(invalidQueries[0]).toHaveProperty('merchantIds.1');
     expect(aggregatePipelines[0]).toEqual([
       { $project: { effectiveMerchantIds: expect.any(Object) } },
-      { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
+      { $unwind: '$effectiveMerchantIds' },
       { $count: 'count' },
     ]);
   });

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -7,6 +7,7 @@ import {
   handleGetBanks,
   handleGetBenefits,
   handleGetBusinesses,
+  handleGetStats,
   handleDiscountSearchGuideSeoPage,
   handleHomeSeoPage,
   handleLegacyBusinessRedirect,
@@ -17,6 +18,7 @@ import {
   resolveRequestPath,
   rehydrateBenefitDoc
 } from '../../../api/[...path].js';
+import { transformRawBenefitToBenefit } from '../../types/mongodb';
 
 const merchantSeoAppShell = [
   '<!doctype html>',
@@ -65,6 +67,26 @@ function createCursor<T>(data: T[]) {
 
 function expectAnyRegexMatches(patterns: RegExp[], value: string) {
   expect(patterns.some((pattern) => pattern.test(value))).toBe(true);
+}
+
+function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
+  expect(query).toMatchObject({
+    $or: [
+      { merchantIds: { $in: merchantIds } },
+      {
+        $and: [
+          { merchantId: { $in: merchantIds } },
+          {
+            $or: [
+              { merchantIds: { $exists: false } },
+              { merchantIds: null },
+              { merchantIds: { $size: 0 } },
+            ],
+          },
+        ],
+      },
+    ],
+  });
 }
 
 function createPaginatedCursor<T>(data: T[]) {
@@ -270,7 +292,256 @@ describe('merchant-first serverless helpers', () => {
     expect(payload.businesses[0].id).toBe('merchant_1');
     expect(payload.businesses[0].benefits).toHaveLength(1);
     expect((merchantQueries[0] as { categories: unknown }).categories).toEqual({ $in: ['shopping'] });
-    expect(((benefitQueries[0] as { merchantId: { $in: unknown[] } }).merchantId).$in).toEqual(['merchant_1']);
+    expectBenefitQueryForMerchants(benefitQueries[0], ['merchant_1']);
+  });
+
+  it('handleGetBusinesses attaches a shared merchantIds benefit under every linked merchant', async () => {
+    const benefitQueries: unknown[] = [];
+    const merchants = [
+      {
+        merchantId: 'merchant_1',
+        merchantName: 'Adidas',
+        merchantKey: 'adidas',
+        categories: ['deportes'],
+        locations: [],
+        banks: ['BBVA'],
+        searchProfile: { description: 'Sportswear' },
+        activeBenefitCount: 1,
+        benefitCount: 1,
+        hasOnlineBenefits: true,
+      },
+      {
+        merchantId: 'merchant_2',
+        merchantName: 'Sporting',
+        merchantKey: 'sporting',
+        categories: ['deportes'],
+        locations: [],
+        banks: ['BBVA'],
+        searchProfile: { description: 'Sports store' },
+        activeBenefitCount: 1,
+        benefitCount: 1,
+        hasOnlineBenefits: true,
+      },
+    ];
+    const sharedBenefit = {
+      id: 'shared-benefit',
+      merchantIds: ['merchant_1', 'merchant_2'],
+      eligibilities: [{
+        bank: 'bbva',
+        bankDisplayName: 'BBVA',
+        cardTypes: [],
+        cardResolutionStatus: 'not_required',
+        subscription: null,
+        subscriptionResolutionStatus: 'not_required',
+      }],
+      benefitTitle: '30% OFF compartido',
+      availableDays: ['Lunes'],
+      discountPercentage: 30,
+      caps: [],
+      online: true,
+      otherDiscounts: null,
+      installments: null,
+      description: 'Promo',
+      termsAndConditions: '',
+      link: null,
+      validUntil: '2099-12-31',
+    };
+
+    const db = {
+      collection(name: string) {
+        if (name === 'providers') {
+          return {
+            find() {
+              return createCursor([{ key: 'bbva', name: 'BBVA', shortName: 'BBVA' }]);
+            },
+          };
+        }
+
+        if (name === 'merchant_assets') {
+          return {
+            async countDocuments() {
+              return merchants.length;
+            },
+            find() {
+              return createCursor(merchants);
+            },
+          };
+        }
+
+        if (name === 'confirmed_benefits') {
+          return {
+            find(query: unknown) {
+              benefitQueries.push(query);
+              return createCursor([sharedBenefit]);
+            },
+          };
+        }
+
+        if (name === 'bank_cards') {
+          return {
+            find() {
+              return createCursor([]);
+            },
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/businesses?collection=confirmed_benefits&limit=2&offset=0');
+
+    await handleGetBusinesses({ method: 'GET' } as never, res as never, url, db as never);
+
+    const payload = JSON.parse(res.body || '{}');
+    expect(res.statusCode).toBe(200);
+    expect(payload.businesses).toHaveLength(2);
+    expect(payload.businesses.map((business: { id: string }) => business.id)).toEqual(['merchant_1', 'merchant_2']);
+    expect(payload.businesses.every((business: { benefits: unknown[] }) => business.benefits.length === 1)).toBe(true);
+    expect(payload.businesses.map((business: { benefits: Array<{ id: string }> }) => business.benefits[0].id)).toEqual([
+      'shared-benefit',
+      'shared-benefit',
+    ]);
+    expect(payload.businesses[0].benefits[0].merchantIds).toEqual(['merchant_1', 'merchant_2']);
+    expectBenefitQueryForMerchants(benefitQueries[0], ['merchant_1', 'merchant_2']);
+  });
+
+  it('handleGetStats counts merchant-benefit applications instead of benefit documents', async () => {
+    const invalidQueries: unknown[] = [];
+    const aggregatePipelines: unknown[][] = [];
+    const db = {
+      collection(name: string) {
+        if (name === 'confirmed_benefits') {
+          return {
+            async findOne(query: unknown) {
+              invalidQueries.push(query);
+              return null;
+            },
+            aggregate(pipeline: unknown[]) {
+              aggregatePipelines.push(pipeline);
+              const serialized = JSON.stringify(pipeline);
+              if (serialized.includes('"online":true')) return createAggregateCursor([{ count: 3 }]);
+              if (serialized.includes('"online":false')) return createAggregateCursor([{ count: 1 }]);
+              if (serialized.includes('"$categories"')) return createAggregateCursor([{ _id: 'deportes', count: 4 }]);
+              if (serialized.includes('"$eligibilities"')) return createAggregateCursor([{ _id: 'bbva', count: 4 }]);
+              return createAggregateCursor([{ count: 4 }]);
+            },
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/stats?collection=confirmed_benefits&includeExpired=true');
+
+    await handleGetStats({ method: 'GET' } as never, res as never, url, db as never);
+
+    const payload = JSON.parse(res.body || '{}');
+    expect(res.statusCode).toBe(200);
+    expect(payload.stats.totalBenefits).toBe(4);
+    expect(payload.stats.onlineBenefits).toBe(3);
+    expect(payload.stats.physicalBenefits).toBe(1);
+    expect(payload.stats.topCategories[0]).toEqual({ category: 'deportes', count: 4 });
+    expect(payload.stats.topBanks[0]).toEqual({ bank: 'bbva', count: 4 });
+    expect(invalidQueries[0]).toHaveProperty('merchantIds.1');
+    expect(aggregatePipelines[0]).toEqual([
+      { $project: { effectiveMerchantIds: expect.any(Object) } },
+      { $unwind: '$effectiveMerchantIds' },
+      { $count: 'count' },
+    ]);
+  });
+
+  it('handleGetBenefits keeps pagination document-based for shared merchantIds benefits', async () => {
+    const benefits = [
+      {
+        id: 'shared-benefit',
+        merchantIds: ['merchant_1', 'merchant_2'],
+        benefitTitle: '30% OFF compartido',
+        description: 'Promo',
+        online: true,
+        validUntil: '2099-12-31',
+      },
+    ];
+    const merchants = [
+      { merchantId: 'merchant_1', merchantName: 'Adidas' },
+      { merchantId: 'merchant_2', merchantName: 'Sporting' },
+    ];
+
+    const db = {
+      collection(name: string) {
+        if (name === 'providers') {
+          return {
+            find() {
+              return createCursor([]);
+            },
+          };
+        }
+
+        if (name === 'confirmed_benefits') {
+          return {
+            find() {
+              return createCursor(benefits);
+            },
+            async countDocuments() {
+              return 1;
+            },
+          };
+        }
+
+        if (name === 'merchant_assets') {
+          return {
+            find() {
+              return createCursor(merchants);
+            },
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/benefits?collection=confirmed_benefits&includeExpired=true');
+
+    await handleGetBenefits({ method: 'GET' } as never, res as never, url, db as never);
+
+    const payload = JSON.parse(res.body || '{}');
+    expect(res.statusCode).toBe(200);
+    expect(payload.pagination.total).toBe(1);
+    expect(payload.benefits).toHaveLength(1);
+    expect(payload.benefits[0].merchantIds).toEqual(['merchant_1', 'merchant_2']);
+    expect(payload.benefits[0]).not.toHaveProperty('merchant');
+  });
+
+  it('transformRawBenefitToBenefit tolerates merchantIds without a singular merchant', () => {
+    const benefit = transformRawBenefitToBenefit({
+      _id: { $oid: 'benefit-object-id' },
+      merchantIds: ['merchant_1', 'merchant_2'],
+      bank: 'BBVA',
+      network: 'VISA',
+      cardTypes: [],
+      benefitTitle: '30% OFF compartido',
+      description: 'Promo',
+      categories: ['deportes'],
+      locations: [],
+      online: true,
+      availableDays: [],
+      discountPercentage: 30,
+      link: '',
+      termsAndConditions: '',
+      validUntil: '2099-12-31',
+      originalId: { $oid: 'raw-object-id' },
+      sourceCollection: 'confirmed_benefits',
+      processedAt: { $date: '2026-06-25T00:00:00.000Z' },
+      processingStatus: 'processed',
+    } as never);
+
+    expect(benefit.id).toBe('benefit-object-id');
+    expect(benefit.merchant.name).toBe('Unknown Merchant');
+    expect(benefit.categories).toEqual(['deportes']);
   });
 
   it('handleGetBanks returns provider descriptors with derived index metadata', async () => {
@@ -715,7 +986,7 @@ describe('merchant-first serverless helpers', () => {
     expect((merchantQueries[1] as { merchantId: unknown }).merchantId).toBe('merchant_1');
     expect(merchantQueries[0]).not.toHaveProperty('$or');
     expect(merchantQueries[1]).not.toHaveProperty('$or');
-    expect(((benefitQueries[0] as { merchantId: { $in: unknown[] } }).merchantId).$in).toEqual(['merchant_1']);
+    expectBenefitQueryForMerchants(benefitQueries[0], ['merchant_1']);
   });
 
   it('handleGetBusinesses preserves Modo source markers in summarized benefits', async () => {
@@ -909,7 +1180,7 @@ describe('merchant-first serverless helpers', () => {
 
   it('handleHomeSeoPage returns crawlable homepage HTML with counts and JSON-LD', async () => {
     const merchantQueries: unknown[] = [];
-    const benefitQueries: unknown[] = [];
+    const benefitAggregatePipelines: unknown[] = [];
     const merchantAggregatePipelines: unknown[] = [];
     const db = {
       collection(name: string) {
@@ -933,9 +1204,9 @@ describe('merchant-first serverless helpers', () => {
 
         if (name === 'confirmed_benefits') {
           return {
-            async countDocuments(query: unknown) {
-              benefitQueries.push(query);
-              return 150;
+            aggregate(pipeline: unknown[]) {
+              benefitAggregatePipelines.push(pipeline);
+              return createAggregateCursor([{ count: 150 }]);
             }
           };
         }
@@ -970,7 +1241,7 @@ describe('merchant-first serverless helpers', () => {
     expect(res.body).toContain('FAQPage');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/"');
     expect(res.body).toContain('src="/assets/index-test.js"');
-    expect(benefitQueries).toHaveLength(1);
+    expect(benefitAggregatePipelines).toHaveLength(1);
     expect(merchantQueries).toHaveLength(2);
     expect(merchantAggregatePipelines).toHaveLength(2);
   });
@@ -1139,6 +1410,15 @@ describe('merchant-first serverless helpers', () => {
                   discountPercentage: 25,
                   availableDays: ['lunes'],
                   validUntil: '2099-12-31'
+                },
+                {
+                  id: 'shared-benefit',
+                  merchantIds: ['merchant_1', 'merchant_2'],
+                  bank: 'Banco Galicia',
+                  benefitTitle: 'Beneficio compartido',
+                  discountPercentage: 30,
+                  availableDays: ['martes'],
+                  validUntil: '2099-12-31'
                 }
               ]);
             }
@@ -1163,6 +1443,7 @@ describe('merchant-first serverless helpers', () => {
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(res.body).toContain('<title>Coto descuentos y promociones | Blink</title>');
     expect(res.body).toContain('<h1>Coto descuentos y promociones</h1>');
+    expect(res.body).toContain('Beneficio compartido');
     expect(res.body).toContain('href="https://www.blinkapp.com.ar/comercios/coto--merchant_1"');
     expect(res.body).toContain('src="/assets/index-test.js"');
     expect(merchantQueries[0]).toEqual({
@@ -1170,7 +1451,7 @@ describe('merchant-first serverless helpers', () => {
       merchantId: 'merchant_1',
       benefitCount: { $gt: 0 }
     });
-    expect((benefitQueries[0] as { merchantId: string }).merchantId).toBe('merchant_1');
+    expectBenefitQueryForMerchants(benefitQueries[0], ['merchant_1']);
   });
 
   it('handleMerchantSeoPage redirects non-canonical merchant slugs', async () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -449,9 +449,45 @@ describe('merchant-first serverless helpers', () => {
     expect(invalidQueries[0]).toHaveProperty('merchantIds.1');
     expect(aggregatePipelines[0]).toEqual([
       { $project: { effectiveMerchantIds: expect.any(Object) } },
-      { $unwind: '$effectiveMerchantIds' },
+      { $unwind: { path: '$effectiveMerchantIds', preserveNullAndEmptyArrays: true } },
       { $count: 'count' },
     ]);
+  });
+
+  it('handleGetStats only treats meaningful singular merchant fields as invalid', async () => {
+    let invalidQuery: unknown;
+    const db = {
+      collection(name: string) {
+        if (name === 'confirmed_benefits') {
+          return {
+            async findOne(query: unknown) {
+              invalidQuery = query;
+              return null;
+            },
+            aggregate() {
+              return createAggregateCursor([{ count: 1 }]);
+            },
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/stats?collection=confirmed_benefits&includeExpired=true');
+
+    await handleGetStats({ method: 'GET' } as never, res as never, url, db as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(invalidQuery).toMatchObject({
+      'merchantIds.1': { $exists: true },
+      $or: [
+        { merchantId: { $exists: true, $nin: [null, ''] } },
+        { merchant: { $exists: true, $ne: null } },
+        { merchantSnapshot: { $exists: true, $ne: null } },
+      ],
+    });
   });
 
   it('handleGetBenefits keeps pagination document-based for shared merchantIds benefits', async () => {
@@ -514,6 +550,70 @@ describe('merchant-first serverless helpers', () => {
     expect(payload.benefits).toHaveLength(1);
     expect(payload.benefits[0].merchantIds).toEqual(['merchant_1', 'merchant_2']);
     expect(payload.benefits[0]).not.toHaveProperty('merchant');
+  });
+
+  it('handleGetBenefits accepts shared merchantIds benefits with null legacy merchant fields', async () => {
+    const benefits = [
+      {
+        id: 'shared-null-benefit',
+        merchantId: null,
+        merchantIds: ['merchant_1', 'merchant_2'],
+        merchant: null,
+        merchantSnapshot: null,
+        benefitTitle: '30% OFF compartido',
+        description: 'Promo',
+        online: true,
+        validUntil: '2099-12-31',
+      },
+    ];
+    const merchants = [
+      { merchantId: 'merchant_1', merchantName: 'Adidas' },
+      { merchantId: 'merchant_2', merchantName: 'Sporting' },
+    ];
+
+    const db = {
+      collection(name: string) {
+        if (name === 'providers') {
+          return {
+            find() {
+              return createCursor([]);
+            },
+          };
+        }
+
+        if (name === 'confirmed_benefits') {
+          return {
+            find() {
+              return createCursor(benefits);
+            },
+            async countDocuments() {
+              return 1;
+            },
+          };
+        }
+
+        if (name === 'merchant_assets') {
+          return {
+            find() {
+              return createCursor(merchants);
+            },
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/benefits?collection=confirmed_benefits&includeExpired=true');
+
+    await handleGetBenefits({ method: 'GET' } as never, res as never, url, db as never);
+
+    const payload = JSON.parse(res.body || '{}');
+    expect(res.statusCode).toBe(200);
+    expect(payload.pagination.total).toBe(1);
+    expect(payload.benefits[0].id).toBe('shared-null-benefit');
+    expect(payload.benefits[0].merchantIds).toEqual(['merchant_1', 'merchant_2']);
   });
 
   it('transformRawBenefitToBenefit tolerates merchantIds without a singular merchant', () => {

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -76,13 +76,7 @@ function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
       {
         $and: [
           { merchantId: { $in: merchantIds } },
-          {
-            $or: [
-              { merchantIds: { $exists: false } },
-              { merchantIds: null },
-              { merchantIds: { $size: 0 } },
-            ],
-          },
+          { $expr: expect.any(Object) },
         ],
       },
     ],
@@ -482,12 +476,14 @@ describe('merchant-first serverless helpers', () => {
     expect(res.statusCode).toBe(200);
     expect(invalidQuery).toMatchObject({
       'merchantIds.1': { $exists: true },
+      $expr: expect.any(Object),
       $or: [
-        { merchantId: { $exists: true, $nin: [null, ''] } },
-        { merchant: { $exists: true, $ne: null } },
-        { merchantSnapshot: { $exists: true, $ne: null } },
+        { $expr: expect.any(Object) },
+        { $expr: expect.any(Object) },
+        { $expr: expect.any(Object) },
       ],
     });
+    expect(JSON.stringify(invalidQuery)).toContain('$objectToArray');
   });
 
   it('handleGetBenefits keeps pagination document-based for shared merchantIds benefits', async () => {

--- a/src/services/__tests__/searchServerless.test.ts
+++ b/src/services/__tests__/searchServerless.test.ts
@@ -55,13 +55,7 @@ function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
       {
         $and: [
           { merchantId: { $in: merchantIds } },
-          {
-            $or: [
-              { merchantIds: { $exists: false } },
-              { merchantIds: null },
-              { merchantIds: { $size: 0 } },
-            ],
-          },
+          { $expr: expect.any(Object) },
         ],
       },
     ],

--- a/src/services/__tests__/searchServerless.test.ts
+++ b/src/services/__tests__/searchServerless.test.ts
@@ -48,6 +48,26 @@ function createCursor<T>(data: T[]) {
   return cursor;
 }
 
+function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
+  expect(query).toMatchObject({
+    $or: [
+      { merchantIds: { $in: merchantIds } },
+      {
+        $and: [
+          { merchantId: { $in: merchantIds } },
+          {
+            $or: [
+              { merchantIds: { $exists: false } },
+              { merchantIds: null },
+              { merchantIds: { $size: 0 } },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+}
+
 function buildMerchantDoc(merchantId: string, merchantName: string, rankingScore?: number) {
   const merchant = {
     merchantId,
@@ -542,10 +562,110 @@ describe('handleSearch', () => {
       'Banco Galicia',
       'Naranja X'
     ]);
-    expect(benefitFindQuery).toMatchObject({
-      merchantId: { $in: ['merchant_sporting'] }
-    });
+    expectBenefitQueryForMerchants(benefitFindQuery, ['merchant_sporting']);
     expect(benefitFindQuery).toHaveProperty('$and.0.$expr');
+  });
+
+  it('hydrates shared merchantIds benefits for every linked search merchant', async () => {
+    isMeilisearchConfiguredMock.mockReturnValue(true);
+    meiliSearchMock
+      .mockResolvedValueOnce({
+        hits: [
+          {
+            ...buildMerchantDoc('merchant_adidas', 'Adidas', 1),
+            business: {
+              id: 'merchant_adidas',
+              name: 'Adidas',
+              category: 'deportes',
+              description: '',
+              rating: 5,
+              location: [],
+              image: '',
+              benefits: []
+            }
+          },
+          {
+            ...buildMerchantDoc('merchant_sporting', 'Sporting', 0.9),
+            business: {
+              id: 'merchant_sporting',
+              name: 'Sporting',
+              category: 'deportes',
+              description: '',
+              rating: 5,
+              location: [],
+              image: '',
+              benefits: []
+            }
+          }
+        ],
+        estimatedTotalHits: 2
+      })
+      .mockResolvedValueOnce({ hits: [] })
+      .mockResolvedValueOnce({ hits: [] });
+
+    let benefitFindQuery: unknown;
+    const sharedBenefit = {
+      id: 'shared-benefit',
+      merchantIds: ['merchant_adidas', 'merchant_sporting'],
+      eligibilities: [{
+        bank: 'galicia',
+        bankDisplayName: 'Banco Galicia',
+        cardTypes: [],
+        cardResolutionStatus: 'not_required',
+        subscription: null,
+        subscriptionResolutionStatus: 'not_required'
+      }],
+      benefitTitle: '30% OFF compartido',
+      availableDays: ['Lunes'],
+      discountPercentage: 30,
+      caps: [],
+      online: true,
+      otherDiscounts: null,
+      installments: null,
+      description: 'Promo compartida',
+      termsAndConditions: '',
+      link: null,
+      validUntil: '2099-12-31',
+    };
+
+    const db = {
+      collection(name: string) {
+        if (name === 'merchant_assets') {
+          return {
+            find() {
+              return createCursor([]);
+            }
+          };
+        }
+
+        if (name === 'confirmed_benefits') {
+          return {
+            find(query: unknown) {
+              benefitFindQuery = query;
+              return createCursor([sharedBenefit]);
+            }
+          };
+        }
+
+        throw new Error(`Unexpected collection: ${name}`);
+      }
+    };
+
+    const res = createResponseCapture();
+    const url = new URL('https://example.com/api/search?q=deportes&limit=20&offset=0&collection=confirmed_benefits');
+
+    await handleSearch({ method: 'GET' } as never, res as never, url, db as never);
+
+    const payload = JSON.parse(res.body || '{}');
+    expect(res.statusCode).toBe(200);
+    expect(payload.merchants).toHaveLength(2);
+    expect(payload.merchants.every((merchant: { business: { benefits: unknown[] } }) => merchant.business.benefits.length === 1)).toBe(true);
+    expect(payload.merchants.map((merchant: { business: { benefits: Array<{ id: string }> } }) => merchant.business.benefits[0].id)).toEqual([
+      'shared-benefit',
+      'shared-benefit'
+    ]);
+    expect(payload.merchants[0].business.benefits[0].merchantIds).toEqual(['merchant_adidas', 'merchant_sporting']);
+    expectBenefitQueryForMerchants(benefitFindQuery, ['merchant_adidas', 'merchant_sporting']);
   });
 
   it.each([

--- a/src/services/__tests__/searchServerless.test.ts
+++ b/src/services/__tests__/searchServerless.test.ts
@@ -52,7 +52,6 @@ function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
   expect(query).toHaveProperty('$or');
   expect((query as { $or: unknown[] }).$or).toEqual(expect.arrayContaining([
       { merchantIds: { $in: merchantIds } },
-      { $expr: expect.any(Object) },
       {
         $and: [
           { merchantId: { $in: merchantIds } },

--- a/src/services/__tests__/searchServerless.test.ts
+++ b/src/services/__tests__/searchServerless.test.ts
@@ -49,17 +49,17 @@ function createCursor<T>(data: T[]) {
 }
 
 function expectBenefitQueryForMerchants(query: unknown, merchantIds: string[]) {
-  expect(query).toMatchObject({
-    $or: [
+  expect(query).toHaveProperty('$or');
+  expect((query as { $or: unknown[] }).$or).toEqual(expect.arrayContaining([
       { merchantIds: { $in: merchantIds } },
+      { $expr: expect.any(Object) },
       {
         $and: [
           { merchantId: { $in: merchantIds } },
           { $expr: expect.any(Object) },
         ],
       },
-    ],
-  });
+  ]));
 }
 
 function buildMerchantDoc(merchantId: string, merchantName: string, rankingScore?: number) {

--- a/src/types/benefit.ts
+++ b/src/types/benefit.ts
@@ -4,10 +4,18 @@
  */
 export interface RawBenefit {
     _id: { $oid: string };
-    merchant: {
+    merchant?: {
         name: string;
         type: string;
     };
+    merchantId?: string | null;
+    merchantIds?: string[];
+    merchantSnapshot?: {
+        merchantId?: string;
+        merchantKey?: string;
+        merchantName?: string;
+        kind?: string;
+    } | null;
     eligibilities: Array<{
         bank: string;
         bankDisplayName: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export interface BankBenefit {
   installments?: number | null;
   validUntil?: string | null;
   id?: string;
+  merchantIds?: string[];
   sourceCollection?: string | null;
   rawBenefitCollection?: string | null;
   source?: string | null;

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -120,10 +120,18 @@ export interface RawBankSubscription {
 
 export interface RawMongoBenefit {
     _id: MongoObjectId;
-    merchant: {
+    merchant?: {
         name: string;
         type: string;
     };
+    merchantId?: string | null;
+    merchantIds?: string[];
+    merchantSnapshot?: {
+        merchantId?: string;
+        merchantKey?: string;
+        merchantName?: string;
+        kind?: string;
+    } | null;
     bank: string;
     network: string;
     cardTypes: {

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -5,6 +5,7 @@
 export interface Benefit {
     id: string;
     merchant: Merchant; // The business/store where you can use the benefit
+    merchantIds?: string[];
     eligibilities: BenefitEligibility[];
     network: string; // Payment network (e.g., "VISA", "Mastercard")
     benefitTitle: string;
@@ -232,6 +233,20 @@ export interface MongoStatsResponse {
 export const extractId = (mongoId: MongoObjectId): string => mongoId.$oid;
 export const formatMongoDate = (mongoDate: MongoDate): Date => new Date(mongoDate.$date);
 
+const normalizeMerchantIds = (value: unknown): string[] => {
+    if (!Array.isArray(value)) return [];
+
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    for (const entry of value) {
+        const merchantId = String(entry || '').trim();
+        if (!merchantId || seen.has(merchantId)) continue;
+        seen.add(merchantId);
+        ids.push(merchantId);
+    }
+    return ids;
+};
+
 // Safe date formatter that handles various date formats
 export const safeFormatDate = (dateValue: unknown): string => {
     try {
@@ -309,6 +324,7 @@ export const transformRawBenefitToBenefit = (rawBenefit: RawMongoBenefit): Benef
                 name: rawBenefit.merchant?.name || 'Unknown Merchant',
                 type: (rawBenefit.merchant?.type as Merchant['type']) || 'business'
             },
+            merchantIds: normalizeMerchantIds(rawBenefit.merchantIds),
             eligibilities: Array.isArray(rawBenefit.eligibilities) ? rawBenefit.eligibilities : [],
             network: rawBenefit.network || 'Unknown Network',
             benefitTitle: rawBenefit.benefitTitle || 'Benefit Available',
@@ -346,6 +362,7 @@ export const transformRawBenefitToBenefit = (rawBenefit: RawMongoBenefit): Benef
                 name: rawBenefit.merchant?.name || 'Unknown Merchant',
                 type: 'business'
             },
+            merchantIds: normalizeMerchantIds(rawBenefit.merchantIds),
             eligibilities: [],
             network: rawBenefit.network || 'Unknown Network',
             benefitTitle: rawBenefit.benefitTitle || 'Benefit Available',


### PR DESCRIPTION
## Summary
- Resolve confirmed benefits by effective merchant linkage so `merchantIds` docs hydrate under every linked merchant.
- Keep `/api/benefits` document-based while making merchant-facing stats, businesses, search, SEO, and detail hydration count/use merchant-benefit applications.
- Update shared web/mobile/raw types to tolerate future multi-merchant docs without singular merchant data.

## Validation
- `npm test` passed: 629 tests.
- `npx tsc --noEmit -p tsconfig.json --pretty false` passed.
- `npm run build` passed.
- Local API and desktop/mobile browser checks matched `https://www.blinkapp.com.ar` for home, search, category, merchant detail, benefit detail, stats, banks, businesses, search, and benefits routes.