### PR TITLE
fix: add supermercados/combustible to shared Category union

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,7 +142,9 @@ export type Category =
   | 'jugueterias'
   | 'hogar'
   | 'electro'
-  | 'shopping';
+  | 'shopping'
+  | 'supermercados'
+  | 'combustible';
 
 export interface Benefit {
   id: string;


### PR DESCRIPTION
## Summary
- Fixes P1 flagged on PR #186: `DataTransformationService.validateAndNormalizeCategory` builds a `Category[]` literal that includes `'supermercados'` and `'combustible'`, but the `Category` union in `src/types/index.ts` hadn't been extended with those tokens, breaking the web type check.
- Adds `'supermercados' | 'combustible'` to the `Category` union in `src/types/index.ts`.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01DuqtkxJMjW6BEaBeiQfhch)_