### PR TITLE
Hide benefits without a validUntil date from the FE

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -509,8 +509,6 @@ function getActiveBenefitsMatch(searchParams, now = new Date()) {
         },
         in: {
           $or: [
-            { $eq: ['$$validUntilValue', null] },
-            { $eq: ['$$validUntilValue', ''] },
             {
               $and: [
                 { $eq: [{ $type: '$$validUntilValue' }, 'string'] },

--- a/api/merchant-seo.js
+++ b/api/merchant-seo.js
@@ -548,7 +548,7 @@ export function getMerchantSeoPathFromMerchant(merchant) {
 
 export function isMerchantBenefitActive(benefit, now = new Date()) {
   const validUntil = String(benefit?.validUntil || '').trim();
-  if (!validUntil) return true;
+  if (!validUntil) return false;
 
   if (DATE_ONLY_PATTERN.test(validUntil)) {
     return validUntil >= formatLocalDateOnly(now);

--- a/src/pages/BenefitDetailPage.tsx
+++ b/src/pages/BenefitDetailPage.tsx
@@ -39,6 +39,7 @@ import {
 import { getOptimizedImageUrl } from '../utils/images';
 import { hasInAppHistory } from '../utils/navigation';
 import { getMerchantSeoPath } from '../seo/merchantUrls';
+import { isBenefitActive } from '../utils/benefits';
 
 const BENEFIT_DAYS = [
   { key: 'monday' as const, abbr: 'L' },
@@ -52,22 +53,6 @@ const BENEFIT_DAYS = [
 
 const SAVED_BENEFITS_STORAGE_KEY = 'blink.savedBenefits';
 const LOCATIONS_PREVIEW_COUNT = 4;
-
-const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-
-const formatLocalDateOnly = (date: Date): string => [
-  date.getFullYear(),
-  String(date.getMonth() + 1).padStart(2, '0'),
-  String(date.getDate()).padStart(2, '0'),
-].join('-');
-
-const isBenefitActive = (validUntil: string | null | undefined, now = new Date()): boolean => {
-  const v = validUntil?.trim();
-  if (!v) return true;
-  if (DATE_ONLY_PATTERN.test(v)) return v >= formatLocalDateOnly(now);
-  const t = Date.parse(v);
-  return Number.isFinite(t) && t >= now.getTime();
-};
 
 const parseBenefitIndex = (benefitIndex?: string): number => {
   const parsedIndex = benefitIndex !== undefined ? Number.parseInt(benefitIndex, 10) : 0;
@@ -416,7 +401,7 @@ function BenefitDetailPage() {
 
   const subscriptionName = getSubscriptionName(benefit.subscription);
   const subscription = getSubscriptionById(benefit.subscription);
-  const isExpired = !isBenefitActive(benefit.validUntil);
+  const isExpired = !isBenefitActive(benefit);
   const discount = parseInt(benefit.rewardRate.match(/(\d+)%/)?.[1] || '0');
   const providerName = benefitProviderName || getBenefitProviderDisplayName(benefit);
   const providerSummary = getBenefitProviderSummary(benefit);

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -55,7 +55,7 @@ async function fetchLandingBusinesses(bank: string, category: string): Promise<B
       }
     }
 
-    if (!response.pagination.hasMore || pageItems.length === 0) {
+    if (!response.pagination.hasMore) {
       break;
     }
   }

--- a/src/pages/__tests__/BusinessDetailPage.test.tsx
+++ b/src/pages/__tests__/BusinessDetailPage.test.tsx
@@ -236,6 +236,7 @@ describe('BusinessDetailPage', () => {
           icon: 'credit_card',
           installments: 6,
           cuando: 'Lunes, Martes, Miercoles, Jueves, Viernes, Sabado, Domingo',
+          validUntil: ACTIVE_VALID_UNTIL,
           eligibilities: [
             {
               bank: 'nacion',

--- a/src/services/__tests__/api.fetchBusinessById.test.ts
+++ b/src/services/__tests__/api.fetchBusinessById.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchBusinessById } from '../api';
+import { fetchBusinessById, fetchBusinessesPaginated } from '../api';
 
 const mockFetch = vi.fn();
 
@@ -64,5 +64,59 @@ describe('fetchBusinessById', () => {
     expect(requestUrl.searchParams.get('search')).toBeNull();
     expect(business?.id).toBe('merchant_1');
     expect(business?.location).toHaveLength(1);
+  });
+
+  it('keeps open-ended benefits when includeExpired is set on the search fallback path', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        query: { q: 'adidas', normalized: 'adidas', expanded: ['adidas'], limit: 1, offset: 0, filters: {} },
+        source: 'meilisearch',
+        intents: [],
+        products: [],
+        merchants: [
+          {
+            entityId: 'merchant_1',
+            merchantId: 'merchant_1',
+            merchantName: 'Adidas',
+            aliases: [],
+            intentTags: [],
+            productTags: [],
+            categories: ['shopping'],
+            banks: [],
+            score: 1,
+            reasons: [],
+            business: {
+              id: 'merchant_1',
+              name: 'Adidas',
+              category: 'shopping',
+              description: 'Sportswear',
+              rating: 5,
+              locations: [],
+              image: '',
+              benefits: [
+                {
+                  bankName: 'BBVA',
+                  cardName: 'Visa',
+                  benefit: 'Promo anterior',
+                  rewardRate: '10%',
+                  color: '#000',
+                  icon: 'credit_card',
+                  validUntil: null
+                }
+              ]
+            }
+          }
+        ],
+        pagination: { totalMerchants: 1, limit: 1, offset: 0, hasMore: false }
+      })
+    });
+
+    const response = await fetchBusinessesPaginated({ search: 'adidas', limit: 1, includeExpired: true });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(response.businesses).toHaveLength(1);
+    expect(response.businesses[0].benefits).toHaveLength(1);
   });
 });

--- a/src/services/__tests__/merchantFirstServerless.test.ts
+++ b/src/services/__tests__/merchantFirstServerless.test.ts
@@ -2783,8 +2783,6 @@ describe('merchant-first serverless helpers', () => {
           },
           in: {
             $or: [
-              { $eq: ['$$validUntilValue', null] },
-              { $eq: ['$$validUntilValue', ''] },
               {
                 $and: [
                   { $eq: [{ $type: '$$validUntilValue' }, 'string'] },

--- a/src/services/__tests__/normalizeBusinesses.dedupeModo.test.ts
+++ b/src/services/__tests__/normalizeBusinesses.dedupeModo.test.ts
@@ -157,4 +157,24 @@ describe('normalizeBusinesses Modo dedup activity bucketing', () => {
     expect(business.benefits[0].id).toBe('modo-promos-raw-active');
     expect(business.benefits[0].acceptsModo).toBeUndefined();
   });
+
+  it('dedups a Modo/bank pair even when the Modo side has no validUntil and the bank side is active', () => {
+    const raw = makeRawBusiness([
+      makeRawBenefit({
+        id: 'modo-promos-raw-open-ended',
+        validUntil: null,
+      }),
+      makeRawBenefit({
+        id: 'bbva-active',
+        validUntil: '2026-06-30',
+      }),
+    ]);
+
+    const [business] = normalizeBusinesses([raw], { includeExpired: true });
+
+    expect(business.benefits).toHaveLength(1);
+    expect(business.benefits[0].id).toBe('bbva-active');
+    expect(business.benefits[0].acceptsModo).toBe(true);
+    expect(business.benefits[0].validUntil).toBe('2026-06-30');
+  });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -181,16 +181,29 @@ export function normalizeBusinesses(
       })
       : [];
     const now = new Date();
-    const activeBenefits: BankBenefit[] = [];
-    const expiredBenefits: BankBenefit[] = [];
+    // Keep benefits with no validUntil grouped with active ones for dedup: a Modo
+    // entry with no end date and a bank entry with a future one are the same promo,
+    // and must be merged before we decide which bucket they land in. Benefits with a
+    // known past validUntil are kept apart so they can't absorb an active/open-ended match.
+    const definitelyExpired: BankBenefit[] = [];
+    const dedupeCandidates: BankBenefit[] = [];
     benefits.forEach((b) => {
-      if (isBenefitActive(b, now)) activeBenefits.push(b);
-      else expiredBenefits.push(b);
+      const hasKnownValidUntil = Boolean(b.validUntil?.trim());
+      if (hasKnownValidUntil && !isBenefitActive(b, now)) definitelyExpired.push(b);
+      else dedupeCandidates.push(b);
     });
-    const dedupedActive = dedupeModoBenefits(activeBenefits);
+
+    const dedupedCandidates = dedupeModoBenefits(dedupeCandidates);
+    const activeBenefits: BankBenefit[] = [];
+    const openEndedBenefits: BankBenefit[] = [];
+    dedupedCandidates.forEach((b) => {
+      if (isBenefitActive(b, now)) activeBenefits.push(b);
+      else openEndedBenefits.push(b);
+    });
+
     const visibleBenefits = options.includeExpired
-      ? [...dedupedActive, ...dedupeModoBenefits(expiredBenefits)]
-      : dedupedActive;
+      ? [...activeBenefits, ...openEndedBenefits, ...dedupeModoBenefits(definitelyExpired)]
+      : activeBenefits;
 
     const category = raw.category || raw.categories?.[0] || 'otros';
     const GENERIC_DEFAULT = 'https://images.pexels.com/photos/4386158/pexels-photo-4386158.jpeg';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -58,14 +58,16 @@ function mapSearchResponseToBusinessesResponse(
     category?: string;
     bank?: string;
     search?: string;
+    includeExpired?: boolean;
   }
 ): BusinessesApiResponse {
   const businesses = normalizeBusinesses(
     (searchData.merchants || []).map((merchantHit) => ({
       ...merchantHit.business,
       aliases: merchantHit.aliases || [],
-    }))
-  ).filter((business) => business.benefits.length > 0);
+    })),
+    { includeExpired: options.includeExpired }
+  );
 
   return {
     success: searchData.success,
@@ -279,7 +281,8 @@ export async function fetchBusinessesPaginated(options: {
         offset,
         category,
         bank,
-        search
+        search,
+        includeExpired
       });
     } catch (error) {
       console.error('[API] fetchSearch failed, falling back to legacy businesses endpoint:', error);

--- a/src/utils/__tests__/benefits.test.ts
+++ b/src/utils/__tests__/benefits.test.ts
@@ -23,16 +23,16 @@ describe('benefit activity helpers', () => {
     expect(isBenefitActive(makeBenefit('2026-05-11'), now)).toBe(false);
   });
 
-  it('treats missing validUntil as active', () => {
-    expect(isBenefitActive(makeBenefit(null), now)).toBe(true);
-    expect(isBenefitActive(makeBenefit(undefined), now)).toBe(true);
+  it('treats missing validUntil as inactive', () => {
+    expect(isBenefitActive(makeBenefit(null), now)).toBe(false);
+    expect(isBenefitActive(makeBenefit(undefined), now)).toBe(false);
   });
 
-  it('filters only expired benefits out of a mixed list', () => {
+  it('filters benefits without validUntil out of a mixed list', () => {
     const active = makeBenefit('2026-05-12');
     const openEnded = makeBenefit(null);
     const expired = makeBenefit('2026-03-25');
 
-    expect(filterActiveBenefits([active, openEnded, expired], now)).toEqual([active, openEnded]);
+    expect(filterActiveBenefits([active, openEnded, expired], now)).toEqual([active]);
   });
 });

--- a/src/utils/benefits.ts
+++ b/src/utils/benefits.ts
@@ -10,7 +10,7 @@ export const formatLocalDateOnly = (date: Date): string => [
 
 export const isBenefitActive = (benefit: Pick<BankBenefit, 'validUntil'>, now = new Date()): boolean => {
   const validUntil = benefit.validUntil?.trim();
-  if (!validUntil) return true;
+  if (!validUntil) return false;
 
   if (DATE_ONLY_PATTERN.test(validUntil)) {
     return validUntil >= formatLocalDateOnly(now);


### PR DESCRIPTION
isBenefitActive previously treated a missing/null validUntil as
always-active, so open-ended benefits showed up in every list. Now
they're classified as inactive (same bucket as expired benefits),
which BusinessDetailPage already had UI for ("Beneficios anteriores" /
"Promoción anterior") but could never reach.

Also dedupes BenefitDetailPage's local copy of the expiration check by
importing the shared utils/benefits helper, so both pages stay in sync.