### PR TITLE
fix: whitelist supermercados/combustible in raw benefit category filter

### DIFF
--- a/mobile/src/types/mongodb.ts
+++ b/mobile/src/types/mongodb.ts
@@ -205,7 +205,8 @@ export const transformRawBenefitToBenefit = (rawBenefit: RawMongoBenefit): Benef
     installments: rawBenefit.installments || null,
     categories: (rawBenefit.categories || []).filter(cat =>
       ['gastronomia', 'moda', 'entretenimiento', 'otros', 'deportes', 'regalos',
-        'viajes', 'automotores', 'belleza', 'jugueterias', 'hogar', 'electro', 'shopping'].includes(cat)
+        'viajes', 'automotores', 'belleza', 'jugueterias', 'hogar', 'electro', 'shopping',
+        'supermercados', 'combustible'].includes(cat)
     ) as Category[],
     termsAndConditions: rawBenefit.termsAndConditions || null,
     locations: transformedLocations,

--- a/src/types/mongodb.ts
+++ b/src/types/mongodb.ts
@@ -336,7 +336,8 @@ export const transformRawBenefitToBenefit = (rawBenefit: RawMongoBenefit): Benef
             installments: rawBenefit.installments || null,
             categories: (rawBenefit.categories || []).filter(cat =>
                 ['gastronomia', 'moda', 'entretenimiento', 'otros', 'deportes', 'regalos',
-                    'viajes', 'automotores', 'belleza', 'jugueterias', 'hogar', 'electro', 'shopping'].includes(cat)
+                    'viajes', 'automotores', 'belleza', 'jugueterias', 'hogar', 'electro', 'shopping',
+                    'supermercados', 'combustible'].includes(cat)
             ) as Category[],
             termsAndConditions: rawBenefit.termsAndConditions || null,
             locations: transformedLocations,


### PR DESCRIPTION
transformRawBenefitToBenefit filtered rawBenefit.categories against a
whitelist that predated these two categories, so Mongo benefits tagged
supermercados or combustible were transformed with categories: [] in
getBenefits/getBenefitById/nearby-benefits flows.